### PR TITLE
feat(canvas): Hide action buttons during node dragging

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/memo/memo.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/memo/memo.tsx
@@ -41,7 +41,7 @@ import { useCanvasData } from '@refly-packages/ai-workspace-common/hooks/canvas/
 import { useAddNode } from '@refly-packages/ai-workspace-common/hooks/canvas/use-add-node';
 import { genSkillID } from '@refly-packages/utils/id';
 import { IContextItem } from '@refly-packages/ai-workspace-common/stores/context-panel';
-
+import { useEditorPerformance } from '@refly-packages/ai-workspace-common/context/editor-performance';
 export const MemoNode = ({
   data,
   selected,
@@ -58,8 +58,6 @@ export const MemoNode = ({
   const language = i18n.languages?.[0];
   const { addNode } = useAddNode();
 
-  // console.log('memo', id);
-
   const { getNode } = useReactFlow();
   const node = getNode(id);
   const targetRef = useRef<HTMLDivElement>(null);
@@ -70,6 +68,8 @@ export const MemoNode = ({
   const { operatingNodeId } = useCanvasStoreShallow((state) => ({
     operatingNodeId: state.operatingNodeId,
   }));
+  const { draggingNodeId } = useEditorPerformance();
+  const isDragging = draggingNodeId === id;
 
   const { handleMouseEnter: onHoverStart, handleMouseLeave: onHoverEnd } = useNodeHoverEffect(id);
 
@@ -297,7 +297,7 @@ export const MemoNode = ({
         {!isPreview && selected && (
           <MemoEditor editor={editor} bgColor={bgColor} onChangeBackground={onUpdateBgColor} />
         )}
-        {!isPreview && !hideActions && (
+        {!isPreview && !hideActions && !isDragging && (
           <ActionButtons type="memo" nodeId={id} isNodeHovered={isHovered} />
         )}
 


### PR DESCRIPTION
- Add dragging state check to conditionally render memo node action buttons
- Integrate editor performance context to track dragging node
- Prevent action buttons from appearing while a node is being dragged

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
