### PR TITLE
fix(canvas): incorrect context state reset for launchpad input

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/launchpad/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/index.tsx
@@ -41,7 +41,7 @@ export const LaunchPad = memo(
     const clearLaunchpadState = useCallback(() => {
       chatStore.resetState();
       contextPanelStore.resetState();
-    }, [chatStore, contextPanelStore]);
+    }, [chatStore.resetState, contextPanelStore.resetState]);
 
     // Handle canvas ID changes
     useEffect(() => {


### PR DESCRIPTION
# Summary

- Fix incorrect context state reset when input in launchpad

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [x] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [x] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

Before:

https://github.com/user-attachments/assets/48f6573e-fec3-4871-92c5-a2bb371cf32e

After:

https://github.com/user-attachments/assets/eb208813-0446-419c-8c26-bf35ad3f81fc


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
