### PR TITLE
fix(canvas): update node styles for preview mode

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/document.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/document.tsx
@@ -161,7 +161,7 @@ export const DocumentNode = memo(
           onMouseEnter={!isPreview ? handleMouseEnter : undefined}
           onMouseLeave={!isPreview ? handleMouseLeave : undefined}
           onClick={onNodeClick}
-          style={containerStyle}
+          style={isPreview ? { width: 288, height: 200 } : containerStyle}
         >
           {!isPreview && !hideActions && <ActionButtons type="document" nodeId={id} isNodeHovered={isHovered} />}
 

--- a/packages/ai-workspace-common/src/components/canvas/nodes/resource.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/resource.tsx
@@ -230,7 +230,7 @@ export const ResourceNode = memo(
       <div className={classNames({ nowheel: isOperating })}>
         <div
           ref={targetRef}
-          style={containerStyle}
+          style={isPreview ? { width: 288, height: 200 } : containerStyle}
           onMouseEnter={!isPreview ? handleMouseEnter : undefined}
           onMouseLeave={!isPreview ? handleMouseLeave : undefined}
           onClick={onNodeClick}
@@ -256,7 +256,7 @@ export const ResourceNode = memo(
                   style={{
                     height: '100%',
                     overflowY: 'auto',
-                    maxHeight: sizeMode === 'compact' ? '40px' : '384px',
+                    maxHeight: sizeMode === 'compact' ? '40px' : '',
                     paddingBottom: '40px',
                   }}
                 >

--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
@@ -498,7 +498,7 @@ export const SkillResponseNode = memo(
         <div
           ref={targetRef}
           className="relative"
-          style={containerStyle}
+          style={isPreview ? { width: 288, height: 200 } : containerStyle}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
           onClick={onNodeClick}


### PR DESCRIPTION
- Adjusted the styling of DocumentNode, ResourceNode, and SkillResponseNode components to set fixed dimensions (288x200) when in preview mode.
- Enhanced the ResourceNode component by removing the maxHeight restriction for non-compact size modes, allowing for more flexible content display.

This change improves the visual consistency and usability of nodes within the canvas when previewing.