### PR TITLE
Feat/canvas auto naming

### DIFF
--- a/apps/api/src/canvas/canvas.controller.ts
+++ b/apps/api/src/canvas/canvas.controller.ts
@@ -10,11 +10,16 @@ import {
 } from '@nestjs/common';
 import { JwtAuthGuard } from '@/auth/guard/jwt-auth.guard';
 import { CanvasService } from './canvas.service';
-import { User as UserType } from '@prisma/client';
 import { LoginedUser } from '@/utils/decorators/user.decorator';
 import { canvasPO2DTO } from '@/canvas/canvas.dto';
 import { buildSuccessResponse } from '@/utils';
-import { UpsertCanvasRequest, DeleteCanvasRequest } from '@refly-packages/openapi-schema';
+import {
+  User,
+  UpsertCanvasRequest,
+  DeleteCanvasRequest,
+  AutoNameCanvasRequest,
+  AutoNameCanvasResponse,
+} from '@refly-packages/openapi-schema';
 
 @Controller('v1/canvas')
 export class CanvasController {
@@ -23,7 +28,7 @@ export class CanvasController {
   @UseGuards(JwtAuthGuard)
   @Get('list')
   async listCanvases(
-    @LoginedUser() user: UserType,
+    @LoginedUser() user: User,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
     @Query('pageSize', new DefaultValuePipe(10), ParseIntPipe) pageSize: number,
   ) {
@@ -33,22 +38,32 @@ export class CanvasController {
 
   @UseGuards(JwtAuthGuard)
   @Post('create')
-  async createCanvas(@LoginedUser() user: UserType, @Body() body: UpsertCanvasRequest) {
+  async createCanvas(@LoginedUser() user: User, @Body() body: UpsertCanvasRequest) {
     const canvas = await this.canvasService.createCanvas(user, body);
     return buildSuccessResponse(canvasPO2DTO(canvas));
   }
 
   @UseGuards(JwtAuthGuard)
   @Post('update')
-  async updateCanvas(@LoginedUser() user: UserType, @Body() body: UpsertCanvasRequest) {
+  async updateCanvas(@LoginedUser() user: User, @Body() body: UpsertCanvasRequest) {
     const canvas = await this.canvasService.updateCanvas(user, body);
     return buildSuccessResponse(canvasPO2DTO(canvas));
   }
 
   @UseGuards(JwtAuthGuard)
   @Post('delete')
-  async deleteCanvas(@LoginedUser() user: UserType, @Body() body: DeleteCanvasRequest) {
+  async deleteCanvas(@LoginedUser() user: User, @Body() body: DeleteCanvasRequest) {
     await this.canvasService.deleteCanvas(user, body);
     return buildSuccessResponse({});
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('autoName')
+  async autoNameCanvas(
+    @LoginedUser() user: User,
+    @Body() body: AutoNameCanvasRequest,
+  ): Promise<AutoNameCanvasResponse> {
+    const data = await this.canvasService.autoNameCanvas(user, body);
+    return buildSuccessResponse(data);
   }
 }

--- a/apps/api/src/canvas/canvas.dto.ts
+++ b/apps/api/src/canvas/canvas.dto.ts
@@ -10,6 +10,11 @@ export interface DeleteCanvasNodesJobData {
   entities: Entity[];
 }
 
+export interface AutoNameCanvasJobData {
+  uid: string;
+  canvasId: string;
+}
+
 export function canvasPO2DTO(canvas: CanvasModel): Canvas {
   return {
     ...pick(canvas, ['canvasId', 'title', 'shareCode']),

--- a/apps/api/src/canvas/canvas.module.ts
+++ b/apps/api/src/canvas/canvas.module.ts
@@ -2,7 +2,11 @@ import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { CanvasController } from './canvas.controller';
 import { CanvasService } from './canvas.service';
-import { ClearCanvasEntityProcessor, SyncCanvasEntityProcessor } from './canvas.processor';
+import {
+  ClearCanvasEntityProcessor,
+  SyncCanvasEntityProcessor,
+  AutoNameCanvasProcessor,
+} from './canvas.processor';
 import { CollabModule } from '@/collab/collab.module';
 import { QUEUE_DELETE_KNOWLEDGE_ENTITY } from '@/utils/const';
 import { CommonModule } from '@/common/common.module';
@@ -18,7 +22,12 @@ import { MiscModule } from '@/misc/misc.module';
     }),
   ],
   controllers: [CanvasController],
-  providers: [CanvasService, SyncCanvasEntityProcessor, ClearCanvasEntityProcessor],
+  providers: [
+    CanvasService,
+    SyncCanvasEntityProcessor,
+    ClearCanvasEntityProcessor,
+    AutoNameCanvasProcessor,
+  ],
   exports: [CanvasService],
 })
 export class CanvasModule {}

--- a/apps/api/src/canvas/canvas.processor.ts
+++ b/apps/api/src/canvas/canvas.processor.ts
@@ -3,8 +3,16 @@ import { Logger } from '@nestjs/common';
 import { Job } from 'bullmq';
 
 import { CanvasService } from './canvas.service';
-import { QUEUE_CLEAR_CANVAS_ENTITY, QUEUE_SYNC_CANVAS_ENTITY } from '@/utils/const';
-import { DeleteCanvasNodesJobData, SyncCanvasEntityJobData } from './canvas.dto';
+import {
+  QUEUE_CLEAR_CANVAS_ENTITY,
+  QUEUE_SYNC_CANVAS_ENTITY,
+  QUEUE_AUTO_NAME_CANVAS,
+} from '@/utils/const';
+import {
+  DeleteCanvasNodesJobData,
+  SyncCanvasEntityJobData,
+  AutoNameCanvasJobData,
+} from './canvas.dto';
 
 @Processor(QUEUE_SYNC_CANVAS_ENTITY)
 export class SyncCanvasEntityProcessor extends WorkerHost {
@@ -44,5 +52,19 @@ export class ClearCanvasEntityProcessor extends WorkerHost {
       this.logger.error(`[${QUEUE_CLEAR_CANVAS_ENTITY}] error ${job.id}: ${error?.stack}`);
       throw error;
     }
+  }
+}
+
+@Processor(QUEUE_AUTO_NAME_CANVAS)
+export class AutoNameCanvasProcessor extends WorkerHost {
+  private logger = new Logger(AutoNameCanvasProcessor.name);
+
+  constructor(private canvasService: CanvasService) {
+    super();
+  }
+
+  async process(job: Job<AutoNameCanvasJobData>) {
+    this.logger.log(`Processing auto name canvas job ${job.id} for canvas ${job.data.canvasId}`);
+    await this.canvasService.autoNameCanvasFromQueue(job.data);
   }
 }

--- a/apps/api/src/misc/misc.controller.ts
+++ b/apps/api/src/misc/misc.controller.ts
@@ -81,6 +81,7 @@ export class MiscController {
     return buildSuccessResponse({ content: result });
   }
 
+  @UseGuards(JwtAuthGuard)
   @Get('static/:objectKey')
   @Header('Access-Control-Allow-Origin', '*')
   @Header('Cross-Origin-Resource-Policy', 'cross-origin')

--- a/apps/api/src/skill/skill.module.ts
+++ b/apps/api/src/skill/skill.module.ts
@@ -12,6 +12,7 @@ import {
   QUEUE_SKILL,
   QUEUE_SKILL_TIMEOUT_CHECK,
   QUEUE_SYNC_REQUEST_USAGE,
+  QUEUE_AUTO_NAME_CANVAS,
 } from '@/utils';
 import { LabelModule } from '@/label/label.module';
 import { SkillProcessor, SkillTimeoutCheckProcessor } from '@/skill/skill.processor';
@@ -34,6 +35,7 @@ import { MiscModule } from '@/misc/misc.module';
     BullModule.registerQueue({ name: QUEUE_SKILL_TIMEOUT_CHECK }),
     BullModule.registerQueue({ name: QUEUE_SYNC_TOKEN_USAGE }),
     BullModule.registerQueue({ name: QUEUE_SYNC_REQUEST_USAGE }),
+    BullModule.registerQueue({ name: QUEUE_AUTO_NAME_CANVAS }),
   ],
   providers: [SkillService, SkillProcessor, SkillTimeoutCheckProcessor],
   controllers: [SkillController],

--- a/apps/api/src/utils/const.ts
+++ b/apps/api/src/utils/const.ts
@@ -8,6 +8,7 @@ export const QUEUE_SYNC_STORAGE_USAGE = 'syncStorageUsage';
 export const QUEUE_SYNC_CANVAS_ENTITY = 'syncCanvasEntity';
 export const QUEUE_CLEAR_CANVAS_ENTITY = 'clearCanvasEntity';
 export const QUEUE_DELETE_KNOWLEDGE_ENTITY = 'deleteKnowledgeEntity';
+export const QUEUE_AUTO_NAME_CANVAS = 'autoNameCanvas';
 
 export const QUEUE_SEND_VERIFICATION_EMAIL = 'sendVerificationEmail';
 export const QUEUE_CHECK_CANCELED_SUBSCRIPTIONS = 'checkCanceledSubscriptions';

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/canvas-rename.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/canvas-rename.tsx
@@ -1,14 +1,20 @@
-import { Input } from 'antd';
+import { Button, Input, Tooltip } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { Modal } from 'antd';
 import { useEffect, useRef, useState } from 'react';
+import { LuSparkles } from 'react-icons/lu';
+import getClient from '@refly-packages/ai-workspace-common/requests/proxiedRequest';
+
 interface CanvasRenameProps {
+  canvasId: string;
   canvasTitle?: string;
   isModalOpen: boolean;
   handleModalOk: (editedTitle: string) => void;
   handleModalCancel: () => void;
 }
+
 export const CanvasRename: React.FC<CanvasRenameProps> = ({
+  canvasId,
   canvasTitle,
   isModalOpen,
   handleModalOk,
@@ -16,6 +22,7 @@ export const CanvasRename: React.FC<CanvasRenameProps> = ({
 }) => {
   const { t } = useTranslation();
   const [editedTitle, setEditedTitle] = useState(canvasTitle);
+  const [isLoading, setIsLoading] = useState(false);
   const inputRef = useRef(null);
 
   useEffect(() => {
@@ -23,6 +30,27 @@ export const CanvasRename: React.FC<CanvasRenameProps> = ({
       setEditedTitle(canvasTitle);
     }
   }, [canvasTitle, isModalOpen]);
+
+  const handleAutoName = async () => {
+    if (!canvasId) return;
+
+    setIsLoading(true);
+    const { data, error } = await getClient().autoNameCanvas({
+      body: {
+        canvasId,
+        directUpdate: false,
+      },
+    });
+    setIsLoading(false);
+
+    if (error || !data.success) {
+      return;
+    }
+
+    if (data?.data?.title) {
+      setEditedTitle(data.data.title);
+    }
+  };
 
   return (
     <Modal
@@ -40,21 +68,32 @@ export const CanvasRename: React.FC<CanvasRenameProps> = ({
         }
       }}
     >
-      <Input
-        autoFocus
-        ref={inputRef}
-        value={editedTitle}
-        onChange={(e) => setEditedTitle(e.target.value)}
-        placeholder={t('canvas.toolbar.editTitlePlaceholder')}
-        onKeyDown={(e) => {
-          if (e.keyCode === 13 && !e.nativeEvent.isComposing) {
-            e.preventDefault();
-            if (editedTitle?.trim()) {
-              handleModalOk(editedTitle);
+      <div className="relative">
+        <Input
+          autoFocus
+          ref={inputRef}
+          value={editedTitle}
+          onChange={(e) => setEditedTitle(e.target.value)}
+          placeholder={t('canvas.toolbar.editTitlePlaceholder')}
+          onKeyDown={(e) => {
+            if (e.keyCode === 13 && !e.nativeEvent.isComposing) {
+              e.preventDefault();
+              if (editedTitle?.trim()) {
+                handleModalOk(editedTitle);
+              }
             }
-          }
-        }}
-      />
+          }}
+        />
+        <Tooltip title={t('canvas.toolbar.autoName')}>
+          <Button
+            type="text"
+            className="absolute right-0.5 top-1/2 -translate-y-1/2 p-1 text-gray-500"
+            onClick={handleAutoName}
+            loading={isLoading}
+            icon={<LuSparkles className="h-4 w-4 flex items-center" />}
+          />
+        </Tooltip>
+      </div>
     </Modal>
   );
 };

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/index.tsx
@@ -97,6 +97,7 @@ const CanvasTitle = memo(
         </div>
 
         <CanvasRename
+          canvasId={canvasId}
           canvasTitle={canvasTitle}
           isModalOpen={isModalOpen}
           handleModalOk={handleModalOk}

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/index.tsx
@@ -4,7 +4,7 @@ import { useSiderStoreShallow } from '@refly-packages/ai-workspace-common/stores
 import { useTranslation } from 'react-i18next';
 import { LOCALE } from '@refly/common-types';
 import { useDebounce } from 'use-debounce';
-
+import { useDebouncedCallback } from 'use-debounce';
 import { MdOutlineImage, MdOutlineAspectRatio } from 'react-icons/md';
 import { AiOutlineMenuUnfold } from 'react-icons/ai';
 import { BiErrorCircle } from 'react-icons/bi';
@@ -23,6 +23,7 @@ import { CanvasRename } from './canvas-rename';
 import { HoverCard } from '@refly-packages/ai-workspace-common/components/hover-card';
 import { CanvasActionDropdown } from '@refly-packages/ai-workspace-common/components/workspace/canvas-list-modal/canvasActionDropdown';
 import { useHoverCard } from '@refly-packages/ai-workspace-common/hooks/use-hover-card';
+import { useHandleSiderData } from '@refly-packages/ai-workspace-common/hooks/use-handle-sider-data';
 
 interface TopToolbarProps {
   canvasId: string;
@@ -49,21 +50,34 @@ const CanvasTitle = memo(
       updateCanvasTitle: state.updateCanvasTitle,
     }));
 
-    const handleEditClick = () => {
+    const handleEditClick = useCallback(() => {
       setIsModalOpen(true);
-    };
+    }, []);
 
-    const handleModalOk = (newTitle: string) => {
-      if (newTitle?.trim()) {
-        syncTitleToYDoc(newTitle);
-        updateCanvasTitle(canvasId, newTitle);
-        setIsModalOpen(false);
-      }
-    };
+    const handleModalOk = useCallback(
+      (newTitle: string) => {
+        if (newTitle?.trim()) {
+          syncTitleToYDoc(newTitle);
+          updateCanvasTitle(canvasId, newTitle);
+          setIsModalOpen(false);
+        }
+      },
+      [canvasId, syncTitleToYDoc, updateCanvasTitle],
+    );
 
-    const handleModalCancel = () => {
+    const handleModalCancel = useCallback(() => {
       setIsModalOpen(false);
-    };
+    }, []);
+
+    const { getCanvasList } = useHandleSiderData();
+    const debouncedRefetchCanvasList = useDebouncedCallback(async () => {
+      await getCanvasList();
+    }, 500);
+
+    // Refetch canvas list when canvas title changes
+    useEffect(() => {
+      debouncedRefetchCanvasList();
+    }, [canvasTitle]);
 
     return (
       <>

--- a/packages/ai-workspace-common/src/components/workspace/canvas-list-modal/canvasActionDropdown.tsx
+++ b/packages/ai-workspace-common/src/components/workspace/canvas-list-modal/canvasActionDropdown.tsx
@@ -148,6 +148,7 @@ export const CanvasActionDropdown = (props: CanvasActionDropdown) => {
 
       <div onClick={(e) => e.stopPropagation()}>
         <CanvasRename
+          canvasId={canvasId}
           canvasTitle={canvasName}
           isModalOpen={isModalOpen}
           handleModalOk={handleModalOk}

--- a/packages/ai-workspace-common/src/hooks/use-handle-sider-data.ts
+++ b/packages/ai-workspace-common/src/hooks/use-handle-sider-data.ts
@@ -16,12 +16,12 @@ export const useHandleSiderData = (initData?: boolean) => {
 
   const [isLoadingCanvas, setIsLoadingCanvas] = useState(false);
 
-  const getCanvasList = async () => {
-    setIsLoadingCanvas(true);
+  const getCanvasList = async (setLoading?: boolean) => {
+    setLoading && setIsLoadingCanvas(true);
     const { data: res, error } = await getClient().listCanvases({
       query: { page: 1, pageSize: DATA_NUM },
     });
-    setIsLoadingCanvas(false);
+    setLoading && setIsLoadingCanvas(false);
     if (error) {
       console.error('getCanvasList error', error);
       return [];
@@ -85,13 +85,13 @@ export const useHandleSiderData = (initData?: boolean) => {
     updateLibraryList(libraryList);
   };
 
-  const loadSiderData = async () => {
-    getCanvasList();
+  const loadSiderData = async (setLoading?: boolean) => {
+    getCanvasList(setLoading);
   };
 
   useEffect(() => {
     if (initData) {
-      loadSiderData();
+      loadSiderData(true);
     }
   }, []);
 

--- a/packages/ai-workspace-common/src/queries/common.ts
+++ b/packages/ai-workspace-common/src/queries/common.ts
@@ -4,6 +4,7 @@ import { type Options } from '@hey-api/client-fetch';
 import { UseQueryResult } from '@tanstack/react-query';
 import {
   addReferences,
+  autoNameCanvas,
   batchCreateResource,
   batchUpdateDocument,
   checkSettingsField,
@@ -357,6 +358,12 @@ export type DeleteCanvasMutationResult = Awaited<ReturnType<typeof deleteCanvas>
 export const useDeleteCanvasKey = 'DeleteCanvas';
 export const UseDeleteCanvasKeyFn = (mutationKey?: Array<unknown>) => [
   useDeleteCanvasKey,
+  ...(mutationKey ?? []),
+];
+export type AutoNameCanvasMutationResult = Awaited<ReturnType<typeof autoNameCanvas>>;
+export const useAutoNameCanvasKey = 'AutoNameCanvas';
+export const UseAutoNameCanvasKeyFn = (mutationKey?: Array<unknown>) => [
+  useAutoNameCanvasKey,
   ...(mutationKey ?? []),
 ];
 export type UpdateResourceMutationResult = Awaited<ReturnType<typeof updateResource>>;

--- a/packages/ai-workspace-common/src/queries/queries.ts
+++ b/packages/ai-workspace-common/src/queries/queries.ts
@@ -4,6 +4,7 @@ import { type Options } from '@hey-api/client-fetch';
 import { useMutation, UseMutationOptions, useQuery, UseQueryOptions } from '@tanstack/react-query';
 import {
   addReferences,
+  autoNameCanvas,
   batchCreateResource,
   batchUpdateDocument,
   checkSettingsField,
@@ -76,6 +77,8 @@ import {
 import {
   AddReferencesData,
   AddReferencesError,
+  AutoNameCanvasData,
+  AutoNameCanvasError,
   BatchCreateResourceData,
   BatchCreateResourceError,
   BatchUpdateDocumentData,
@@ -689,6 +692,23 @@ export const useDeleteCanvas = <
   useMutation<TData, TError, Options<DeleteCanvasData, true>, TContext>({
     mutationKey: Common.UseDeleteCanvasKeyFn(mutationKey),
     mutationFn: (clientOptions) => deleteCanvas(clientOptions) as unknown as Promise<TData>,
+    ...options,
+  });
+export const useAutoNameCanvas = <
+  TData = Common.AutoNameCanvasMutationResult,
+  TError = AutoNameCanvasError,
+  TQueryKey extends Array<unknown> = unknown[],
+  TContext = unknown,
+>(
+  mutationKey?: TQueryKey,
+  options?: Omit<
+    UseMutationOptions<TData, TError, Options<AutoNameCanvasData, true>, TContext>,
+    'mutationKey' | 'mutationFn'
+  >,
+) =>
+  useMutation<TData, TError, Options<AutoNameCanvasData, true>, TContext>({
+    mutationKey: Common.UseAutoNameCanvasKeyFn(mutationKey),
+    mutationFn: (clientOptions) => autoNameCanvas(clientOptions) as unknown as Promise<TData>,
     ...options,
   });
 export const useUpdateResource = <

--- a/packages/ai-workspace-common/src/requests/services.gen.ts
+++ b/packages/ai-workspace-common/src/requests/services.gen.ts
@@ -42,6 +42,9 @@ import type {
   DeleteCanvasData,
   DeleteCanvasError,
   DeleteCanvasResponse,
+  AutoNameCanvasData,
+  AutoNameCanvasError,
+  AutoNameCanvasResponse2,
   ListResourcesData,
   ListResourcesError,
   ListResourcesResponse,
@@ -388,6 +391,23 @@ export const deleteCanvas = <ThrowOnError extends boolean = false>(
   return (options?.client ?? client).post<DeleteCanvasResponse, DeleteCanvasError, ThrowOnError>({
     ...options,
     url: '/canvas/delete',
+  });
+};
+
+/**
+ * Auto name canvas
+ * Auto name a canvas
+ */
+export const autoNameCanvas = <ThrowOnError extends boolean = false>(
+  options: Options<AutoNameCanvasData, ThrowOnError>,
+) => {
+  return (options?.client ?? client).post<
+    AutoNameCanvasResponse2,
+    AutoNameCanvasError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/canvas/autoName',
   });
 };
 

--- a/packages/ai-workspace-common/src/requests/types.gen.ts
+++ b/packages/ai-workspace-common/src/requests/types.gen.ts
@@ -214,7 +214,7 @@ export type Document = {
 /**
  * Entity type
  */
-export type EntityType = 'document' | 'resource' | 'canvas' | 'user';
+export type EntityType = 'document' | 'resource' | 'canvas' | 'user' | 'skillResponse';
 
 /**
  * Entity
@@ -1459,6 +1459,29 @@ export type DeleteCanvasRequest = {
    * Whether to delete all files in the canvas
    */
   deleteAllFiles?: boolean;
+};
+
+export type AutoNameCanvasRequest = {
+  /**
+   * Canvas ID
+   */
+  canvasId: string;
+  /**
+   * Whether to directly update the canvas title
+   */
+  directUpdate?: boolean;
+};
+
+export type AutoNameCanvasResponse = BaseResponse & {
+  /**
+   * Auto name canvas result
+   */
+  data?: {
+    /**
+     * New canvas title
+     */
+    title?: string;
+  };
 };
 
 export type UpsertResourceRequest = {
@@ -2984,6 +3007,14 @@ export type DeleteCanvasData = {
 export type DeleteCanvasResponse = BaseResponse;
 
 export type DeleteCanvasError = unknown;
+
+export type AutoNameCanvasData = {
+  body: AutoNameCanvasRequest;
+};
+
+export type AutoNameCanvasResponse2 = AutoNameCanvasResponse;
+
+export type AutoNameCanvasError = unknown;
 
 export type ListResourcesData = {
   query?: {

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -638,6 +638,7 @@ const translations = {
       addSkill: 'Add Skill',
       addTool: 'Add Tool',
       autoLayout: 'Auto Layout',
+      autoName: 'Auto Name',
       askAI: 'Ask AI',
       askAIDescription:
         'Ask AI, select context or switch skill, input requirements, get help with writing, reading comprehension, or question answering',

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -633,6 +633,7 @@ const translations = {
       addSkill: '添加技能',
       addTool: '添加工具',
       autoLayout: '自动布局',
+      autoName: '自动命名',
       askAI: '问问 AI',
       askAIDescription:
         '通过 AI 提问，可以选择上下文、切换技能或模型，以获取写作灵感、内容创作、知识问答等。',

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -274,6 +274,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseResponse'
+  /canvas/autoName:
+    post:
+      tags:
+        - canvas
+      summary: Auto name canvas
+      description: Auto name a canvas
+      operationId: autoNameCanvas
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AutoNameCanvasRequest'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AutoNameCanvasResponse'
   /knowledge/resource/list:
     get:
       tags:
@@ -1731,6 +1751,7 @@ components:
         - resource
         - canvas
         - user
+        - skillResponse
     Entity:
       type: object
       description: Entity
@@ -2984,6 +3005,30 @@ components:
           type: boolean
           description: Whether to delete all files in the canvas
           default: false
+    AutoNameCanvasRequest:
+      type: object
+      required:
+        - canvasId
+      properties:
+        canvasId:
+          type: string
+          description: Canvas ID
+        directUpdate:
+          type: boolean
+          description: Whether to directly update the canvas title
+          default: false
+    AutoNameCanvasResponse:
+      allOf:
+        - $ref: '#/components/schemas/BaseResponse'
+        - type: object
+          properties:
+            data:
+              type: object
+              description: Auto name canvas result
+              properties:
+                title:
+                  type: string
+                  description: New canvas title
     UpsertResourceRequest:
       type: object
       required:

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -262,7 +262,7 @@ export const DocumentSchema = {
 export const EntityTypeSchema = {
   type: 'string',
   description: 'Entity type',
-  enum: ['document', 'resource', 'canvas', 'user'],
+  enum: ['document', 'resource', 'canvas', 'user', 'skillResponse'],
 } as const;
 
 export const EntitySchema = {
@@ -1897,6 +1897,45 @@ export const DeleteCanvasRequestSchema = {
       default: false,
     },
   },
+} as const;
+
+export const AutoNameCanvasRequestSchema = {
+  type: 'object',
+  required: ['canvasId'],
+  properties: {
+    canvasId: {
+      type: 'string',
+      description: 'Canvas ID',
+    },
+    directUpdate: {
+      type: 'boolean',
+      description: 'Whether to directly update the canvas title',
+      default: false,
+    },
+  },
+} as const;
+
+export const AutoNameCanvasResponseSchema = {
+  allOf: [
+    {
+      $ref: '#/components/schemas/BaseResponse',
+    },
+    {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'object',
+          description: 'Auto name canvas result',
+          properties: {
+            title: {
+              type: 'string',
+              description: 'New canvas title',
+            },
+          },
+        },
+      },
+    },
+  ],
 } as const;
 
 export const UpsertResourceRequestSchema = {

--- a/packages/openapi-schema/src/services.gen.ts
+++ b/packages/openapi-schema/src/services.gen.ts
@@ -42,6 +42,9 @@ import type {
   DeleteCanvasData,
   DeleteCanvasError,
   DeleteCanvasResponse,
+  AutoNameCanvasData,
+  AutoNameCanvasError,
+  AutoNameCanvasResponse2,
   ListResourcesData,
   ListResourcesError,
   ListResourcesResponse,
@@ -388,6 +391,23 @@ export const deleteCanvas = <ThrowOnError extends boolean = false>(
   return (options?.client ?? client).post<DeleteCanvasResponse, DeleteCanvasError, ThrowOnError>({
     ...options,
     url: '/canvas/delete',
+  });
+};
+
+/**
+ * Auto name canvas
+ * Auto name a canvas
+ */
+export const autoNameCanvas = <ThrowOnError extends boolean = false>(
+  options: Options<AutoNameCanvasData, ThrowOnError>,
+) => {
+  return (options?.client ?? client).post<
+    AutoNameCanvasResponse2,
+    AutoNameCanvasError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/canvas/autoName',
   });
 };
 

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -214,7 +214,7 @@ export type Document = {
 /**
  * Entity type
  */
-export type EntityType = 'document' | 'resource' | 'canvas' | 'user';
+export type EntityType = 'document' | 'resource' | 'canvas' | 'user' | 'skillResponse';
 
 /**
  * Entity
@@ -1459,6 +1459,29 @@ export type DeleteCanvasRequest = {
    * Whether to delete all files in the canvas
    */
   deleteAllFiles?: boolean;
+};
+
+export type AutoNameCanvasRequest = {
+  /**
+   * Canvas ID
+   */
+  canvasId: string;
+  /**
+   * Whether to directly update the canvas title
+   */
+  directUpdate?: boolean;
+};
+
+export type AutoNameCanvasResponse = BaseResponse & {
+  /**
+   * Auto name canvas result
+   */
+  data?: {
+    /**
+     * New canvas title
+     */
+    title?: string;
+  };
 };
 
 export type UpsertResourceRequest = {
@@ -2984,6 +3007,14 @@ export type DeleteCanvasData = {
 export type DeleteCanvasResponse = BaseResponse;
 
 export type DeleteCanvasError = unknown;
+
+export type AutoNameCanvasData = {
+  body: AutoNameCanvasRequest;
+};
+
+export type AutoNameCanvasResponse2 = AutoNameCanvasResponse;
+
+export type AutoNameCanvasError = unknown;
 
 export type ListResourcesData = {
   query?: {

--- a/packages/skill-template/src/engine/index.ts
+++ b/packages/skill-template/src/engine/index.ts
@@ -147,10 +147,7 @@ export class SkillEngine {
     public service: ReflyService,
     private options?: SkillEngineOptions,
   ) {
-    this.options = {
-      defaultModel: 'openai/gpt-4o-mini',
-      ...options,
-    };
+    this.options = options;
   }
 
   configure(config: SkillRunnableConfig) {


### PR DESCRIPTION
# Summary

- Support dedicated endpoint for canvas auto-naming
- Automatic naming after initial skill invocation

# Impact Areas

Please check the areas this PR affects:

- [x] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [x] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
