### PR TITLE
fix(canvas): refine node type filtering in selection actions

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/multi-selection-menu/selection-action-menu.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/multi-selection-menu/selection-action-menu.tsx
@@ -57,9 +57,7 @@ export const SelectionActionMenu: FC<SelectionActionMenuProps> = ({ onClose }) =
 
   const handleAskAI = useCallback(() => {
     // Get all selected nodes except skills
-    const selectedNodes = getNodes().filter(
-      (node) => node.selected && !['skill', 'memo'].includes(node.type),
-    ) as CanvasNode[];
+    const selectedNodes = getNodes().filter((node) => node.selected && !['skill'].includes(node.type)) as CanvasNode[];
 
     const connectTo = selectedNodes.map((node) => ({
       type: node.type as CanvasNodeType,

--- a/packages/ai-workspace-common/src/components/canvas/nodes/group.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/group.tsx
@@ -38,7 +38,7 @@ type GroupNodeProps = Omit<NodeProps, 'data'> & {
 const getChildNodes = (id: string, nodes: CanvasNode[]) => {
   const childNodes = nodes.filter((node) => {
     const isInGroup = node.parentId === id;
-    return isInGroup && !['skill', 'memo', 'group'].includes(node.type);
+    return isInGroup && !['skill', 'group'].includes(node.type);
   }) as CanvasNode[];
 
   return childNodes;


### PR DESCRIPTION
- Updated the selection action menu to exclude 'memo' nodes from the selected nodes for AI actions, enhancing the filtering logic.
- Adjusted the group node child retrieval to exclude 'memo' and 'group' types, improving the accuracy of child node selection.
- These changes streamline node interactions and ensure that only relevant node types are processed in selection actions, enhancing overall user experience.