### PR TITLE
fix(api): properly handle edges cases for sharing and duplication

### DIFF
--- a/apps/api/src/common/elasticsearch.service.ts
+++ b/apps/api/src/common/elasticsearch.service.ts
@@ -225,10 +225,13 @@ export class ElasticsearchService implements OnModuleInit {
 
   async duplicateResource(resourceId: string, newId: string, user: User): Promise<void> {
     try {
-      const { body } = await this.client.get<{ _source: ResourceDocument }>({
-        index: indexConfig.resource.index,
-        id: resourceId,
-      });
+      const { body } = await this.client.get<{ _source: ResourceDocument }>(
+        {
+          index: indexConfig.resource.index,
+          id: resourceId,
+        },
+        { ignore: [404] },
+      );
 
       if (!body?._source) {
         this.logger.warn(`Resource ${resourceId} not found`);
@@ -253,10 +256,13 @@ export class ElasticsearchService implements OnModuleInit {
 
   async duplicateDocument(documentId: string, newId: string, user: User): Promise<void> {
     try {
-      const { body } = await this.client.get<{ _source: DocumentDocument }>({
-        index: indexConfig.document.index,
-        id: documentId,
-      });
+      const { body } = await this.client.get<{ _source: DocumentDocument }>(
+        {
+          index: indexConfig.document.index,
+          id: documentId,
+        },
+        { ignore: [404] },
+      );
 
       if (!body?._source) {
         this.logger.warn(`Document ${documentId} not found`);

--- a/apps/api/src/misc/misc.service.ts
+++ b/apps/api/src/misc/misc.service.ts
@@ -223,6 +223,9 @@ export class MiscService implements OnModuleInit {
    * @param storageKey - The storage key of the file to publish
    */
   async publishFile(storageKey: string) {
+    if (!storageKey) {
+      return '';
+    }
     const stream = await this.minioClient('private').getObject(storageKey);
     await this.minioClient('public').putObject(storageKey, stream);
     return this.generateFileURL({ visibility: 'public', storageKey });

--- a/apps/api/src/share/share.service.ts
+++ b/apps/api/src/share/share.service.ts
@@ -140,8 +140,10 @@ export class ShareService {
     }
 
     // Publish minimap
-    const minimapUrl = await this.miscService.publishFile(canvas.minimapStorageKey);
-    canvasData.minimapUrl = minimapUrl;
+    if (canvas.minimapStorageKey) {
+      const minimapUrl = await this.miscService.publishFile(canvas.minimapStorageKey);
+      canvasData.minimapUrl = minimapUrl;
+    }
 
     // Upload public canvas data to Minio
     const { storageKey } = await this.miscService.uploadBuffer(user, {
@@ -310,6 +312,7 @@ export class ShareService {
         if (!originalUrl.startsWith(privateStaticEndpoint)) return null;
 
         const storageKey = originalUrl.replace(`${privateStaticEndpoint}/`, '');
+        if (!storageKey) return null;
 
         try {
           // Publish the file to public bucket


### PR DESCRIPTION
# Summary

- Add 404 ignore option for Elasticsearch resource and document retrieval
- Add null check for storage key in file publishing methods
- Prevent potential errors when processing missing or empty storage keys

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
