### PR TITLE
feat(model): add isDefault flag to model selection and metadata

### DIFF
--- a/apps/api/src/misc/misc.dto.ts
+++ b/apps/api/src/misc/misc.dto.ts
@@ -14,7 +14,7 @@ export interface FileObject {
 
 export function modelInfoPO2DTO(modelInfo: ModelInfoPO): ModelInfo {
   return {
-    ...pick(modelInfo, ['name', 'label', 'provider', 'contextLimit', 'maxOutput']),
+    ...pick(modelInfo, ['name', 'label', 'provider', 'contextLimit', 'maxOutput', 'isDefault']),
     tier: modelInfo.tier as ModelTier,
     capabilities: JSON.parse(modelInfo.capabilities),
   };

--- a/cypress/e2e/canvas.cy.ts
+++ b/cypress/e2e/canvas.cy.ts
@@ -41,10 +41,10 @@ describe('Canvas Flow', () => {
     // Wait for the response node to be visible first
     cy.get('[data-cy="skill-response-node"]').should('be.visible');
 
-    // Then wait for the input to be visible and have the correct value
-    cy.get('[data-cy="skill-response-node-header-input"]')
+    // Then wait for the header to be visible and contain the correct text
+    cy.get('[data-cy="skill-response-node-header"]')
       .should('be.visible')
-      .should('have.value', 'Say this is a test');
+      .should('contain.text', 'Say this is a test');
 
     // Verify the response is displayed in the chat
     cy.get('[data-cy="skill-response-node"]').should('be.visible').contains('This is a test');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -90,4 +90,48 @@ beforeEach(() => {
       subscribers_count: 100,
     },
   }).as('githubApi');
+
+  cy.intercept('GET', 'https://react-tweet.vercel.app/api/tweet/**', {
+    statusCode: 200,
+    body: {
+      data: {
+        __typename: 'Tweet',
+        lang: 'en',
+        favorite_count: 2,
+        // created_at: '2025-01-14T15:55:04.000Z',
+        display_text_range: [0, 125],
+        entities: {
+          hashtags: [],
+          urls: [],
+          user_mentions: [],
+          symbols: [],
+        },
+        id_str: '1879195537259294991',
+        text: '',
+        user: {
+          id_str: '22260506',
+          name: '',
+          profile_image_url_https:
+            'https://pbs.twimg.com/profile_images/1246941661311238144/K6r3twlf_normal.jpg',
+          screen_name: 'ediyiqian',
+          verified: false,
+          is_blue_verified: true,
+          profile_image_shape: 'Circle',
+        },
+        edit_control: {
+          edit_tweet_ids: [],
+          editable_until_msecs: '1736873704000',
+          is_edit_eligible: true,
+          edits_remaining: '5',
+        },
+        conversation_count: 1,
+        news_action_type: 'conversation',
+        isEdited: false,
+        isStaleEdit: false,
+        note_tweet: {
+          id: '',
+        },
+      },
+    },
+  }).as('tweetApi');
 });

--- a/packages/ai-workspace-common/src/requests/types.gen.ts
+++ b/packages/ai-workspace-common/src/requests/types.gen.ts
@@ -3075,6 +3075,10 @@ export type ModelInfo = {
    * Model capabilities
    */
   capabilities?: ModelCapabilities;
+  /**
+   * Whether this model is the default model
+   */
+  isDefault?: boolean;
 };
 
 export type ListModelsResponse = BaseResponse & {

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -4867,6 +4867,9 @@ components:
         capabilities:
           description: Model capabilities
           $ref: '#/components/schemas/ModelCapabilities'
+        isDefault:
+          type: boolean
+          description: Whether this model is the default model
     ListModelsResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -4381,6 +4381,10 @@ export const ModelInfoSchema = {
       description: 'Model capabilities',
       $ref: '#/components/schemas/ModelCapabilities',
     },
+    isDefault: {
+      type: 'boolean',
+      description: 'Whether this model is the default model',
+    },
   },
 } as const;
 

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -3075,6 +3075,10 @@ export type ModelInfo = {
    * Model capabilities
    */
   capabilities?: ModelCapabilities;
+  /**
+   * Whether this model is the default model
+   */
+  isDefault?: boolean;
 };
 
 export type ListModelsResponse = BaseResponse & {


### PR DESCRIPTION
- Extend ModelInfo type with optional isDefault property
- Implement model selection logic to prioritize default models
- Update OpenAPI schema and type generation to include isDefault flag
- Add helper function to select available models based on usage and default status

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
