### PR TITLE
fix: alert issues

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -60,3 +60,4 @@ jobs:
           push: true
           tags: |
             reflyai/refly-${{ matrix.app }}:${{ github.sha }}
+            reflyai/refly-${{ matrix.app }}:nightly

--- a/packages/ai-workspace-common/src/components/editor/core/extensions/updated-image.ts
+++ b/packages/ai-workspace-common/src/components/editor/core/extensions/updated-image.ts
@@ -7,9 +7,12 @@ const UpdatedImage = Image.extend({
       ...this.parent?.(),
       src: {
         default: '',
-        parseHTML: (element) => element.getAttribute('src') || '',
+        parseHTML: (element) => {
+          const src = element?.getAttribute('src');
+          return src ?? '';
+        },
         renderHTML: (attributes) => ({
-          src: attributes.src || '',
+          src: attributes?.src ?? '',
         }),
       },
       width: {

--- a/packages/ai-workspace-common/src/hooks/use-document-sync.ts
+++ b/packages/ai-workspace-common/src/hooks/use-document-sync.ts
@@ -2,21 +2,33 @@ import { useMemo } from 'react';
 import { useDocumentContext } from '@refly-packages/ai-workspace-common/context/document';
 
 export const useDocumentSync = () => {
-  const { ydoc } = useDocumentContext();
+  const { ydoc, provider } = useDocumentContext();
 
   const syncFunctions = useMemo(() => {
     const syncTitleToYDoc = (title: string) => {
-      ydoc?.transact(() => {
-        const yTitle = ydoc?.getText('title');
-        yTitle?.delete(0, yTitle?.length ?? 0);
-        yTitle?.insert(0, title);
-      });
+      if (!ydoc || provider?.status !== 'connected') return;
+
+      try {
+        ydoc.transact(() => {
+          const yTitle = ydoc.getText('title');
+          if (!yTitle) return;
+
+          yTitle.delete(0, yTitle.length ?? 0);
+          yTitle.insert(0, title);
+        });
+      } catch (error) {
+        console.error('Transaction error when syncing title:', error);
+
+        if (error instanceof DOMException && error.name === 'InvalidStateError') {
+          console.warn('Database connection is closing. Transaction aborted.');
+        }
+      }
     };
 
     return {
       syncTitleToYDoc,
     };
-  }, [ydoc]);
+  }, [ydoc, provider]);
 
   return syncFunctions;
 };


### PR DESCRIPTION
# Summary

- Fix ydoc retrieval issues when canvas stateStorageKey is not present
- Fix markdown serialization error when image src is null
- Improve ydoc transaction handling when provider is not connected

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
