### PR TITLE
feat(deploy): Add multi-arch pandoc installation in API Dockerfile

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,8 +1,21 @@
 # Base image
 FROM node:20-alpine@sha256:b5b9467fe7b33aad47f1ec3f6e0646a658f85f05c18d4243024212a91f3b7554
 
-# Install curl for healthcheck
-RUN apk add --no-cache curl
+# Install curl for healthcheck and pandoc dependencies
+RUN apk add --no-cache curl gcompat
+
+# Install pandoc based on architecture
+ARG TARGETARCH
+
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        wget https://github.com/jgm/pandoc/releases/download/3.6.3/pandoc-3.6.3-linux-amd64.tar.gz \
+        && tar xvzf pandoc-3.6.3-linux-amd64.tar.gz --strip-components 1 -C /usr/local/ \
+        && rm pandoc-3.6.3-linux-amd64.tar.gz; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        wget https://github.com/jgm/pandoc/releases/download/3.6.3/pandoc-3.6.3-linux-arm64.tar.gz \
+        && tar xvzf pandoc-3.6.3-linux-arm64.tar.gz --strip-components 1 -C /usr/local/ \
+        && rm pandoc-3.6.3-linux-arm64.tar.gz; \
+    fi
 
 WORKDIR /app
 


### PR DESCRIPTION
# Summary

- Install pandoc for different architectures (amd64 and arm64)
- Add gcompat library for compatibility
- Use wget to download and extract pandoc binaries
- Conditionally install based on target architecture

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
