### PR TITLE
feat(ui): Add preset colors for memo background color picker

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/memo/memo-editor.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/memo/memo-editor.tsx
@@ -5,7 +5,9 @@ import { Color } from 'antd/es/color-picker';
 import { NodeSelector } from '@refly-packages/ai-workspace-common/components/editor/components/selectors/node-selector';
 import { TextButtons } from '@refly-packages/ai-workspace-common/components/editor/components/selectors/text-buttons';
 import { LinkSelector } from '@refly-packages/ai-workspace-common/components/editor/components/selectors/link-selector';
+
 import './memo-editor.scss';
+import { useTranslation } from 'react-i18next';
 type MemoEditorProps = {
   editor: EditorInstance;
   bgColor: string;
@@ -16,6 +18,22 @@ export const MemoEditor: FC<MemoEditorProps> = ({ editor, bgColor, onChangeBackg
   const [open, setOpen] = useState(false);
   const [openLink, setOpenLink] = useState(false);
   const [_openColor, _setOpenColor] = useState(false);
+  const { t } = useTranslation();
+
+  // Define preset colors
+  const presetColors = [
+    '#FFFFFF', // White
+    '#e2defc', // Purple
+    '#d6ebfd', // Blue
+    '#cff9fe', // Cyan
+    '#dcfae6', // Light Green
+    '#e8fad7', // Green
+    '#fffee7', // Yellow
+    '#fee1c7', // Orange
+    '#ffede7', // Pink
+    '#f2f4f7', // Gray
+  ];
+
   const colorChange = (_color: Color, css: string) => {
     onChangeBackground?.(css);
   };
@@ -26,6 +44,8 @@ export const MemoEditor: FC<MemoEditorProps> = ({ editor, bgColor, onChangeBackg
           className="memo-color-picker items-center border-none rounded-none hover:bg-gray-100"
           defaultValue={bgColor}
           onChange={colorChange}
+          showText={false}
+          presets={[{ label: t('common.presetColors'), colors: presetColors }]}
         />
         <Divider className="mx-0 h-8" type="vertical" />
         <NodeSelector open={open} onOpenChange={setOpen} triggerEditor={editor} />

--- a/packages/ai-workspace-common/src/components/canvas/nodes/memo/memo-editor.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/memo/memo-editor.tsx
@@ -26,8 +26,8 @@ export const MemoEditor: FC<MemoEditorProps> = ({ editor, bgColor, onChangeBackg
     '#e2defc', // Purple
     '#d6ebfd', // Blue
     '#cff9fe', // Cyan
-    '#dcfae6', // Light Green
-    '#e8fad7', // Green
+    '#d1f9e8', // Light Green
+    '#e3fbcc', // Green
     '#fffee7', // Yellow
     '#fee1c7', // Orange
     '#ffede7', // Pink

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -66,6 +66,7 @@ const translations = {
     uploadSuccess: 'Upload successful',
     uploadFailed: 'Upload failed',
     dropImageHere: 'Drop image here',
+    presetColors: 'Preset Colors',
   },
   verifyRules: {
     emailRequired: 'Email cannot be empty',

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -74,6 +74,7 @@ const translations = {
     uploadSuccess: '上传成功',
     uploadFailed: '上传失败',
     dropImageHere: '拖放图片到这里',
+    presetColors: '预设颜色',
   },
   verifyRules: {
     emailRequired: '邮箱地址不能为空',


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
