### PR TITLE
refactor(memo-node): simplify editor content rendering and improve ed…

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/memo/memo.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/memo/memo.tsx
@@ -16,7 +16,6 @@ import { useCanvasStoreShallow } from '@refly-packages/ai-workspace-common/store
 import Moveable from 'react-moveable';
 import classNames from 'classnames';
 import { useEditor, EditorContent } from '@tiptap/react';
-import { Markdown as MarkdownPreview } from '@refly-packages/ai-workspace-common/components/markdown';
 import { Markdown } from 'tiptap-markdown';
 import StarterKit from '@tiptap/starter-kit';
 import TextStyle from '@tiptap/extension-text-style';
@@ -211,7 +210,7 @@ export const MemoNode = ({
       }),
     ],
     content: data?.metadata?.jsonContent || data?.contentPreview || '',
-    editable: true,
+    editable: !isPreview && !readonly,
     onUpdate: ({ editor }) => {
       onMemoUpdates(editor);
     },
@@ -359,16 +358,15 @@ export const MemoNode = ({
           )}
           <div className="flex flex-col h-full p-3 box-border">
             <div className="relative flex-grow overflow-y-auto pr-2 -mr-2">
-              {!isPreview && !readonly ? (
-                <div className="editor-wrapper" style={{ userSelect: 'text', cursor: 'text' }}>
-                  <EditorContent
-                    editor={editor}
-                    className={classNames('text-xs memo-node-editor h-full w-full')}
-                  />
-                </div>
-              ) : (
-                <MarkdownPreview className="text-xs" content={data?.contentPreview ?? ''} />
-              )}
+              <div
+                className="editor-wrapper"
+                style={{ userSelect: 'text', cursor: isPreview || readonly ? 'default' : 'text' }}
+              >
+                <EditorContent
+                  editor={editor}
+                  className={classNames('text-xs memo-node-editor h-full w-full')}
+                />
+              </div>
             </div>
 
             <div className="flex justify-end items-center flex-shrink-0 mt-2 text-[10px] text-gray-400 z-20">


### PR DESCRIPTION
…itability

- Remove separate markdown preview component
- Conditionally set editor editability based on preview and readonly states
- Adjust editor wrapper styling to reflect interaction state
- Simplify content rendering logic for memo nodes

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
