### PR TITLE
fix(skills): enhance step management and metadata handling

### DIFF
--- a/packages/ai-workspace-common/src/hooks/use-invoke-action.ts
+++ b/packages/ai-workspace-common/src/hooks/use-invoke-action.ts
@@ -69,7 +69,7 @@ export const useInvokeAction = () => {
   };
 
   const findOrCreateStep = (steps: ActionStep[], stepMeta: ActionStepMeta) => {
-    const existingStep = steps?.find((s) => s.name === stepMeta.name);
+    const existingStep = steps?.find((s) => s.name === stepMeta?.name);
     return existingStep
       ? { ...existingStep }
       : {

--- a/packages/skill-template/src/base.ts
+++ b/packages/skill-template/src/base.ts
@@ -64,6 +64,7 @@ export abstract class BaseSkill extends StructuredTool {
 
     const eventData: SkillEvent = {
       event: data.event!,
+      step: config.metadata?.step,
       resultId,
       ...data,
     };
@@ -156,6 +157,7 @@ export interface SkillRunnableConfig extends RunnableConfig {
     modelName?: string;
     selectedSkill?: SkillMeta;
     currentSkill?: SkillMeta;
+    currentStep?: ActionStepMeta;
     chatHistory?: BaseMessage[];
     installedSkills?: SkillMeta[];
     tplConfig?: SkillTemplateConfig;

--- a/packages/skill-template/src/scheduler/utils/queryRewrite.ts
+++ b/packages/skill-template/src/scheduler/utils/queryRewrite.ts
@@ -137,7 +137,6 @@ Examples of query rewriting with context and chat history:
        "type": "selectedContent",
        "entityId": "content-2",
        "title": "AI Trends 2023",
-       "url": "https://example.com/ai-trends",
        "useWholeContent": true
      }
    ]
@@ -266,7 +265,6 @@ Expected JSON Structure:
     "type": "canvas" | "resource" | "selectedContent",
     "entityId": string,
     "title": string,
-    "url": string,
     "useWholeContent": boolean
   }],
   "intent": "SEARCH_QA" | "WRITING" | "READING_COMPREHENSION" | "OTHER",
@@ -311,7 +309,6 @@ Please analyze the query, focusing primarily on the current query and available 
           type: z.enum(['canvas', 'resource', 'selectedContent']),
           entityId: z.string().optional(),
           title: z.string(),
-          url: z.string().optional(),
           useWholeContent: z.boolean(),
         }),
       ),
@@ -321,7 +318,10 @@ Please analyze the query, focusing primarily on the current query and available 
     }),
   );
 
-  const result = await runnable.invoke([new SystemMessage(systemPrompt), new HumanMessage(userMessage)]);
+  const result = await runnable.invoke([new SystemMessage(systemPrompt), new HumanMessage(userMessage)], {
+    ...ctx.config,
+    metadata: ctx.config.metadata,
+  });
 
   ctx.ctxThis.engine.logger.log(`- Rewritten Query: ${result.rewrittenQuery}
     - Mentioned Context: ${safeStringifyJSON(result.mentionedContext)}

--- a/packages/skill-template/src/skills/common-qna.ts
+++ b/packages/skill-template/src/skills/common-qna.ts
@@ -29,6 +29,10 @@ import { buildFinalRequestMessages, SkillPromptModule } from '../scheduler/utils
 import * as commonQnA from '../scheduler/module/commonQnA';
 
 const stepTitleDict = {
+  analyzeContext: {
+    en: 'Context Analysis',
+    'zh-CN': '上下文分析',
+  },
   commonQnA: {
     en: 'Question Answering',
     'zh-CN': '问题回答',
@@ -78,7 +82,14 @@ export class CommonQnA extends BaseSkill {
       documents,
       contentList,
       projects,
+      uiLocale,
     } = config.configurable;
+
+    // set current step
+    config.metadata.step = {
+      name: 'analyzeContext',
+      title: stepTitleDict.analyzeContext[uiLocale],
+    };
 
     const { tplConfig } = config?.configurable || {};
     const enableWebSearch = tplConfig?.enableWebSearch?.value as boolean;
@@ -183,11 +194,6 @@ export class CommonQnA extends BaseSkill {
 
     const { currentSkill, uiLocale = 'en' } = config.configurable;
 
-    const stepMeta: ActionStepMeta = {
-      name: 'commonQnA',
-      title: stepTitleDict.commonQnA[uiLocale],
-    };
-
     // common preprocess
     const module = {
       buildSystemPrompt: commonQnA.buildCommonQnASystemPrompt,
@@ -198,13 +204,18 @@ export class CommonQnA extends BaseSkill {
 
     this.emitEvent({ event: 'log', content: `Start to generate an answer...` }, config);
 
+    // set current step
+    config.metadata.step = {
+      name: 'commonQnA',
+      title: stepTitleDict.commonQnA[uiLocale],
+    };
+
     const model = this.engine.chatModel({ temperature: 0.1 });
     const responseMessage = await model.invoke(requestMessages, {
       ...config,
       metadata: {
         ...config.metadata,
         ...currentSkill,
-        step: stepMeta,
       },
     });
 


### PR DESCRIPTION
- Updated `use-invoke-action` to safely access step metadata.
- Added `currentStep` to `SkillRunnableConfig` for better tracking of the current step.
- Modified `BaseSkill` implementations to set `config.metadata.step` for `analyzeContext`, `commonQnA`, and `generateDocument` steps.
- Removed unused `url` fields from query structures to streamline data handling.
- Improved logging and context management during skill execution.