### PR TITLE
feat(sider): add feedback alert and update translations

### DIFF
--- a/apps/web/src/components/layout/sider.tsx
+++ b/apps/web/src/components/layout/sider.tsx
@@ -7,7 +7,7 @@ import {
   Menu,
   Tag,
 } from "@arco-design/web-react"
-import { Skeleton, Tooltip, message } from "antd"
+import { Alert, Skeleton, Tooltip, message } from "antd"
 import {
   useLocation,
   useNavigate,
@@ -421,6 +421,21 @@ export const SiderLayout = (props: { source: "sider" | "popover" }) => {
           </div>
 
           <div className="sider-footer">
+            <Alert
+              message={
+                <div className="flex cursor-pointer items-center justify-center">
+                  <a
+                    href="https://powerformer.feishu.cn/wiki/Syrsw7DJxiaExSkoSiXcTF1inBg?from=canvas"
+                    target="_blank">
+                    👉{"    "}
+                    <span>{t("loggedHomePage.siderMenu.joinFeedback")}</span>
+                  </a>
+                </div>
+              }
+              type="success"
+              closable
+              style={{ marginBottom: 8 }}
+            />
             {!!userStore.userProfile?.uid && (
               <MenuItem
                 key="Settings"

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -708,6 +708,7 @@ const translations = {
       recentProjects: 'Recent Projects',
       recentChats: 'Recent Chats',
       viewMore: 'View More',
+      joinFeedback: 'Join Feedback Group',
     },
   },
   knowledgeLibrary: {

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -705,6 +705,7 @@ const translations = {
       recentProjects: '最近项目',
       recentChats: '最近会话',
       viewMore: '查看更多',
+      joinFeedback: '加入反馈群',
     },
   },
   knowledgeLibrary: {


### PR DESCRIPTION
- Introduced an Alert component in the SiderLayout to provide users with a link to join the feedback group.
- Updated English and Chinese translations to include the new "Join Feedback Group" text, enhancing user engagement and localization support.