### PR TITLE
fix(node-selector): refine target node filtering to exclude only 'gro…

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/common/node-selector/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/common/node-selector/index.tsx
@@ -60,7 +60,7 @@ export const NodeSelector = (props: NodeSelectorProps) => {
 
   const { nodes } = useCanvasData();
 
-  const targetNodes = nodes.filter((node) => !['skill', 'memo', 'group'].includes(node?.type));
+  const targetNodes = nodes.filter((node) => !['group'].includes(node?.type));
   const sortedItems: IContextItem[] = targetNodes.map((node) => ({
     title: node.data?.title,
     entityId: node.data?.entityId,


### PR DESCRIPTION
…up' type

- Updated the NodeSelector component to filter out nodes of type 'group' from the selection options, enhancing the accuracy of node selection.
- This change aims to improve the user experience by ensuring that only relevant node types are available for selection within the canvas environment.