### PR TITLE
feat: auto consumption of images in chat history

### DIFF
--- a/packages/skill-template/src/scheduler/utils/queryProcessor.ts
+++ b/packages/skill-template/src/scheduler/utils/queryProcessor.ts
@@ -1,7 +1,7 @@
 import { GraphState } from '../types';
 import { BaseSkill, SkillRunnableConfig } from '../../base';
 import { checkHasContext, countToken, countMessagesTokens } from './token';
-import { truncateMessages } from './truncator';
+import { isEmptyMessage, truncateMessages } from './truncator';
 import { analyzeQueryAndContext, preprocessQuery } from './query-rewrite/index';
 import { safeStringifyJSON } from '@refly-packages/utils';
 import { checkIsSupportedModel } from './model';
@@ -47,7 +47,7 @@ export async function processQuery(options: QueryProcessorOptions): Promise<Quer
   ctxThis.engine.logger.log(`preprocess query: ${query}`);
 
   // Process chat history
-  const chatHistory = rawChatHistory.filter((message) => message.content !== '');
+  const chatHistory = rawChatHistory.filter((message) => !isEmptyMessage(message));
   const usedChatHistory = truncateMessages(chatHistory, 20, 4000, 30000);
 
   // Check context


### PR DESCRIPTION
# Summary

Images in chat history will automatically be passed to the model, so users don't have to specify identical images for subsequent asks.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [x] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [x] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

<img width="1738" alt="image" src="https://github.com/user-attachments/assets/e8a3834b-f381-4e7f-b3b8-1ac6a7c484b1" />

Note that no images are passed for the second question.

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
