### PR TITLE
feat(canvas): support persisting and duplicating tplConfig for skill nodes

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/launchpad/config-manager/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/config-manager/index.tsx
@@ -95,8 +95,6 @@ const ConfigItem = React.memo(
       props.onValueChange(field, val, displayValue);
     };
 
-    console.log('item', item, configValue);
-
     if (item.inputMode === 'input') {
       return (
         <Input
@@ -222,13 +220,23 @@ interface ConfigManagerProps {
   formErrors: Record<string, string>;
   resetConfig?: () => void;
   setFormErrors: (errors: any) => void;
+  onFormValuesChange?: (changedValues: any, allValues: any) => void;
 }
 
 export const ConfigManager = (props: ConfigManagerProps) => {
   const { i18n, t } = useTranslation();
   const locale = i18n.languages?.[0] || 'en';
 
-  const { schema, fieldPrefix, form, tplConfig, configScope, formErrors, setFormErrors } = props;
+  const {
+    schema,
+    fieldPrefix,
+    form,
+    tplConfig,
+    configScope,
+    formErrors,
+    setFormErrors,
+    onFormValuesChange,
+  } = props;
   const [resetCounter, setResetCounter] = useState<number>(0);
   const [formValues, setFormValues] = useState<Record<string, DynamicConfigValue>>({});
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
@@ -387,6 +395,7 @@ export const ConfigManager = (props: ConfigManagerProps) => {
             for (const field of Object.keys(changedValues)) {
               validateField(field, changedValues[field]);
             }
+            onFormValuesChange?.(changedValues, _allValues);
           }}
         >
           <Space direction="vertical" style={{ width: '100%' }}>

--- a/packages/ai-workspace-common/src/components/canvas/nodes/shared/types.ts
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/shared/types.ts
@@ -72,6 +72,7 @@ export type ResponseNodeMeta = {
   currentLog?: ActionLog;
   structuredData?: Record<string, unknown>;
   contextItems?: IContextItem[];
+  tplConfig?: SkillTemplateConfig;
   sizeMode?: 'compact' | 'adaptive';
   style?: React.CSSProperties;
   originalWidth?: number;

--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
@@ -424,7 +424,7 @@ export const SkillResponseNode = memo(
         return;
       }
 
-      const { context, history, title, modelInfo, actionMeta } = resultData.data;
+      const { context, history, title, modelInfo, actionMeta, tplConfig } = resultData.data;
       const contextItems = context ? convertResultContextToItems(context, history) : [];
 
       // Create new skill node with context, similar to group node implementation
@@ -445,6 +445,7 @@ export const SkillResponseNode = memo(
               query: title,
               modelInfo,
               selectedSkill: actionMeta,
+              tplConfig,
             },
           },
         },


### PR DESCRIPTION
# Summary

- Extend skill and response nodes to support template configuration
- Add `tplConfig` to node metadata and types
- Implement config change handling in skill node
- Enhance config manager with optional form values change callback

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
