### PR TITLE
fix: purge nested duplicate context for node data

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
@@ -11,7 +11,10 @@ import {
 
 import { actionEmitter } from '@refly-packages/ai-workspace-common/events/action';
 import { ActionStepCard } from './action-step';
-import { convertResultContextToItems } from '@refly-packages/ai-workspace-common/utils/map-context-items';
+import {
+  convertResultContextToItems,
+  purgeContextItems,
+} from '@refly-packages/ai-workspace-common/utils/map-context-items';
 
 import { PreviewChatInput } from './preview-chat-input';
 import { SourceListModal } from '@refly-packages/ai-workspace-common/components/source-list/source-list-modal';
@@ -167,7 +170,7 @@ const SkillResponseNodePreviewComponent = ({ node, resultId }: SkillResponseNode
   const contextItems = useMemo(() => {
     // Prefer contextItems from node metadata
     if (data.metadata?.contextItems) {
-      return data.metadata?.contextItems;
+      return purgeContextItems(data.metadata?.contextItems);
     }
 
     // Fallback to contextItems from context (could be legacy nodes)

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill.tsx
@@ -4,7 +4,7 @@ import { useDebouncedCallback } from 'use-debounce';
 import { useTranslation } from 'react-i18next';
 import { IconClose } from '@arco-design/web-react/icon';
 import { Button } from 'antd';
-import { ModelInfo, Skill, SkillTemplateConfig } from '@refly/openapi-schema';
+import { ModelInfo, Skill, SkillRuntimeConfig, SkillTemplateConfig } from '@refly/openapi-schema';
 import { CanvasNode, CanvasNodeData, SkillNodeMeta } from '../nodes/shared/types';
 import { ChatInput } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/chat-input';
 import { getSkillIcon } from '@refly-packages/ai-workspace-common/components/common/icon';
@@ -89,7 +89,7 @@ export const SkillNodePreview = memo(({ node }: SkillNodePreviewProps) => {
   });
 
   const { entityId, metadata = {} } = latestNode?.data ?? {};
-  const { query, selectedSkill, modelInfo, contextItems = [], tplConfig } = metadata;
+  const { query, selectedSkill, modelInfo, contextItems = [], tplConfig, runtimeConfig } = metadata;
   const skill = useFindSkill(selectedSkill?.name);
 
   const [localQuery, setLocalQuery] = useState(query);
@@ -137,6 +137,13 @@ export const SkillNodePreview = memo(({ node }: SkillNodePreviewProps) => {
   const setContextItems = useCallback(
     (items: IContextItem[]) => {
       setNodeDataByEntity({ entityId, type: 'skill' }, { metadata: { contextItems: items } });
+    },
+    [entityId, setNodeDataByEntity],
+  );
+
+  const setRuntimeConfig = useCallback(
+    (runtimeConfig: SkillRuntimeConfig) => {
+      setNodeDataByEntity({ entityId, type: 'skill' }, { metadata: { runtimeConfig } });
     },
     [entityId, setNodeDataByEntity],
   );
@@ -303,6 +310,8 @@ export const SkillNodePreview = memo(({ node }: SkillNodePreviewProps) => {
         handleAbort={abortAction}
         onUploadImage={handleImageUpload}
         contextItems={contextItems}
+        runtimeConfig={runtimeConfig}
+        setRuntimeConfig={setRuntimeConfig}
       />
     </div>
   );

--- a/packages/ai-workspace-common/src/hooks/canvas/use-add-node.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-add-node.ts
@@ -18,6 +18,7 @@ import { CanvasNodeFilter } from './use-node-selection';
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 import { locateToNodePreviewEmitter } from '@refly-packages/ai-workspace-common/events/locateToNodePreview';
 import { useNodePosition } from './use-node-position';
+import { purgeContextItems } from '@refly-packages/ai-workspace-common/utils/map-context-items';
 
 const deduplicateNodes = (nodes: any[]) => {
   const uniqueNodesMap = new Map();
@@ -114,6 +115,11 @@ export const useAddNode = () => {
         setSelectedNode(existingNode);
         setNodeCenter(existingNode.id);
         return;
+      }
+
+      // Purge context items if they exist
+      if (node.data.metadata?.contextItems) {
+        node.data.metadata.contextItems = purgeContextItems(node.data.metadata.contextItems);
       }
 
       // Find source nodes

--- a/packages/ai-workspace-common/src/hooks/canvas/use-canvas-sync.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-canvas-sync.ts
@@ -5,6 +5,7 @@ import { Edge } from '@xyflow/react';
 import { CanvasNode } from '../../components/canvas/nodes';
 import { UndoManager } from 'yjs';
 import { omit } from '@refly/utils';
+import { purgeContextItems } from '@refly-packages/ai-workspace-common/utils/map-context-items';
 
 export const useCanvasSync = () => {
   const { provider } = useCanvasContext();
@@ -56,12 +57,24 @@ export const useCanvasSync = () => {
     const syncNodesToYDoc = (nodes: CanvasNode<any>[]) => {
       if (!nodes?.length) return;
 
+      // Purge context items from nodes
+      const purgedNodes = nodes.map((node) => ({
+        ...node,
+        data: {
+          ...node.data,
+          metadata: {
+            ...node.data?.metadata,
+            contextItems: purgeContextItems(node.data?.metadata?.contextItems),
+          },
+        },
+      }));
+
       safeTransaction(() => {
         const yNodes = ydoc?.getArray('nodes');
         if (!yNodes) return;
 
         yNodes.delete(0, yNodes.length ?? 0);
-        yNodes.push(nodes);
+        yNodes.push(purgedNodes);
       });
     };
 

--- a/packages/ai-workspace-common/src/hooks/canvas/use-set-node-data-by-entity.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-set-node-data-by-entity.ts
@@ -5,6 +5,8 @@ import { useCanvasStore, useCanvasStoreShallow } from '../../stores/canvas';
 import { CanvasNodeData } from '../../components/canvas/nodes';
 import { CanvasNodeType } from '@refly/openapi-schema';
 import { useCanvasSync } from './use-canvas-sync';
+import { purgeContextItems } from '@refly-packages/ai-workspace-common/utils/map-context-items';
+import { IContextItem } from '@refly-packages/ai-workspace-common/stores/context-panel';
 
 export interface CanvasNodeFilter {
   type: CanvasNodeType;
@@ -21,11 +23,14 @@ export const useSetNodeDataByEntity = () => {
   const { syncNodesToYDoc } = useCanvasSync();
 
   return useCallback(
-    <T = any>(
-      filter: CanvasNodeFilter,
-      nodeData: Partial<CanvasNodeData<T>>,
-      selectedCanvasId?: string,
-    ) => {
+    (filter: CanvasNodeFilter, nodeData: Partial<CanvasNodeData>, selectedCanvasId?: string) => {
+      // Purge context items if they exist
+      if (Array.isArray(nodeData.metadata?.contextItems)) {
+        nodeData.metadata.contextItems = purgeContextItems(
+          nodeData.metadata.contextItems as IContextItem[],
+        );
+      }
+
       const { data } = useCanvasStore.getState();
       const canvasId = selectedCanvasId ?? contextCanvasId ?? routeCanvasId;
       const currentNodes = data[canvasId]?.nodes ?? [];

--- a/packages/ai-workspace-common/src/stores/context-panel.ts
+++ b/packages/ai-workspace-common/src/stores/context-panel.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { useShallow } from 'zustand/react/shallow';
 import { CanvasNodeType, SelectionKey, SkillRuntimeConfig } from '@refly/openapi-schema';
+import { purgeContextItems } from '@refly-packages/ai-workspace-common/utils/map-context-items';
 
 export interface FilterErrorInfo {
   [key: string]: {
@@ -51,7 +52,6 @@ interface ContextPanelState {
   setContextItems: (items: IContextItem[]) => void;
   removeContextItem: (entityId: string) => void;
   clearContextItems: () => void;
-  updateContextItem: (item: IContextItem) => void;
 }
 
 export const defaultSelectedTextCardState = {
@@ -97,30 +97,24 @@ export const useContextPanelStore = create<ContextPanelState>()(
           updatedItems[existingIndex] = item;
           return {
             ...state,
-            contextItems: updatedItems,
+            contextItems: purgeContextItems(updatedItems),
           };
         }
 
         // Add new item to end
         return {
           ...state,
-          contextItems: [...state.contextItems, item],
+          contextItems: purgeContextItems([...state.contextItems, item]),
         };
       }),
-    setContextItems: (items: IContextItem[]) => set((state) => ({ ...state, contextItems: items })),
+    setContextItems: (items: IContextItem[]) =>
+      set((state) => ({ ...state, contextItems: purgeContextItems(items) })),
     removeContextItem: (entityId: string) =>
       set((state) => ({
         ...state,
         contextItems: state.contextItems.filter((item) => item.entityId !== entityId),
       })),
     clearContextItems: () => set((state) => ({ ...state, contextItems: [] })),
-    updateContextItem: (updatedItem: IContextItem) =>
-      set((state) => ({
-        ...state,
-        contextItems: state.contextItems.map((item) =>
-          item.entityId === updatedItem.entityId ? { ...item, ...updatedItem } : item,
-        ),
-      })),
 
     resetState: () => set((state) => ({ ...state, ...defaultState })),
   })),

--- a/packages/ai-workspace-common/src/utils/map-context-items.ts
+++ b/packages/ai-workspace-common/src/utils/map-context-items.ts
@@ -3,6 +3,7 @@ import { Node, Edge } from '@xyflow/react';
 import { IContextItem } from '@refly-packages/ai-workspace-common/stores/context-panel';
 import { getClientOrigin } from '@refly-packages/utils/url';
 import { CanvasNodeFilter } from '@refly-packages/ai-workspace-common/hooks/canvas/use-node-selection';
+import { omit } from '@refly/utils';
 
 export const convertResultContextToItems = (
   context: SkillContext,
@@ -66,7 +67,7 @@ export const convertResultContextToItems = (
     });
   }
 
-  return items;
+  return purgeContextItems(items);
 };
 
 export const convertContextItemsToNodeFilters = (items: IContextItem[]): CanvasNodeFilter[] => {
@@ -94,9 +95,10 @@ export const convertContextItemsToInvokeParams = (
     item: IContextItem,
   ) => { storageKey: string; title: string; entityId: string; metadata: any }[],
 ): { context: SkillContext; resultHistory: ActionResult[]; images: string[] } => {
+  const purgedItems = purgeContextItems(items);
   const context = {
     contentList: [
-      ...(items
+      ...(purgedItems
         ?.filter((item) => item.selection)
         ?.map((item) => ({
           content: item.selection?.content ?? '',
@@ -109,7 +111,7 @@ export const convertContextItemsToInvokeParams = (
             }),
           },
         })) ?? []),
-      ...(items
+      ...(purgedItems
         ?.filter((item) => item.type === 'memo' && getMemo)
         ?.flatMap((item) =>
           getMemo(item).map((memo) => ({
@@ -121,7 +123,7 @@ export const convertContextItemsToInvokeParams = (
             },
           })),
         ) ?? []),
-      ...(items
+      ...(purgedItems
         ?.filter((item) => item.type === 'codeArtifact' && getCodeArtifact)
         ?.flatMap((item) =>
           getCodeArtifact(item).map((code) => ({
@@ -134,7 +136,7 @@ export const convertContextItemsToInvokeParams = (
           })),
         ) ?? []),
     ],
-    resources: items
+    resources: purgedItems
       ?.filter((item) => item?.type === 'resource')
       .map((item) => ({
         resourceId: item.entityId,
@@ -148,7 +150,7 @@ export const convertContextItemsToInvokeParams = (
           ...item.metadata,
         },
       })),
-    documents: items
+    documents: purgedItems
       ?.filter((item) => item?.type === 'document')
       .map((item) => ({
         docId: item.entityId,
@@ -162,7 +164,7 @@ export const convertContextItemsToInvokeParams = (
           url: getClientOrigin(),
         },
       })),
-    urls: items
+    urls: purgedItems
       ?.filter((item) => item?.type === 'website')
       .map((item) => ({
         url: item.metadata?.url || '',
@@ -172,14 +174,14 @@ export const convertContextItemsToInvokeParams = (
         },
       })),
   };
-  const resultHistory = items
+  const resultHistory = purgedItems
     ?.filter((item) => item.type === 'skillResponse')
     .flatMap((item) => {
       return item.metadata?.withHistory
         ? getHistory(item)
         : [{ title: item.title, resultId: item.entityId }];
     });
-  const images = items
+  const images = purgedItems
     ?.filter((item) => item.type === 'image')
     .flatMap((item) => {
       if (getImages) {
@@ -255,4 +257,18 @@ export const convertContextItemsToEdges = (
     edgesToAdd,
     edgesToDelete,
   };
+};
+
+/**
+ * Purge the metadata from the context items
+ * @param items
+ * @returns purged context items
+ */
+export const purgeContextItems = (items: IContextItem[]): IContextItem[] => {
+  return items.map((item) => ({
+    ...omit(item, ['metadata']),
+    metadata: {
+      withHistory: item.metadata?.withHistory,
+    },
+  }));
 };

--- a/packages/ai-workspace-common/src/utils/map-context-items.ts
+++ b/packages/ai-workspace-common/src/utils/map-context-items.ts
@@ -265,6 +265,9 @@ export const convertContextItemsToEdges = (
  * @returns purged context items
  */
 export const purgeContextItems = (items: IContextItem[]): IContextItem[] => {
+  if (!Array.isArray(items)) {
+    return [];
+  }
   return items.map((item) => ({
     ...omit(item, ['metadata']),
     metadata: {


### PR DESCRIPTION
# Summary

- Purge nested duplicate context when adding new nodes
- Automatically remove recursive `contextItems` data for existing canvases
- Add missing `runtimeConfig` for skill node preview

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
