### PR TITLE
fix(rendering): adjust SVG and Mermaid rendering scale for better qua…

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
@@ -54,6 +54,7 @@ import { useEditorPerformance } from '@refly-packages/ai-workspace-common/contex
 import cn from 'classnames';
 import { ReasoningContentPreview } from './shared/reasoning-content-preview';
 import { useUpdateSkillResponseTitle } from '@refly-packages/ai-workspace-common/hooks/use-update-skill-response-title';
+import { truncateContent } from '@refly-packages/ai-workspace-common/utils/content';
 
 const POLLING_WAIT_TIME = 15000;
 
@@ -673,7 +674,7 @@ export const SkillResponseNode = memo(
                   {status !== 'failed' && metadata?.reasoningContent && (
                     <ReasoningContentPreview
                       resultId={entityId}
-                      content={metadata.reasoningContent}
+                      content={truncateContent(metadata.reasoningContent)}
                       sources={sources}
                       isOperating={isOperating}
                       stepStatus={status === 'executing' ? 'executing' : 'finish'}
@@ -683,7 +684,7 @@ export const SkillResponseNode = memo(
                   {status !== 'failed' && content && (
                     <ContentPreview
                       resultId={entityId}
-                      content={content || t('canvas.nodePreview.resource.noContentPreview')}
+                      content={truncateContent(content)}
                       sizeMode={sizeMode}
                       isOperating={isOperating}
                       sources={sources}

--- a/packages/ai-workspace-common/src/components/markdown/plugins/mermaid/render.tsx
+++ b/packages/ai-workspace-common/src/components/markdown/plugins/mermaid/render.tsx
@@ -69,7 +69,7 @@ const MermaidComponent = memo(
           features: {
             removeControlCharacter: false,
           },
-          scale: 10, // Higher resolution
+          scale: 1, // Higher resolution
           quality: 1,
           backgroundColor: '#ffffff',
         });

--- a/packages/ai-workspace-common/src/modules/artifacts/code-runner/render/svg.tsx
+++ b/packages/ai-workspace-common/src/modules/artifacts/code-runner/render/svg.tsx
@@ -25,7 +25,7 @@ const SVGRenderer = memo(({ content, title }: SVGRendererProps) => {
           removeControlCharacter: false,
         },
         // Use higher scale for better quality on high DPI displays
-        scale: 3,
+        scale: 1,
         quality: 1.0,
         backgroundColor: '#ffffff',
       });

--- a/packages/ai-workspace-common/src/utils/content.ts
+++ b/packages/ai-workspace-common/src/utils/content.ts
@@ -5,7 +5,7 @@
 /**
  * Maximum number of characters allowed for node content preview
  */
-export const MAX_CONTENT_PREVIEW_LENGTH = 1000;
+export const MAX_CONTENT_PREVIEW_LENGTH = 200;
 
 /**
  * Truncates content to a maximum length
@@ -20,7 +20,7 @@ export const truncateContent = (
   if (!content) return '';
   if (content.length <= maxLength) return content;
 
-  return content.substring(0, maxLength);
+  return `${content.substring(0, maxLength)}...`;
 };
 
 /**
@@ -33,9 +33,8 @@ export const truncateContent = (
 export const processContentPreview = (
   contents: (string | undefined)[] = [],
   separator = '\n',
-  maxLength = MAX_CONTENT_PREVIEW_LENGTH,
 ): string => {
   const filteredContents = contents.filter(Boolean) as string[];
   const joinedContent = filteredContents.join(separator);
-  return truncateContent(joinedContent, maxLength);
+  return joinedContent;
 };

--- a/packages/ai-workspace-common/src/utils/content.ts
+++ b/packages/ai-workspace-common/src/utils/content.ts
@@ -5,7 +5,7 @@
 /**
  * Maximum number of characters allowed for node content preview
  */
-export const MAX_CONTENT_PREVIEW_LENGTH = 200;
+export const MAX_CONTENT_PREVIEW_LENGTH = 1000;
 
 /**
  * Truncates content to a maximum length


### PR DESCRIPTION
…lity

- Reduce rendering scale from 3/10 to 1 for both SVG and Mermaid components
- Maintain high-quality rendering with quality parameter set to 1.0
- Ensure consistent rendering approach across different visualization components

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
