### PR TITLE
fix(api): adjust storage quota default

### DIFF
--- a/apps/api/src/config/app.config.ts
+++ b/apps/api/src/config/app.config.ts
@@ -112,9 +112,9 @@ export default () => ({
       t2: Number.parseInt(process.env.QUOTA_T2_REQUEST) || -1,
     },
     storage: {
-      file: Number.parseInt(process.env.QUOTA_STORAGE_FILE) || -1,
-      object: Number.parseInt(process.env.QUOTA_STORAGE_OBJECT) || -1,
-      vector: Number.parseInt(process.env.QUOTA_STORAGE_VECTOR) || -1,
+      file: Number.parseInt(process.env.QUOTA_STORAGE_FILE) || 10000,
+      object: Number.parseInt(process.env.QUOTA_STORAGE_OBJECT) || 1000000000,
+      vector: Number.parseInt(process.env.QUOTA_STORAGE_VECTOR) || 1000000000,
     },
   },
   credentials: {


### PR DESCRIPTION
# Summary

- Set storage quota to non-negative values to facilitate local deploy.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
