### PR TITLE
feat(canvas): update node creation with additional parameters

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/canvas-toolbar/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-toolbar/index.tsx
@@ -300,49 +300,69 @@ export const CanvasToolbar = memo<ToolbarProps>(({ onToolSelect, nodeLength }) =
   );
 
   const createSkillNode = useCallback(() => {
-    addNode({
-      type: 'skill',
-      data: { title: 'Skill', entityId: genSkillID() },
-    });
+    addNode(
+      {
+        type: 'skill',
+        data: { title: 'Skill', entityId: genSkillID() },
+      },
+      [],
+      true,
+      true,
+    );
   }, [addNode]);
 
   const createMemo = useCallback(() => {
     const memoId = genMemoID();
-    addNode({
-      type: 'memo',
-      data: { title: t('canvas.nodeTypes.memo'), entityId: memoId },
-    });
+    addNode(
+      {
+        type: 'memo',
+        data: { title: t('canvas.nodeTypes.memo'), entityId: memoId },
+      },
+      [],
+      true,
+      true,
+    );
   }, [addNode, t]);
 
   const createCodeArtifactNode = useCallback(() => {
     // For code artifacts, we'll use a resource ID since there's no specific prefix for code artifacts
     const codeArtifactId = genCodeArtifactID();
-    addNode({
-      type: 'codeArtifact',
-      data: {
-        title: t('canvas.nodeTypes.codeArtifact', 'Code Artifact'),
-        entityId: codeArtifactId,
-        contentPreview: '',
-        metadata: {
-          status: 'finish',
-          language: 'typescript',
-          activeTab: 'code',
+    addNode(
+      {
+        type: 'codeArtifact',
+        data: {
+          title: t('canvas.nodeTypes.codeArtifact', 'Code Artifact'),
+          entityId: codeArtifactId,
+          contentPreview: '',
+          metadata: {
+            status: 'finish',
+            language: 'typescript',
+            activeTab: 'code',
+          },
         },
       },
-    });
+      [],
+      true,
+      true,
+    );
   }, [addNode, t]);
 
   const createWebsiteNode = useCallback(() => {
-    addNode({
-      type: 'website',
-      data: {
-        title: t('canvas.nodes.website.defaultTitle', 'Website'),
-        entityId: genSkillID(),
-        metadata: {
-          viewMode: 'form',
+    addNode(
+      {
+        type: 'website',
+        data: {
+          title: t('canvas.nodes.website.defaultTitle', 'Website'),
+          entityId: genSkillID(),
+          metadata: {
+            viewMode: 'form',
+          },
         },
       },
-    });
+      [],
+      true,
+      true,
+    );
   }, [addNode, t]);
 
   const handleToolSelect = useCallback(

--- a/packages/ai-workspace-common/src/components/canvas/menu-popper/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/menu-popper/index.tsx
@@ -205,53 +205,73 @@ export const MenuPopper: FC<MenuPopperProps> = ({ open, position, setOpen }) => 
   const menuScreenPosition = getMenuScreenPosition();
 
   const createSkillNode = (position: { x: number; y: number }) => {
-    addNode({
-      type: 'skill',
-      data: { title: 'Skill', entityId: genSkillID() },
-      position: position,
-    });
+    addNode(
+      {
+        type: 'skill',
+        data: { title: 'Skill', entityId: genSkillID() },
+        position: position,
+      },
+      [],
+      true,
+      true,
+    );
   };
 
   const createMemo = (position: { x: number; y: number }) => {
     const memoId = genMemoID();
-    addNode({
-      type: 'memo',
-      data: { title: t('canvas.nodeTypes.memo'), entityId: memoId },
-      position: position,
-    });
+    addNode(
+      {
+        type: 'memo',
+        data: { title: t('canvas.nodeTypes.memo'), entityId: memoId },
+        position: position,
+      },
+      [],
+      true,
+      true,
+    );
   };
 
   const createCodeArtifactNode = (position: { x: number; y: number }) => {
     // For code artifacts, we'll use a resource ID since there's no specific prefix for code artifacts
     const codeArtifactId = genResourceID();
-    addNode({
-      type: 'codeArtifact',
-      data: {
-        title: t('canvas.nodeTypes.codeArtifact', 'Code Artifact'),
-        entityId: codeArtifactId,
-        contentPreview: '',
-        metadata: {
-          status: 'finish',
-          language: 'typescript',
-          activeTab: 'code',
+    addNode(
+      {
+        type: 'codeArtifact',
+        data: {
+          title: t('canvas.nodeTypes.codeArtifact', 'Code Artifact'),
+          entityId: codeArtifactId,
+          contentPreview: '',
+          metadata: {
+            status: 'finish',
+            language: 'typescript',
+            activeTab: 'code',
+          },
         },
+        position: position,
       },
-      position: position,
-    });
+      [],
+      true,
+      true,
+    );
   };
 
   const createWebsiteNode = (position: { x: number; y: number }) => {
-    addNode({
-      type: 'website',
-      data: {
-        title: t('canvas.nodes.website.defaultTitle', 'Website'),
-        entityId: genSkillID(),
-        metadata: {
-          viewMode: 'form',
+    addNode(
+      {
+        type: 'website',
+        data: {
+          title: t('canvas.nodes.website.defaultTitle', 'Website'),
+          entityId: genSkillID(),
+          metadata: {
+            viewMode: 'form',
+          },
         },
+        position,
       },
-      position,
-    });
+      [],
+      true,
+      true,
+    );
     setOpen(false);
   };
 

--- a/packages/ai-workspace-common/src/hooks/canvas/use-create-document.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-create-document.ts
@@ -165,7 +165,7 @@ export const useCreateDocument = () => {
           position: position,
         };
 
-        addNode(newNode);
+        addNode(newNode, [], true, true);
       }
     },
     [


### PR DESCRIPTION
- Modify node creation methods in CanvasToolbar and MenuPopper to include empty connections array
- Add optional parameters for node positioning and auto-selection
- Standardize node creation across different components
- Update useCreateDocument hook to match new node creation signature

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
