### PR TITLE
feat(account-settings): add loading state for avatar upload

### DIFF
--- a/packages/ai-workspace-common/src/components/settings/account-setting/index.tsx
+++ b/packages/ai-workspace-common/src/components/settings/account-setting/index.tsx
@@ -9,12 +9,13 @@ import { useTranslation } from 'react-i18next';
 import { useDebouncedCallback } from 'use-debounce';
 import ImgCrop from 'antd-img-crop';
 import { useSiderStoreShallow } from '@refly-packages/ai-workspace-common/stores/sider';
+import { AiOutlineLoading3Quarters } from 'react-icons/ai';
 
 export const AccountSetting = () => {
   const [form] = Form.useForm();
   const userStore = useUserStore();
   const { t } = useTranslation();
-
+  const [loadingAvatar, setLoadingAvatar] = useState(false);
   const { showSettingModal } = useSiderStoreShallow((state) => ({
     showSettingModal: state.showSettingModal,
   }));
@@ -37,9 +38,12 @@ export const AccountSetting = () => {
   };
 
   const uploadAvatar = async (file: File) => {
+    if (loadingAvatar) return;
+    setLoadingAvatar(true);
     const { data } = await getClient().upload({
       body: { file, visibility: 'public' },
     });
+    setLoadingAvatar(false);
     if (data?.data.url) {
       setAvatarError(false);
       setAvatarUrl(data.data.url);
@@ -153,7 +157,12 @@ export const AccountSetting = () => {
                 showUploadList={false}
                 beforeUpload={beforeUpload}
               >
-                <div className="w-full h-full bg-gray-200 rounded-full flex items-center justify-center overflow-hidden">
+                <div className="w-full h-full relative bg-gray-200 rounded-full flex items-center justify-center overflow-hidden">
+                  {loadingAvatar && (
+                    <div className="absolute inset-0 bg-black/20 flex items-center justify-center">
+                      <AiOutlineLoading3Quarters size={22} className="animate-spin text-white" />
+                    </div>
+                  )}
                   {avatarUrl && !avatarError ? (
                     <img
                       src={avatarUrl}


### PR DESCRIPTION
- Implement loading indicator during avatar upload
- Add spinner overlay to provide visual feedback
- Prevent multiple simultaneous avatar uploads
- Use AiOutlineLoading3Quarters icon for loading state

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
