### PR TITLE
fix(web): simplify canvas title update mechanism

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
+      - name: Install Cypress
+        run: pnpm cy:install
+
       - name: Start Middleware Containers
         run: |
           docker compose -f deploy/docker/docker-compose.middleware.yml up -d

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "codegen": "turbo run codegen",
     "clean": "turbo run clean",
     "cy:open": "cypress open",
+    "cy:install": "cypress install",
     "lint": "biome lint .",
     "lint:fix": "biome lint . --write",
     "format": "biome format .",

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/index.tsx
@@ -4,7 +4,6 @@ import { useSiderStoreShallow } from '@refly-packages/ai-workspace-common/stores
 import { useTranslation } from 'react-i18next';
 import { LOCALE } from '@refly/common-types';
 import { useDebounce } from 'use-debounce';
-import { useDebouncedCallback } from 'use-debounce';
 import { MdOutlineImage, MdOutlineAspectRatio } from 'react-icons/md';
 import { AiOutlineMenuUnfold } from 'react-icons/ai';
 import { BiErrorCircle } from 'react-icons/bi';
@@ -23,7 +22,6 @@ import { CanvasRename } from './canvas-rename';
 import { HoverCard } from '@refly-packages/ai-workspace-common/components/hover-card';
 import { CanvasActionDropdown } from '@refly-packages/ai-workspace-common/components/workspace/canvas-list-modal/canvasActionDropdown';
 import { useHoverCard } from '@refly-packages/ai-workspace-common/hooks/use-hover-card';
-import { useHandleSiderData } from '@refly-packages/ai-workspace-common/hooks/use-handle-sider-data';
 
 interface TopToolbarProps {
   canvasId: string;
@@ -58,7 +56,6 @@ const CanvasTitle = memo(
       (newTitle: string) => {
         if (newTitle?.trim()) {
           syncTitleToYDoc(newTitle);
-          updateCanvasTitle(canvasId, newTitle);
           setIsModalOpen(false);
         }
       },
@@ -69,14 +66,9 @@ const CanvasTitle = memo(
       setIsModalOpen(false);
     }, []);
 
-    const { getCanvasList } = useHandleSiderData();
-    const debouncedRefetchCanvasList = useDebouncedCallback(async () => {
-      await getCanvasList();
-    }, 500);
-
     // Refetch canvas list when canvas title changes
     useEffect(() => {
-      debouncedRefetchCanvasList();
+      updateCanvasTitle(canvasId, canvasTitle);
     }, [canvasTitle]);
 
     return (


### PR DESCRIPTION
- Remove unnecessary debounced canvas list refetching
- Directly update canvas title in useEffect
- Clean up unused imports and hooks

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
