### PR TITLE
fix(api & canvas): missing image display when exporting canvas as image

### DIFF
--- a/apps/api/src/knowledge/knowledge.service.ts
+++ b/apps/api/src/knowledge/knowledge.service.ts
@@ -125,9 +125,7 @@ export class KnowledgeService {
     return resources.map((resource) => ({
       ...resource,
       downloadURL: resource.rawFileKey
-        ? this.miscService.generateFileURL({
-            storageKey: resource.rawFileKey,
-          })
+        ? this.miscService.generateFileURL({ storageKey: resource.rawFileKey }, { download: true })
         : undefined,
     }));
   }

--- a/apps/api/src/misc/misc.controller.ts
+++ b/apps/api/src/misc/misc.controller.ts
@@ -6,10 +6,10 @@ import {
   Get,
   Param,
   StreamableFile,
-  Header,
   Res,
   UseInterceptors,
   UploadedFile,
+  Req,
 } from '@nestjs/common';
 import path from 'node:path';
 import { JwtAuthGuard } from '@/auth/guard/jwt-auth.guard';
@@ -23,10 +23,9 @@ import {
 } from '@refly-packages/openapi-schema';
 import { buildSuccessResponse } from '@/utils';
 import { LoginedUser } from '@/utils/decorators/user.decorator';
-import { Response } from 'express';
+import { Response, Request } from 'express';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ParamsError } from '@refly-packages/errors';
-import { OptionalJwtAuthGuard } from '@/auth/guard/optional-jwt-auth.guard';
 
 @Controller('v1/misc')
 export class MiscController {
@@ -82,21 +81,25 @@ export class MiscController {
     return buildSuccessResponse({ content: result });
   }
 
-  @UseGuards(OptionalJwtAuthGuard)
+  @UseGuards(JwtAuthGuard)
   @Get('static/:objectKey')
-  @Header('Access-Control-Allow-Origin', '*')
-  @Header('Cross-Origin-Resource-Policy', 'cross-origin')
   async serveStatic(
-    @LoginedUser() user: User | null,
+    @LoginedUser() user: User,
     @Param('objectKey') objectKey: string,
     @Res({ passthrough: true }) res: Response,
+    @Req() req: Request,
   ): Promise<StreamableFile> {
     const fileStream = await this.miscService.getInternalFileStream(user, `static/${objectKey}`);
     const filename = path.basename(objectKey);
 
+    const origin = req.headers.origin;
+
     res.set({
       'Content-Type': 'application/octet-stream',
       'Content-Disposition': `inline; filename="${filename}"`,
+      'Access-Control-Allow-Origin': origin || '*',
+      'Access-Control-Allow-Credentials': 'true',
+      'Cross-Origin-Resource-Policy': 'cross-origin',
     });
 
     return fileStream;

--- a/apps/api/src/misc/misc.service.ts
+++ b/apps/api/src/misc/misc.service.ts
@@ -419,7 +419,7 @@ export class MiscService implements OnModuleInit {
     }
   }
 
-  async getInternalFileStream(user: User | null, storageKey: string): Promise<StreamableFile> {
+  async getInternalFileStream(user: User, storageKey: string): Promise<StreamableFile> {
     const file = await this.prisma.staticFile.findFirst({
       select: { uid: true, visibility: true, entityId: true, entityType: true },
       where: { storageKey, deletedAt: null },
@@ -428,7 +428,7 @@ export class MiscService implements OnModuleInit {
       throw new NotFoundException();
     }
 
-    if (!user || user.uid !== file.uid) {
+    if (user.uid !== file.uid) {
       if (file.entityType === 'canvas') {
         const canvas = await this.prisma.canvas.findFirst({
           where: { canvasId: file.entityId, isPublic: true, deletedAt: null },

--- a/packages/ai-workspace-common/src/hooks/use-download-file.ts
+++ b/packages/ai-workspace-common/src/hooks/use-download-file.ts
@@ -10,7 +10,7 @@ export const useDownloadFile = () => {
     }
 
     if (resource.rawFileKey) {
-      const fileUrl = `${serverOrigin}/v1/misc/${resource.rawFileKey}`;
+      const fileUrl = `${serverOrigin}/v1/misc/${resource.rawFileKey}?download=1`;
       window.open(fileUrl, '_blank');
     }
   }, []);


### PR DESCRIPTION
# Summary

- Update static file endpoint to use JwtAuthGuard and handle CORS dynamically
- Modify file stream service to require authenticated user
- Improve canvas image export by converting images to base64 for better compatibility
- Add robust error handling for image conversion in export process

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| <img width="599" alt="image" src="https://github.com/user-attachments/assets/1873b461-5249-4684-97c9-5d05c5acf116" /> | <img width="515" alt="image" src="https://github.com/user-attachments/assets/263cdb50-fa34-431a-adf1-aa61deeb49a4" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
