### PR TITLE
feat: mark reasoning capability in model config

### DIFF
--- a/deploy/model-providers/openrouter.sql
+++ b/deploy/model-providers/openrouter.sql
@@ -8,7 +8,7 @@ VALUES
     ('anthropic/claude-3.5-haiku', 'Claude 3.5 Haiku', 'anthropic', 't2', 't', 'f', 200000, 8192, '{"vision":true}'),
 
     -- DeepSeek models
-    ('deepseek/deepseek-r1', 'DeepSeek R1', 'deepseek', 't1', 't', 'f', 64000, 8192, '{}'),
+    ('deepseek/deepseek-r1', 'DeepSeek R1', 'deepseek', 't1', 't', 'f', 64000, 8192, '{"reasoning":true}'),
     ('deepseek/deepseek-chat', 'DeepSeek V3', 'deepseek', 't2', 't', 'f', 64000, 8192, '{}'),
     ('deepseek/deepseek-r1-distill-qwen-32b', 'DeepSeek R1 Distill Qwen 32B', 'deepseek', 't2', 't', 'f', 131072, 131072, '{}'),
 

--- a/packages/ai-workspace-common/src/requests/types.gen.ts
+++ b/packages/ai-workspace-common/src/requests/types.gen.ts
@@ -2806,6 +2806,10 @@ export type ModelCapabilities = {
    * Whether this model can take images as input
    */
   vision?: boolean;
+  /**
+   * Whether this model includes reasoning content
+   */
+  reasoning?: boolean;
 };
 
 export type ModelInfo = {

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -4478,6 +4478,9 @@ components:
         vision:
           type: boolean
           description: Whether this model can take images as input
+        reasoning:
+          type: boolean
+          description: Whether this model includes reasoning content
     ModelInfo:
       type: object
       required:

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -4064,6 +4064,10 @@ export const ModelCapabilitiesSchema = {
       type: 'boolean',
       description: 'Whether this model can take images as input',
     },
+    reasoning: {
+      type: 'boolean',
+      description: 'Whether this model includes reasoning content',
+    },
   },
 } as const;
 

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -2806,6 +2806,10 @@ export type ModelCapabilities = {
    * Whether this model can take images as input
    */
   vision?: boolean;
+  /**
+   * Whether this model includes reasoning content
+   */
+  reasoning?: boolean;
 };
 
 export type ModelInfo = {

--- a/packages/skill-template/src/engine/chat-deepseek.ts
+++ b/packages/skill-template/src/engine/chat-deepseek.ts
@@ -440,7 +440,7 @@ export class ChatDeepSeek extends ChatOpenAI<ChatDeepSeekCallOptions> {
         ...fields?.configuration,
       },
       modelKwargs: {
-        include_reasoning: true,
+        include_reasoning: fields?.include_reasoning,
       },
     });
   }

--- a/packages/skill-template/src/engine/index.ts
+++ b/packages/skill-template/src/engine/index.ts
@@ -168,10 +168,12 @@ export class SkillEngine {
       });
     }
 
+    const config = this.config?.configurable;
+
     return new ChatDeepSeek({
       model: useDefaultChatModel
         ? this.options.defaultModel
-        : this.config?.configurable?.modelInfo?.name || this.options.defaultModel,
+        : config.modelInfo?.name || this.options.defaultModel,
       apiKey: process.env.OPENROUTER_API_KEY || process.env.OPENAI_API_KEY,
       configuration: {
         baseURL: process.env.OPENROUTER_API_KEY && 'https://openrouter.ai/api/v1',
@@ -181,7 +183,7 @@ export class SkillEngine {
         },
       },
       ...params,
-      include_reasoning: true,
+      include_reasoning: config?.modelInfo?.capabilities?.reasoning,
     });
   }
 }


### PR DESCRIPTION
# Summary

- Add `reasoning` to model capabilities field
- Only pass the `include_reasoning` parameter to model provider when `reasoning` is present

Related error log:

![image](https://github.com/user-attachments/assets/4f648d64-76d4-4490-b106-017232cf804b)

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
