### PR TITLE
feat(canvas): enhance canvas data handling and navigation

### DIFF
--- a/packages/ai-workspace-common/src/hooks/canvas/use-delete-canvas.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-delete-canvas.ts
@@ -33,6 +33,7 @@ export const useDeleteCanvas = () => {
 
         // Check and remove canvasId from localStorage if matches
         const { currentCanvasId, setCurrentCanvasId, deleteCanvasData } = useCanvasStore.getState();
+        const latestCurrentCanvasId = currentCanvasId;
         if (currentCanvasId === canvasId) {
           setCurrentCanvasId(null);
         }
@@ -44,15 +45,22 @@ export const useDeleteCanvas = () => {
         await indexedDbProvider.clearData();
         await indexedDbProvider.destroy();
 
-        getCanvasList();
+        // Get updated canvas list
+        const updatedCanvasList = await getCanvasList();
 
-        if (currentCanvasId === canvasId) {
-          const firstCanvas = canvasList?.find((canvas) => canvas.id !== canvasId);
-          if (firstCanvas?.id) {
-            navigate(`/canvas/${firstCanvas?.id}`, { replace: true });
-          } else {
-            navigate('/canvas/empty', { replace: true });
-          }
+        // Only navigate if we're currently on the deleted canvas
+        if (latestCurrentCanvasId === canvasId) {
+          // Find the first available canvas that's not the deleted one
+          const remainingCanvas = updatedCanvasList?.find((canvas) => canvas.id !== canvasId);
+
+          // Use setTimeout to ensure all state updates are processed
+          setTimeout(() => {
+            if (remainingCanvas?.id) {
+              navigate(`/canvas/${remainingCanvas.id}`, { replace: true });
+            } else {
+              navigate('/canvas/empty', { replace: true });
+            }
+          }, 0);
         }
       }
     } finally {

--- a/packages/ai-workspace-common/src/hooks/use-handle-sider-data.ts
+++ b/packages/ai-workspace-common/src/hooks/use-handle-sider-data.ts
@@ -15,7 +15,6 @@ export const useHandleSiderData = (initData?: boolean) => {
   const [isLoadingCanvas, setIsLoadingCanvas] = useState(false);
 
   const getCanvasList = async () => {
-    if (isLoadingCanvas) return;
     setIsLoadingCanvas(true);
     const { data: res, error } = await getClient().listCanvases({
       query: { page: 1, pageSize: DATA_NUM },
@@ -23,17 +22,17 @@ export const useHandleSiderData = (initData?: boolean) => {
     setIsLoadingCanvas(false);
     if (error) {
       console.error('getCanvasList error', error);
-      return;
+      return [];
     }
     const canvases = res?.data || [];
-    updateCanvasList(
-      canvases.map((canvas) => ({
-        id: canvas.canvasId,
-        name: canvas.title,
-        updatedAt: canvas.updatedAt,
-        type: 'canvas',
-      })),
-    );
+    const formattedCanvases = canvases.map((canvas) => ({
+      id: canvas.canvasId,
+      name: canvas.title,
+      updatedAt: canvas.updatedAt,
+      type: 'canvas' as const,
+    }));
+    updateCanvasList(formattedCanvases);
+    return formattedCanvases;
   };
 
   const getDocumentList = async () => {


### PR DESCRIPTION
- Refactored the `getCanvasList` function to return an empty array on error and ensure consistent data formatting.
- Updated the `useDeleteCanvas` hook to navigate to the first available canvas after deletion, using the updated canvas list.
- Introduced a temporary variable to store the current canvas ID before deletion to improve navigation logic.