### PR TITLE
feat(skill-template): add URL extraction and crawling support for con…

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
@@ -85,7 +85,7 @@ const NodeHeader = memo(
         </div>
         {skillName && skillName !== 'commonQnA' && (
           <div className="flex-shrink-0 mb-2">
-            <SelectedSkillHeader readonly skill={skill} className="rounded-sm" />
+            <SelectedSkillHeader readonly skill={skill} className="rounded-md" />
           </div>
         )}
       </>
@@ -537,7 +537,7 @@ export const SkillResponseNode = memo(
                 <div className="flex flex-col gap-3">
                   {status === 'failed' && (
                     <div
-                      className="flex items-center justify-center gap-1 mt-1 hover:bg-gray-50 rounded-sm p-2 cursor-pointer"
+                      className="flex items-center justify-center gap-1 mt-1 hover:bg-gray-50 rounded-md p-2 cursor-pointer"
                       onClick={() => handleRerun()}
                     >
                       <IconError className="h-4 w-4 text-red-500" />
@@ -548,7 +548,7 @@ export const SkillResponseNode = memo(
                   )}
 
                   {(status === 'waiting' || status === 'executing') && (
-                    <div className="flex items-center gap-2 bg-gray-100 rounded-sm p-2">
+                    <div className="flex items-center gap-2 bg-gray-100 rounded-md p-2">
                       <IconLoading className="h-3 w-3 animate-spin text-green-500" />
                       <span className="text-xs text-gray-500 max-w-48 truncate">
                         {log ? (
@@ -565,7 +565,7 @@ export const SkillResponseNode = memo(
 
                   {status !== 'failed' && sources.length > 0 && (
                     <div
-                      className="flex items-center justify-between gap-2 border-gray-100 border-solid rounded-sm p-2 hover:bg-gray-50 cursor-pointer"
+                      className="flex items-center rounded-md justify-between gap-2 border-gray-100 border-solid p-2 hover:bg-gray-50 cursor-pointer "
                       onClick={handleClickSources}
                     >
                       <span className="flex items-center gap-1 text-xs text-gray-500">

--- a/packages/ai-workspace-common/src/components/source-list/index.tsx
+++ b/packages/ai-workspace-common/src/components/source-list/index.tsx
@@ -169,14 +169,12 @@ export const SourceList = (props: SourceListProps) => {
         {sources.slice(0, 3).map((item, index) => (
           <SourceItem key={index} index={index} source={item} />
         ))}
-        {sources.length > 3 && (
-          <ViewMoreItem
-            onClick={handleViewMore}
-            key="view-more"
-            sources={sources}
-            extraCnt={sources.slice(3).length}
-          />
-        )}
+        <ViewMoreItem
+          onClick={handleViewMore}
+          key="view-more"
+          sources={sources}
+          extraCnt={sources.slice(3).length}
+        />
       </div>
     </div>
   ) : null;

--- a/packages/ai-workspace-common/src/requests/types.gen.ts
+++ b/packages/ai-workspace-common/src/requests/types.gen.ts
@@ -735,13 +735,13 @@ export type SourceMeta = {
   /**
    * Source type
    */
-  sourceType?: 'webSearch' | 'library';
+  sourceType?: 'webSearch' | 'library' | 'urlSource';
 };
 
 /**
  * Source type
  */
-export type sourceType = 'webSearch' | 'library';
+export type sourceType = 'webSearch' | 'library' | 'urlSource';
 
 /**
  * Source selection

--- a/packages/i18n/src/en-US/skill-log.ts
+++ b/packages/i18n/src/en-US/skill-log.ts
@@ -35,6 +35,18 @@ const translations = {
     title: 'Generate Answer',
     description: 'Start to generate answer...',
   },
+  extractUrls: {
+    title: 'Extract URLs',
+    description: 'Total of {{totalResults}} results, completed in {{duration}}ms',
+  },
+  crawlUrls: {
+    title: 'Read URLs',
+    description: 'Total of {{totalResults}} results, completed in {{duration}}ms',
+  },
+  analyzeQuery: {
+    title: 'Analyze Query',
+    description: 'Analyze query completed, completed in {{duration}}ms',
+  },
 };
 
 export default translations;

--- a/packages/i18n/src/en-US/skill.ts
+++ b/packages/i18n/src/en-US/skill.ts
@@ -4,6 +4,9 @@ const translations = {
     description: 'Answer questions based on the context',
     placeholder: 'Ask AI a question, press / to select skill...',
     steps: {
+      analyzeQuery: {
+        name: 'Query Analysis',
+      },
       analyzeContext: {
         name: 'Context Analysis',
       },
@@ -17,6 +20,9 @@ const translations = {
     description: 'Answer questions based on the custom system prompt and context',
     placeholder: 'Let AI help you answer questions with a custom system prompt...',
     steps: {
+      analyzeQuery: {
+        name: 'Query Analysis',
+      },
       analyzeContext: {
         name: 'Context Analysis',
       },
@@ -30,6 +36,9 @@ const translations = {
     description: 'Generate documents based on the question and context',
     placeholder: 'Let AI help you generate a document...',
     steps: {
+      analyzeQuery: {
+        name: 'Query Analysis',
+      },
       analyzeContext: {
         name: 'Context Analysis',
       },
@@ -55,6 +64,9 @@ const translations = {
     description: 'Search the web and get answers',
     placeholder: 'Search the web and get answers...',
     steps: {
+      analyzeQuery: {
+        name: 'Query Analysis',
+      },
       analyzeContext: {
         name: 'Context Analysis',
       },
@@ -71,6 +83,9 @@ const translations = {
     description: 'Search the library and get answers',
     placeholder: 'Search the library and get answers...',
     steps: {
+      analyzeQuery: {
+        name: 'Query Analysis',
+      },
       analyzeContext: {
         name: 'Context Analysis',
       },
@@ -87,6 +102,9 @@ const translations = {
     description: 'Brainstorm questions based on the context',
     placeholder: 'Let AI recommend questions for you...',
     steps: {
+      analyzeQuery: {
+        name: 'Query Analysis',
+      },
       recommendQuestions: {
         name: 'Generate Recommended Questions',
       },

--- a/packages/i18n/src/zh-Hans/skill-log.ts
+++ b/packages/i18n/src/zh-Hans/skill-log.ts
@@ -35,6 +35,18 @@ const translations = {
     title: '生成答案',
     description: '开始生成答案...',
   },
+  extractUrls: {
+    title: '提取网页链接',
+    description: '总共 {{totalResults}} 个结果, 耗时 {{duration}} 毫秒',
+  },
+  crawlUrls: {
+    title: '阅读网页链接',
+    description: '总共 {{totalResults}} 个结果, 耗时 {{duration}} 毫秒',
+  },
+  analyzeQuery: {
+    title: '分析需求',
+    description: '分析需求完成，耗时 {{duration}} 毫秒',
+  },
 };
 
 export default translations;

--- a/packages/i18n/src/zh-Hans/skill.ts
+++ b/packages/i18n/src/zh-Hans/skill.ts
@@ -4,6 +4,9 @@ const translations = {
     description: '基于上下文回答问题',
     placeholder: '向 AI 提问，输入 / 选择技能...',
     steps: {
+      analyzeQuery: {
+        name: '分析需求',
+      },
       analyzeContext: {
         name: '上下文分析',
       },
@@ -17,6 +20,9 @@ const translations = {
     description: '基于自定义系统提示和上下文回答问题',
     placeholder: '让 AI 基于自定义系统提示回答问题...',
     steps: {
+      analyzeQuery: {
+        name: '分析需求',
+      },
       analyzeContext: {
         name: '上下文分析',
       },
@@ -30,6 +36,9 @@ const translations = {
     description: '根据需求和上下文进行写作',
     placeholder: '让 AI 帮您生成一篇文档...',
     steps: {
+      analyzeQuery: {
+        name: '分析需求',
+      },
       analyzeContext: {
         name: '上下文分析',
       },
@@ -44,7 +53,14 @@ const translations = {
   editDoc: {
     name: '编辑文档',
     placeholder: '让 AI 帮您编辑文档...',
-    steps: {},
+    steps: {
+      analyzeQuery: {
+        name: '分析需求',
+      },
+      analyzeContext: {
+        name: '上下文分析',
+      },
+    },
   },
   rewriteDoc: {
     name: '重写文档',
@@ -55,6 +71,9 @@ const translations = {
     description: '搜索网络并获取答案',
     placeholder: '搜索网络并获取答案...',
     steps: {
+      analyzeQuery: {
+        name: '分析需求',
+      },
       analyzeContext: {
         name: '上下文分析',
       },
@@ -71,6 +90,9 @@ const translations = {
     description: '搜索知识库并获取答案',
     placeholder: '搜索知识库并获取答案...',
     steps: {
+      analyzeQuery: {
+        name: '分析需求',
+      },
       analyzeContext: {
         name: '上下文分析',
       },
@@ -87,6 +109,9 @@ const translations = {
     description: '基于上下文脑暴问题',
     placeholder: '让 AI 为您生成推荐问题...',
     steps: {
+      analyzeQuery: {
+        name: '分析需求',
+      },
       recommendQuestions: {
         name: '生成推荐问题',
       },

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -2293,6 +2293,7 @@ components:
           enum:
             - webSearch
             - library
+            - urlSource
     SourceSelection:
       type: object
       description: Source selection

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -901,7 +901,7 @@ export const SourceMetaSchema = {
     sourceType: {
       type: 'string',
       description: 'Source type',
-      enum: ['webSearch', 'library'],
+      enum: ['webSearch', 'library', 'urlSource'],
     },
   },
 } as const;

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -735,13 +735,13 @@ export type SourceMeta = {
   /**
    * Source type
    */
-  sourceType?: 'webSearch' | 'library';
+  sourceType?: 'webSearch' | 'library' | 'urlSource';
 };
 
 /**
  * Source type
  */
-export type sourceType = 'webSearch' | 'library';
+export type sourceType = 'webSearch' | 'library' | 'urlSource';
 
 /**
  * Source selection

--- a/packages/skill-template/package.json
+++ b/packages/skill-template/package.json
@@ -22,6 +22,8 @@
     "dotenv": "~16.4.5",
     "duck-duck-scrape": "~2.2.5",
     "is-url": "~1.2.4",
+    "json-parse-even-better-errors": "^4.0.0",
+    "jsonrepair": "^3.12.0",
     "langchain": "0.3.15",
     "linkify-it": "^5.0.0",
     "lodash": "~4.17.21",
@@ -29,6 +31,7 @@
     "p-limit": "3.1.0",
     "tlds": "^1.255.0",
     "tsx": "^4.6.2",
-    "zod": "3.23.8"
+    "zod": "3.23.8",
+    "zod-to-json-schema": "^3.24.3"
   }
 }

--- a/packages/skill-template/package.json
+++ b/packages/skill-template/package.json
@@ -23,9 +23,11 @@
     "duck-duck-scrape": "~2.2.5",
     "is-url": "~1.2.4",
     "langchain": "0.3.15",
+    "linkify-it": "^5.0.0",
     "lodash": "~4.17.21",
     "lodash.uniqby": "~4.7.0",
     "p-limit": "3.1.0",
+    "tlds": "^1.255.0",
     "tsx": "^4.6.2",
     "zod": "3.23.8"
   }

--- a/packages/skill-template/src/engine/index.ts
+++ b/packages/skill-template/src/engine/index.ts
@@ -112,6 +112,12 @@ export interface ReflyService {
       additionalMetadata?: Record<string, any>;
     },
   ) => Promise<InMemorySearchResponse>;
+
+  // New method to crawl URLs and get their content
+  crawlUrl: (
+    user: User,
+    url: string,
+  ) => Promise<{ title?: string; content?: string; metadata?: Record<string, any> }>;
 }
 
 export interface SkillEngineOptions {

--- a/packages/skill-template/src/scheduler/types/index.ts
+++ b/packages/skill-template/src/scheduler/types/index.ts
@@ -65,6 +65,7 @@ export interface IContext {
   messages?: BaseMessage[];
   webSearchSources?: Source[];
   librarySearchSources?: Source[];
+  urlSources?: Source[];
   locale?: string | LOCALE;
 }
 

--- a/packages/skill-template/src/scheduler/utils/extract-weblink.ts
+++ b/packages/skill-template/src/scheduler/utils/extract-weblink.ts
@@ -1,0 +1,258 @@
+import { SkillRunnableConfig } from '../../base';
+import { Source } from '@refly-packages/openapi-schema';
+import { BaseSkill } from '../../base';
+import pLimit from 'p-limit';
+// Import linkify-it and tlds
+import LinkifyIt from 'linkify-it';
+import tlds from 'tlds';
+
+// 默认的并发限制和批处理大小
+const DEFAULT_CONCURRENCY_LIMIT = 5;
+const DEFAULT_BATCH_SIZE = 8;
+
+// Initialize linkify-it with all TLDs
+const linkify = new LinkifyIt();
+// Add all top-level domains and enable fuzzy IP detection
+linkify.tlds(tlds).set({ fuzzyIP: true, fuzzyLink: true });
+
+/**
+ * Validates URL using built-in Node.js URL class
+ * @param url The URL string to validate
+ * @returns Boolean indicating if the URL is valid
+ */
+export function isValidUrl(url: string): boolean {
+  try {
+    // Check if URL can be constructed (validates format)
+    new URL(url);
+    return true;
+  } catch {
+    // Invalid URL format
+    return false;
+  }
+}
+
+/**
+ * Extract URLs from text using linkify-it
+ * Much faster and more reliable than regex or AI-based extraction
+ * @param query The text to extract URLs from
+ * @returns Object with detected URLs and whether URLs were found
+ */
+export function extractUrlsWithLinkify(query: string): {
+  hasUrls: boolean;
+  detectedUrls: string[];
+} {
+  if (!query) {
+    return { hasUrls: false, detectedUrls: [] };
+  }
+
+  // Find all links in text
+  const matches = linkify.match(query);
+
+  if (!matches || matches.length === 0) {
+    return { hasUrls: false, detectedUrls: [] };
+  }
+
+  // Extract URLs and normalize them
+  const detectedUrls = matches
+    .map((match) => {
+      // Get the raw URL
+      let url = match.url;
+
+      // If schema is missing, add https://
+      if (!match.schema) {
+        url = `https://${url}`;
+      }
+
+      return url;
+    })
+    .filter(isValidUrl); // Filter out any URLs that aren't valid
+
+  return {
+    hasUrls: detectedUrls.length > 0,
+    detectedUrls,
+  };
+}
+
+// Helper to chunk array into batches
+const chunk = <T>(arr: T[], size: number): T[][] => {
+  return Array.from({ length: Math.ceil(arr.length / size) }, (_, i) =>
+    arr.slice(i * size, i * size + size),
+  );
+};
+
+/**
+ * Crawl a single URL and format it as a source
+ * @param url URL string to crawl
+ * @param user User for the crawl request
+ * @param engine SkillEngine with access to crawl service
+ * @param logger Logger for reporting progress
+ * @returns Source object with content from the URL or null on failure
+ */
+async function crawlSingleUrl(
+  url: string,
+  user: any,
+  engine: any,
+  logger: any,
+): Promise<Source | null> {
+  try {
+    // Verify URL is valid using Node.js URL API
+    if (!isValidUrl(url)) {
+      logger.warn(`Skipping invalid URL: ${url}`);
+      return null;
+    }
+
+    const result = await engine.service.crawlUrl(user, url);
+
+    if (result?.content) {
+      return {
+        pageContent: result.content,
+        metadata: {
+          source: url,
+          title: result.title || url,
+          // Use type assertion to allow custom properties
+          ...(result.metadata || {}),
+        } as any,
+        url,
+        title: result.title || url,
+      };
+    }
+
+    if (logger) {
+      logger.warn(`URL crawled but no content returned: ${url}`);
+    }
+    return null;
+  } catch (error) {
+    if (logger) {
+      logger.error(`Failed to crawl URL ${url}: ${error}`);
+    }
+    return null;
+  }
+}
+
+/**
+ * Crawl URLs extracted from a query and format them as sources
+ * @param urls Array of URLs to crawl
+ * @param config The skill runnable configuration
+ * @param skill The BaseSkill instance with access to the engine
+ * @param options Optional configuration for concurrency and batch size
+ * @returns Array of sources with content from the URLs
+ */
+export async function crawlExtractedUrls(
+  urls: string[],
+  config: SkillRunnableConfig,
+  skill: BaseSkill,
+  options?: {
+    concurrencyLimit?: number;
+    batchSize?: number;
+  },
+): Promise<Source[]> {
+  if (!urls || urls.length === 0) {
+    return [];
+  }
+
+  const { user } = config.configurable;
+  const engine = skill.engine;
+  const logger = engine.logger;
+
+  if (!engine || !engine.service || !engine.service.crawlUrl) {
+    if (logger) {
+      logger.error('Crawl URL service not available');
+    }
+    return [];
+  }
+
+  // Set up concurrency control
+  const concurrencyLimit = options?.concurrencyLimit || DEFAULT_CONCURRENCY_LIMIT;
+  const limit = pLimit(concurrencyLimit);
+
+  // Filter out invalid URLs
+  const validUrls = urls.filter((url) => isValidUrl(url));
+  if (validUrls.length < urls.length) {
+    logger.warn(`Filtered out ${urls.length - validUrls.length} invalid URLs`);
+  }
+
+  // Split URLs into batches for processing
+  const batchSize = options?.batchSize || DEFAULT_BATCH_SIZE;
+  const batches = chunk(validUrls, batchSize);
+
+  logger.log(
+    `Starting to crawl ${validUrls.length} URLs with concurrency limit of ${concurrencyLimit} in ${batches.length} batches`,
+  );
+
+  const sources: Source[] = [];
+
+  // Process each batch sequentially
+  for (let i = 0; i < batches.length; i++) {
+    const batch = batches[i];
+    logger.log(`Processing batch ${i + 1}/${batches.length} with ${batch.length} URLs`);
+
+    // Process URLs in each batch concurrently
+    const batchResults = await Promise.all(
+      batch.map((url) => limit(() => crawlSingleUrl(url, user, engine, logger))),
+    );
+
+    // Filter out failed crawls and add to sources
+    const validResults = batchResults.filter(Boolean) as Source[];
+    sources.push(...validResults);
+
+    logger.log(
+      `Completed batch ${i + 1}/${batches.length}: ${validResults.length}/${batch.length} URLs successfully crawled`,
+    );
+  }
+
+  return sources;
+}
+
+/**
+ * Extract URLs from a query, crawl them, and return as sources
+ * Uses linkify-it for efficient URL extraction without AI
+ * @param query The user's query text
+ * @param config The skill runnable configuration
+ * @param skill The BaseSkill instance
+ * @param model The language model to use (unused but kept for API compatibility)
+ * @returns Array of sources with content from the URLs
+ */
+export async function extractAndCrawlUrls(
+  query: string,
+  config: SkillRunnableConfig,
+  skill: BaseSkill,
+  options?: {
+    concurrencyLimit?: number;
+    batchSize?: number;
+  },
+): Promise<{
+  sources: Source[];
+  analysis: { hasUrls: boolean; queryIntent: string };
+}> {
+  const logger = skill.engine.logger;
+
+  // Use linkify-it for fast and reliable URL extraction
+  const { hasUrls, detectedUrls } = extractUrlsWithLinkify(query);
+
+  if (!hasUrls) {
+    // If no URLs detected, return empty result
+    logger.log('No URLs detected with linkify-it');
+    return {
+      sources: [],
+      analysis: {
+        hasUrls: false,
+        queryIntent: query,
+      },
+    };
+  }
+
+  logger.log(
+    `Detected ${detectedUrls.length} URLs with linkify-it: ${JSON.stringify(detectedUrls)}`,
+  );
+
+  // Crawl the extracted URLs
+  const sources = await crawlExtractedUrls(detectedUrls, config, skill, options);
+
+  return {
+    sources,
+    analysis: {
+      hasUrls: Boolean(sources.length),
+      queryIntent: query, // Use query directly as intent
+    },
+  };
+}

--- a/packages/skill-template/src/scheduler/utils/extractor.ts
+++ b/packages/skill-template/src/scheduler/utils/extractor.ts
@@ -5,55 +5,188 @@ import { checkIsSupportedModel } from './model';
 import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
 import { ToolCall } from '@langchain/core/messages/tool';
 import { ModelInfo } from '@refly-packages/openapi-schema';
+import parseJson from 'json-parse-even-better-errors';
+import { jsonrepair } from 'jsonrepair';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 
-// Helper function to extract JSON from markdown code blocks
-function extractJsonFromMarkdown(content: string): any {
+// Enhanced interface for extraction errors
+interface ExtractionError {
+  message: string;
+  pattern?: string;
+  content?: string;
+  cause?: Error;
+  attemptedRepair?: boolean;
+}
+
+// Helper functions to preprocess and fix common JSON issues
+function preprocessJsonString(str: string): string {
+  // 创建一个新变量而不是修改参数
+  let result = str;
+
+  // Remove BOM characters that can appear at the start of some strings
+  result = result.replace(/^\uFEFF/, '');
+
+  // Normalize line endings
+  result = result.replace(/\r\n/g, '\n');
+
+  // Remove zero-width spaces and other invisible characters
+  // 修复字符类问题，分开定义特殊字符
+  result = result
+    .replace(/\u200B/g, '')
+    .replace(/\u200C/g, '')
+    .replace(/\u200D/g, '')
+    .replace(/\uFEFF/g, '');
+
+  // Replace "smart" quotes with straight quotes
+  result = result.replace(/[\u2018\u2019]/g, "'").replace(/[\u201C\u201D]/g, '"');
+
+  // Fix trailing commas in arrays and objects (common LLM error)
+  result = result.replace(/,(\s*[\]}])/g, '$1');
+
+  // Fix unquoted property names
+  result = result.replace(/([{,]\s*)(\w+)(\s*:)/g, '$1"$2"$3');
+
+  // Fix single-quoted strings (convert to double-quoted)
+  result = fixSingleQuotedStrings(result);
+
+  return result;
+}
+
+// Helper function to convert single quotes to double quotes while being careful with nested quotes
+function fixSingleQuotedStrings(str: string): string {
+  // This is a simplified approach - for complex cases we rely on jsonrepair
+  let inString = false;
+  let inDoubleQuoteString = false;
+  let result = '';
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+    const prevChar = i > 0 ? str[i - 1] : '';
+
+    // Toggle string state based on quotes
+    if (char === '"' && prevChar !== '\\') {
+      inDoubleQuoteString = !inDoubleQuoteString;
+    } else if (char === "'" && prevChar !== '\\' && !inDoubleQuoteString) {
+      inString = !inString;
+      result += '"';
+      continue;
+    }
+
+    result += char;
+  }
+
+  return result;
+}
+
+// Helper function to extract JSON from markdown code blocks with better error handling
+function extractJsonFromMarkdown(content: string): { result?: any; error?: ExtractionError } {
   // Remove any escaped newlines and normalize line endings
   const normalizedContent = content.replace(/\\n/g, '\n').replace(/\r\n/g, '\n');
 
   // Try different JSON extraction patterns
   const patterns = [
-    // Pattern 1: Standard markdown code block
-    /```(?:json)?\n([\s\S]*?)\n```/,
-    // Pattern 2: Single-line code block
+    // Pattern 1: Standard markdown code block with json tag
+    /```(?:json)\s*\n([\s\S]*?)\n```/,
+    // Pattern 2: Standard markdown code block without language tag
+    /```\s*\n([\s\S]*?)\n```/,
+    // Pattern 3: Single-line code block
     /`(.*?)`/,
-    // Pattern 3: Raw JSON
+    // Pattern 4: Raw JSON in common structures
+    /({[\s\S]*}|\[[\s\S]*\])/,
+    // Pattern 5: Raw JSON (fallback)
     /([\s\S]*)/,
   ];
 
+  const errors: ExtractionError[] = [];
+
+  // First pass - try with the original patterns
   for (const pattern of patterns) {
     const match = normalizedContent.match(pattern);
     if (match?.[1]) {
       try {
         const trimmed = match[1].trim();
-        return JSON.parse(trimmed);
-      } catch (_e) {}
+        const preprocessed = preprocessJsonString(trimmed);
+        return { result: parseJson(preprocessed) };
+      } catch (e) {
+        errors.push({
+          message: `Failed to parse JSON using pattern ${pattern}`,
+          pattern: pattern.toString(),
+          content: match[1].substring(0, 200) + (match[1].length > 200 ? '...' : ''),
+          cause: e instanceof Error ? e : new Error(String(e)),
+        });
+      }
     }
   }
 
-  // If all patterns fail, try to parse the entire content
+  // Second pass - try with jsonrepair
+  for (const pattern of patterns) {
+    const match = normalizedContent.match(pattern);
+    if (match?.[1]) {
+      try {
+        const trimmed = match[1].trim();
+        // First preprocess, then try to repair the JSON
+        const preprocessed = preprocessJsonString(trimmed);
+        const repaired = jsonrepair(preprocessed);
+        return {
+          result: parseJson(repaired),
+        };
+      } catch (e) {
+        errors.push({
+          message: `Failed to repair and parse JSON using pattern ${pattern}`,
+          pattern: pattern.toString(),
+          content: match[1].substring(0, 200) + (match[1].length > 200 ? '...' : ''),
+          cause: e instanceof Error ? e : new Error(String(e)),
+          attemptedRepair: true,
+        });
+      }
+    }
+  }
+
+  // Last resort - try to parse the entire content with repair
   try {
-    return JSON.parse(normalizedContent);
-  } catch (_error) {
-    throw new Error('Failed to parse JSON from response');
+    // Try to repair the entire content
+    const preprocessed = preprocessJsonString(normalizedContent);
+    const repaired = jsonrepair(preprocessed);
+    return { result: parseJson(repaired) };
+  } catch (e) {
+    // If all attempts fail, return a detailed error
+    const finalError: ExtractionError = {
+      message:
+        'Failed to parse JSON from response after trying all extraction patterns and repair attempts',
+      content: normalizedContent.substring(0, 200) + (normalizedContent.length > 200 ? '...' : ''),
+      cause: e instanceof Error ? e : new Error(String(e)),
+      attemptedRepair: true,
+    };
+
+    return { error: finalError };
   }
 }
 
-// Helper function to generate schema instructions from Zod schema
+// Helper function to generate schema instructions from Zod schema with improved documentation
 function generateSchemaInstructions(schema: z.ZodType): string {
+  // 使用 zodToJsonSchema 将 Zod schema 转换为 JSON Schema
+  const jsonSchema = zodToJsonSchema(schema, { target: 'openApi3' });
+
+  // 保留原有的字段描述逻辑，用于生成更友好的文档
   const shape = (schema as any)._def.shape;
   const schemaName = schema.description || 'structured_output';
 
-  // Generate field descriptions
+  // Generate field descriptions with better type information
   const fields = Object.entries(shape || {})
     .map(([key, value]) => {
       const fieldType = (value as any).typeName;
       const description = (value as any).description;
       const isOptional = !(value as any)._def.required;
+      const constraints = getFieldConstraints(value as z.ZodType);
 
-      return `- "${key}": ${fieldType}${isOptional ? ' (optional)' : ''} - ${description || ''}`;
+      return `- "${key}": ${fieldType}${isOptional ? ' (optional)' : ''}${
+        constraints ? ` ${constraints}` : ''
+      } - ${description || ''}`;
     })
     .join('\n');
+
+  // 添加 JSON Schema 的完整定义
+  const jsonSchemaStr = JSON.stringify(jsonSchema, null, 2);
 
   return `Please provide a JSON object for "${schemaName}" with the following structure:
 ${fields}
@@ -62,7 +195,43 @@ Important:
 1. Respond ONLY with a valid JSON object
 2. Wrap the JSON in \`\`\`json and \`\`\` tags
 3. Make sure all required fields are included
-4. Follow the exact types specified`;
+4. Follow the exact types specified
+5. Ensure JSON is properly formatted without syntax errors
+6. Use double quotes for property names and string values
+7. Avoid trailing commas in arrays and objects
+8. Use camelCase for property names (not snake_case)
+
+JSON Schema Definition:
+\`\`\`json
+${jsonSchemaStr}
+\`\`\`
+
+Your response MUST match this schema exactly.`;
+}
+
+// Helper function to extract field constraints for better schema documentation
+function getFieldConstraints(field: z.ZodType): string | undefined {
+  if (!field._def) return undefined;
+
+  const constraints: string[] = [];
+
+  if ('minLength' in field._def && field._def.minLength !== undefined) {
+    constraints.push(`min length: ${field._def.minLength}`);
+  }
+
+  if ('maxLength' in field._def && field._def.maxLength !== undefined) {
+    constraints.push(`max length: ${field._def.maxLength}`);
+  }
+
+  if ('minimum' in field._def && field._def.minimum !== undefined) {
+    constraints.push(`min: ${field._def.minimum}`);
+  }
+
+  if ('maximum' in field._def && field._def.maximum !== undefined) {
+    constraints.push(`max: ${field._def.maximum}`);
+  }
+
+  return constraints.length > 0 ? `(${constraints.join(', ')})` : undefined;
 }
 
 interface ExtendedAIMessage extends AIMessage {
@@ -74,21 +243,56 @@ export async function extractStructuredData<T extends z.ZodType>(
   schema: T,
   prompt: string,
   config: SkillRunnableConfig,
-  maxRetries,
+  maxRetries: number,
   modelInfo: ModelInfo,
 ): Promise<z.infer<T>> {
   let lastError = '';
+  const detailedErrors: string[] = [];
   let structuredOutputFailed = false;
 
   // Check if model supports structured output
   const useStructuredOutput = checkIsSupportedModel(modelInfo);
 
-  const tryParseContent = async (content: string): Promise<z.infer<T> | null> => {
+  const tryParseContent = async (
+    content: string,
+  ): Promise<{ data?: z.infer<T>; error?: string; rawContent?: string }> => {
     try {
-      const extractedJson = extractJsonFromMarkdown(content);
-      return await schema.parseAsync(extractedJson);
-    } catch (_error) {
-      return null;
+      const extraction = extractJsonFromMarkdown(content);
+
+      if (extraction.error) {
+        return {
+          error: `JSON extraction failed: ${extraction.error.message}`,
+          rawContent: extraction.error.content,
+        };
+      }
+
+      if (!extraction.result) {
+        return { error: 'No JSON data could be extracted from the response' };
+      }
+
+      // Perform schema validation with detailed error capture
+      try {
+        const validatedData = await schema.parseAsync(extraction.result);
+        return { data: validatedData };
+      } catch (validationError) {
+        if (validationError instanceof z.ZodError) {
+          const formattedErrors = validationError.errors
+            .map((err) => `- ${err.path.join('.')}: ${err.message}`)
+            .join('\n');
+          return {
+            error: `Schema validation failed: \n${formattedErrors}`,
+            rawContent: JSON.stringify(extraction.result, null, 2).substring(0, 300),
+          };
+        }
+        return {
+          error: `Schema validation error: ${validationError instanceof Error ? validationError.message : String(validationError)}`,
+          rawContent: JSON.stringify(extraction.result, null, 2).substring(0, 300),
+        };
+      }
+    } catch (e) {
+      return {
+        error: `Unexpected error during parsing: ${e instanceof Error ? e.message : String(e)}`,
+      };
     }
   };
 
@@ -144,16 +348,36 @@ export async function extractStructuredData<T extends z.ZodType>(
 
           // Try different result formats
           if (result?.raw?.content) {
-            const parsed = await tryParseContent(String(result.raw.content));
-            if (parsed) return parsed;
+            const parseResult = await tryParseContent(String(result.raw.content));
+            if (parseResult.data) return parseResult.data;
+            if (parseResult.error) {
+              const errorWithContent = parseResult.rawContent
+                ? `${parseResult.error}\n\nPartial content: ${parseResult.rawContent}`
+                : parseResult.error;
+              detailedErrors.push(errorWithContent);
+            }
           }
 
           const rawMessage = result?.raw as ExtendedAIMessage;
           if (rawMessage?.tool_calls?.[0]?.args) {
             try {
               return await schema.parseAsync(rawMessage.tool_calls[0].args);
-            } catch {
-              // Continue to next attempt if parsing fails
+            } catch (validationError) {
+              if (validationError instanceof z.ZodError) {
+                const formattedErrors = validationError.errors
+                  .map((err) => `- ${err.path.join('.')}: ${err.message}`)
+                  .join('\n');
+                const errorWithContent = `Tool call schema validation failed: \n${formattedErrors}\n\nPartial content: ${JSON.stringify(
+                  rawMessage.tool_calls[0].args,
+                  null,
+                  2,
+                ).substring(0, 300)}`;
+                detailedErrors.push(errorWithContent);
+              } else {
+                detailedErrors.push(
+                  `Tool call validation error: ${validationError instanceof Error ? validationError.message : String(validationError)}`,
+                );
+              }
             }
           }
 
@@ -165,16 +389,44 @@ export async function extractStructuredData<T extends z.ZodType>(
             structuredError instanceof Error
               ? structuredError.message
               : 'Unknown structured output error';
+          detailedErrors.push(lastError);
         }
       }
 
-      // Fallback approach
+      // Fallback approach with more explicit JSON formatting guidance
       const schemaInstructions = generateSchemaInstructions(schema);
-      const fullPrompt = `${prompt}\n\n${schemaInstructions}${
-        lastError
-          ? `\n\nPrevious attempt failed with error: ${lastError}\nPlease try again and ensure the response is valid JSON.`
-          : ''
-      }`;
+
+      // 添加更明确的 JSON 结构示例，基于 schema 生成
+      const jsonSchemaExample = generateSchemaExample(schema);
+
+      const jsonFormatExamples = `
+JSON formatting tips:
+- Always use double quotes for keys and string values: {"name": "value"}
+- Arrays use square brackets: ["item1", "item2"]
+- Objects use curly braces: {"key1": "value1", "key2": "value2"}
+- Boolean values are lowercase: true, false
+- Numbers don't need quotes: {"count": 42}
+- Nested objects example: {"user": {"name": "John", "age": 30}}
+- Nested arrays example: {"items": ["apple", "banana"]}
+
+Example response format:
+\`\`\`json
+${jsonSchemaExample}
+\`\`\`
+`;
+
+      const errorFeedback =
+        detailedErrors.length > 0
+          ? `\n\nPrevious attempts failed with these errors:
+${detailedErrors
+  .slice(-2)
+  .map((err, idx) => `Attempt ${i - detailedErrors.slice(-2).length + idx + 1}: ${err}`)
+  .join('\n\n')}
+
+Please fix these issues and ensure your response matches the schema exactly.`
+          : '';
+
+      const fullPrompt = `${prompt}\n\n${schemaInstructions}\n${jsonFormatExamples}${errorFeedback}`;
 
       const response = await Promise.resolve(
         model.invoke(fullPrompt, {
@@ -189,10 +441,18 @@ export async function extractStructuredData<T extends z.ZodType>(
       });
 
       const content = await processResponse(response);
-      const parsed = await tryParseContent(content);
+      const parseResult = await tryParseContent(content);
 
-      if (parsed) {
-        return parsed;
+      if (parseResult.data) {
+        return parseResult.data;
+      }
+
+      if (parseResult.error) {
+        const errorWithContent = parseResult.rawContent
+          ? `${parseResult.error}\n\nPartial content: ${parseResult.rawContent}`
+          : parseResult.error;
+        detailedErrors.push(errorWithContent);
+        throw new Error(parseResult.error);
       }
 
       throw new Error('Failed to parse response as valid JSON matching schema');
@@ -202,13 +462,74 @@ export async function extractStructuredData<T extends z.ZodType>(
 
       if (i === maxRetries - 1) {
         throw new Error(
-          `Failed to extract structured data after ${maxRetries} attempts. Last error: ${lastError}`,
+          `Failed to extract structured data after ${maxRetries} attempts. Last error: ${lastError}\n\nDetailed errors:\n${detailedErrors.slice(-3).join('\n\n')}`,
         );
       }
     }
   }
 
   throw new Error(
-    `Failed to extract structured data after ${maxRetries} attempts. Last error: ${lastError}`,
+    `Failed to extract structured data after ${maxRetries} attempts. Last error: ${lastError}\n\nDetailed errors:\n${detailedErrors.slice(-3).join('\n\n')}`,
   );
+}
+
+// 生成基于 schema 的示例 JSON
+function generateSchemaExample(schema: z.ZodType): string {
+  try {
+    const jsonSchema = zodToJsonSchema(schema, { target: 'openApi3' });
+
+    // 递归生成示例值
+    function generateExampleForSchema(schema: any): any {
+      if (!schema) return null;
+
+      // 处理不同类型的 schema
+      if (schema.type === 'object' && schema.properties) {
+        const result: Record<string, any> = {};
+        for (const [key, prop] of Object.entries<any>(schema.properties)) {
+          result[key] = generateExampleForSchema(prop);
+        }
+        return result;
+      }
+
+      if (schema.type === 'array' && schema.items) {
+        return [generateExampleForSchema(schema.items)];
+      }
+
+      if (schema.type === 'string') {
+        if (schema.enum && schema.enum.length > 0) {
+          return schema.enum[0];
+        }
+        return schema.example || schema.default || 'example string';
+      }
+
+      if (schema.type === 'number' || schema.type === 'integer') {
+        return schema.example || schema.default || 42;
+      }
+
+      if (schema.type === 'boolean') {
+        return schema.example || schema.default || true;
+      }
+
+      if (schema.type === 'null') {
+        return null;
+      }
+
+      // 处理复合类型
+      if (schema.oneOf || schema.anyOf) {
+        const options = schema.oneOf || schema.anyOf;
+        if (options && options.length > 0) {
+          return generateExampleForSchema(options[0]);
+        }
+      }
+
+      return null;
+    }
+
+    const example = generateExampleForSchema(jsonSchema);
+    return JSON.stringify(example, null, 2);
+  } catch (error) {
+    // 如果生成失败，返回一个基本示例
+    console.error('Failed to generate schema example:', error);
+    return '{\n  "example": "This is a placeholder. Please follow the schema definition above."\n}';
+  }
 }

--- a/packages/skill-template/src/scheduler/utils/query-rewrite/core.ts
+++ b/packages/skill-template/src/scheduler/utils/query-rewrite/core.ts
@@ -118,9 +118,6 @@ export async function analyzeQueryAndContext(
     tplConfig: SkillTemplateConfig;
   },
 ): Promise<QueryAnalysis> {
-  // set current step
-  ctx.config.metadata.step = { name: 'analyzeContext' };
-
   const { chatHistory, resources, documents, contentList, modelInfo } = ctx.config.configurable;
   const context: IContext = {
     resources,

--- a/packages/skill-template/src/skills/generate-doc.ts
+++ b/packages/skill-template/src/skills/generate-doc.ts
@@ -19,6 +19,7 @@ import { truncateMessages, truncateSource } from '../scheduler/utils/truncator';
 import { countToken } from '../scheduler/utils/token';
 import { buildFinalRequestMessages, SkillPromptModule } from '../scheduler/utils/message';
 import { processQuery } from '../scheduler/utils/queryProcessor';
+import { extractAndCrawlUrls } from '../scheduler/utils/extract-weblink';
 
 // prompts
 import * as generateDocument from '../scheduler/module/generateDocument';
@@ -61,6 +62,7 @@ export class GenerateDoc extends BaseSkill {
     config: SkillRunnableConfig,
     module: SkillPromptModule,
   ) => {
+    config.metadata.step = { name: 'analyzeQuery' };
     const { messages = [], images = [] } = state;
     const { locale = 'en', modelInfo } = config.configurable;
     const { tplConfig } = config?.configurable || {};
@@ -80,14 +82,26 @@ export class GenerateDoc extends BaseSkill {
       state,
     });
 
+    // Extract URLs from the query and crawl them with optimized concurrent processing
+    const { sources: urlSources, analysis } = await extractAndCrawlUrls(query, config, this, {
+      concurrencyLimit: 5, // Increase concurrent URL crawling limit
+      batchSize: 8, // Increase batch size for URL processing
+    });
+
+    this.engine.logger.log(`URL extraction analysis: ${safeStringifyJSON(analysis)}`);
+    this.engine.logger.log(`Extracted URL sources count: ${urlSources.length}`);
+
     let context = '';
     let sources: Source[] = [];
 
-    const needPrepareContext = hasContext && remainingTokens > 0;
+    // Consider URL sources for context preparation
+    const hasUrlSources = urlSources.length > 0;
+    const needPrepareContext = (hasContext || hasUrlSources) && remainingTokens > 0;
     const isModelContextLenSupport = checkModelContextLenSupport(modelInfo);
 
     this.engine.logger.log(`optimizedQuery: ${optimizedQuery}`);
     this.engine.logger.log(`mentionedContext: ${safeStringifyJSON(mentionedContext)}`);
+    this.engine.logger.log(`hasUrlSources: ${hasUrlSources}`);
 
     if (needPrepareContext) {
       config.metadata.step = { name: 'analyzeContext' };
@@ -98,6 +112,7 @@ export class GenerateDoc extends BaseSkill {
           maxTokens: remainingTokens,
           enableMentionedContext: hasContext,
           rewrittenQueries,
+          urlSources, // Pass URL sources to the prepareContext function
         },
         {
           config,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1321,6 +1321,12 @@ importers:
       is-url:
         specifier: ~1.2.4
         version: 1.2.4
+      json-parse-even-better-errors:
+        specifier: ^4.0.0
+        version: 4.0.0
+      jsonrepair:
+        specifier: ^3.12.0
+        version: 3.12.0
       langchain:
         specifier: 0.3.15
         version: 0.3.15(@langchain/core@0.3.29)(@langchain/deepseek@0.0.1)(axios@1.7.4)(openai@4.83.0)
@@ -1345,6 +1351,9 @@ importers:
       zod:
         specifier: 3.23.8
         version: 3.23.8
+      zod-to-json-schema:
+        specifier: ^3.24.3
+        version: 3.24.3(zod@3.23.8)
 
   packages/tsconfig: {}
 
@@ -4809,7 +4818,7 @@ packages:
       openai: 4.83.0(ws@8.17.1)(zod@3.23.8)
       uuid: 10.0.0
       zod: 3.23.8
-      zod-to-json-schema: 3.23.3(zod@3.23.8)
+      zod-to-json-schema: 3.24.3(zod@3.23.8)
     transitivePeerDependencies:
       - '@langchain/anthropic'
       - '@langchain/aws'
@@ -4843,7 +4852,7 @@ packages:
       p-retry: 4.6.2
       uuid: 10.0.0
       zod: 3.23.8
-      zod-to-json-schema: 3.23.3(zod@3.23.8)
+      zod-to-json-schema: 3.24.3(zod@3.23.8)
     transitivePeerDependencies:
       - openai
     dev: false
@@ -4904,7 +4913,7 @@ packages:
       js-tiktoken: 1.0.14
       openai: 4.83.0(ws@8.17.1)(zod@3.23.8)
       zod: 3.23.8
-      zod-to-json-schema: 3.23.3(zod@3.23.8)
+      zod-to-json-schema: 3.24.3(zod@3.23.8)
     transitivePeerDependencies:
       - encoding
       - ws
@@ -14961,6 +14970,11 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dev: false
 
+  /json-parse-even-better-errors@4.0.0:
+    resolution: {integrity: sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    dev: false
+
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
     requiresBuild: true
@@ -15003,6 +15017,11 @@ packages:
   /jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /jsonrepair@3.12.0:
+    resolution: {integrity: sha512-SWfjz8SuQ0wZjwsxtSJ3Zy8vvLg6aO/kxcp9TWNPGwJKgTZVfhNEQBMk/vPOpYCDFWRxD6QWuI6IHR1t615f0w==}
+    hasBin: true
     dev: false
 
   /jsonwebtoken@9.0.2:
@@ -15170,7 +15189,7 @@ packages:
       uuid: 10.0.0
       yaml: 2.5.1
       zod: 3.23.8
-      zod-to-json-schema: 3.23.3(zod@3.23.8)
+      zod-to-json-schema: 3.24.3(zod@3.23.8)
     transitivePeerDependencies:
       - encoding
       - openai
@@ -15246,7 +15265,7 @@ packages:
       uuid: 10.0.0
       yaml: 2.5.1
       zod: 3.23.8
-      zod-to-json-schema: 3.23.3(zod@3.23.8)
+      zod-to-json-schema: 3.24.3(zod@3.23.8)
     transitivePeerDependencies:
       - encoding
       - openai
@@ -22437,6 +22456,14 @@ packages:
     resolution: {integrity: sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==}
     peerDependencies:
       zod: ^3.23.3
+    dependencies:
+      zod: 3.23.8
+    dev: false
+
+  /zod-to-json-schema@3.24.3(zod@3.23.8):
+    resolution: {integrity: sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A==}
+    peerDependencies:
+      zod: ^3.24.1
     dependencies:
       zod: 3.23.8
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1324,6 +1324,9 @@ importers:
       langchain:
         specifier: 0.3.15
         version: 0.3.15(@langchain/core@0.3.29)(@langchain/deepseek@0.0.1)(axios@1.7.4)(openai@4.83.0)
+      linkify-it:
+        specifier: ^5.0.0
+        version: 5.0.0
       lodash:
         specifier: ~4.17.21
         version: 4.17.21
@@ -1333,6 +1336,9 @@ importers:
       p-limit:
         specifier: 3.1.0
         version: 3.1.0
+      tlds:
+        specifier: ^1.255.0
+        version: 1.255.0
       tsx:
         specifier: ^4.6.2
         version: 4.19.1
@@ -20732,6 +20738,11 @@ packages:
   /titleize@3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
     engines: {node: '>=12'}
+    dev: false
+
+  /tlds@1.255.0:
+    resolution: {integrity: sha512-tcwMRIioTcF/FcxLev8MJWxCp+GUALRhFEqbDoZrnowmKSGqPrl5pqS+Sut2m8BgJ6S4FExCSSpGffZ0Tks6Aw==}
+    hasBin: true
     dev: false
 
   /tldts-core@6.1.75:


### PR DESCRIPTION
…text enrichment

- Implement URL detection and extraction using regex and AI-powered methods
- Add new `crawlUrl` method to skill service for fetching web page content
- Enhance context preparation to include URL sources with high relevance
- Update type definitions to support 'urlSource' as a new source type
- Introduce concurrent URL crawling with configurable batch processing
- Modify context summarization and flattening to prioritize URL sources

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
