### PR TITLE
feat(canvas): improve loading and group node rendering

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/group-action-menu/group-name.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/group-action-menu/group-name.tsx
@@ -1,7 +1,7 @@
 import { Input } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { FC, useCallback, useState, useEffect } from 'react';
-// import CommonColorPicker from '../nodes/shared/color-picker';
+import CommonColorPicker from '../nodes/shared/color-picker';
 
 interface GroupNameProps {
   title: string;
@@ -17,8 +17,8 @@ export const GroupName: FC<GroupNameProps> = ({
   onUpdateName,
   selected,
   readonly,
-  // bgColor,
-  // onChangeBgColor,
+  bgColor,
+  onChangeBgColor,
 }) => {
   const { t } = useTranslation();
   const [name, setName] = useState(title);
@@ -48,7 +48,7 @@ export const GroupName: FC<GroupNameProps> = ({
         pointerEvents: showInput ? 'auto' : 'none',
       }}
     >
-      <div className="flex gap-1">
+      <div className="flex gap-3">
         <Input
           className="!bg-transparent !border-none !shadow-none !pl-0 !text-base !text-black"
           disabled={readonly}
@@ -58,9 +58,9 @@ export const GroupName: FC<GroupNameProps> = ({
           onBlur={() => setIsEditing(false)}
           onFocus={() => setIsEditing(true)}
         />
-        {/* <div style={{ display: selected ? 'block' : 'none' }}>
+        <div style={{ display: selected ? 'block' : 'none' }}>
           <CommonColorPicker color={bgColor} onChange={onChangeBgColor} />
-        </div> */}
+        </div>
       </div>
     </div>
   );

--- a/packages/ai-workspace-common/src/components/canvas/group-action-menu/group-name.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/group-action-menu/group-name.tsx
@@ -59,7 +59,7 @@ export const GroupName: FC<GroupNameProps> = ({
           onFocus={() => setIsEditing(true)}
         />
         <div style={{ display: selected ? 'block' : 'none' }}>
-          <CommonColorPicker color={bgColor} onChange={onChangeBgColor} />
+          <CommonColorPicker disabledAlpha={true} color={bgColor} onChange={onChangeBgColor} />
         </div>
       </div>
     </div>

--- a/packages/ai-workspace-common/src/components/canvas/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/index.tsx
@@ -191,7 +191,7 @@ const Flow = memo(({ canvasId }: { canvasId: string }) => {
   const reactFlowInstance = useReactFlow();
 
   const { pendingNode, clearPendingNode } = useCanvasNodesStore();
-  const { provider, readonly, shareNotFound } = useCanvasContext();
+  const { provider, readonly, shareNotFound, shareLoading } = useCanvasContext();
 
   const { config, operatingNodeId, setOperatingNodeId, setInitialFitViewCompleted } =
     useCanvasStoreShallow((state) => ({
@@ -726,7 +726,8 @@ const Flow = memo(({ canvasId }: { canvasId: string }) => {
       className="w-full h-full"
       style={{ maxHeight: '100%' }}
       spinning={
-        !readonly && !hasCanvasSynced && provider?.status !== 'connected' && !connectionTimeout
+        (!readonly && !hasCanvasSynced && provider?.status !== 'connected' && !connectionTimeout) ||
+        (readonly && shareLoading)
       }
       tip={connectionTimeout ? t('common.connectionFailed') : t('common.loading')}
     >

--- a/packages/ai-workspace-common/src/components/canvas/nodes/group.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/group.tsx
@@ -24,6 +24,7 @@ import { useEditorPerformance } from '@refly-packages/ai-workspace-common/contex
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 import { useSetNodeDataByEntity } from '@refly-packages/ai-workspace-common/hooks/canvas/use-set-node-data-by-entity';
 import { useThrottledCallback } from 'use-debounce';
+import { useNodeData } from '@refly-packages/ai-workspace-common/hooks/canvas/use-node-data';
 
 interface GroupMetadata {
   label?: string;
@@ -71,6 +72,7 @@ export const GroupNode = memo(
     const { addNode } = useAddNode();
     const { selectNodeCluster, groupNodeCluster, layoutNodeCluster } = useNodeCluster();
     const setNodeDataByEntity = useSetNodeDataByEntity();
+    const { setNodeStyle } = useNodeData();
 
     // Memoize node and its measurements
     const node = useMemo(() => getNode(id), [id, getNode]);
@@ -234,6 +236,10 @@ export const GroupNode = memo(
       handleGroupCluster,
       handleLayoutCluster,
     ]);
+
+    useEffect(() => {
+      setNodeStyle(id, { zIndex: -1 });
+    }, [id, setNodeStyle]);
 
     const handleMouseEnter = useCallback(() => {
       setIsHovered(true);

--- a/packages/ai-workspace-common/src/components/canvas/nodes/group.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/group.tsx
@@ -24,6 +24,7 @@ import { useEditorPerformance } from '@refly-packages/ai-workspace-common/contex
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 import { useSetNodeDataByEntity } from '@refly-packages/ai-workspace-common/hooks/canvas/use-set-node-data-by-entity';
 import { useThrottledCallback } from 'use-debounce';
+import { useNodeData } from '@refly-packages/ai-workspace-common/hooks/canvas/use-node-data';
 
 interface GroupMetadata {
   label?: string;
@@ -71,6 +72,7 @@ export const GroupNode = memo(
     const { addNode } = useAddNode();
     const { selectNodeCluster, groupNodeCluster, layoutNodeCluster } = useNodeCluster();
     const setNodeDataByEntity = useSetNodeDataByEntity();
+    const { setNodeStyle } = useNodeData();
 
     // Memoize node and its measurements
     const node = useMemo(() => getNode(id), [id, getNode]);
@@ -429,6 +431,10 @@ export const GroupNode = memo(
               target.style.top = `${newTop}px`;
 
               setSize({ width: newWidth, height: newHeight });
+              setNodeStyle(id, {
+                width: `${newWidth}px`,
+                height: `${newHeight}px`,
+              });
             }}
             hideDefaultLines={true}
             className={`!pointer-events-auto ${!isHovered ? 'moveable-control-hidden' : 'moveable-control-show'}`}

--- a/packages/ai-workspace-common/src/components/canvas/nodes/group.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/group.tsx
@@ -24,7 +24,6 @@ import { useEditorPerformance } from '@refly-packages/ai-workspace-common/contex
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 import { useSetNodeDataByEntity } from '@refly-packages/ai-workspace-common/hooks/canvas/use-set-node-data-by-entity';
 import { useThrottledCallback } from 'use-debounce';
-import { useNodeData } from '@refly-packages/ai-workspace-common/hooks/canvas/use-node-data';
 
 interface GroupMetadata {
   label?: string;
@@ -72,7 +71,6 @@ export const GroupNode = memo(
     const { addNode } = useAddNode();
     const { selectNodeCluster, groupNodeCluster, layoutNodeCluster } = useNodeCluster();
     const setNodeDataByEntity = useSetNodeDataByEntity();
-    const { setNodeStyle } = useNodeData();
 
     // Memoize node and its measurements
     const node = useMemo(() => getNode(id), [id, getNode]);
@@ -237,10 +235,6 @@ export const GroupNode = memo(
       handleLayoutCluster,
     ]);
 
-    useEffect(() => {
-      setNodeStyle(id, { zIndex: -1 });
-    }, [id, setNodeStyle]);
-
     const handleMouseEnter = useCallback(() => {
       setIsHovered(true);
       onHoverStart();
@@ -345,7 +339,6 @@ export const GroupNode = memo(
               background: 'transparent',
               border: selected ? '2px dashed #00968F' : '2px dashed rgba(0, 0, 0, 0.1)',
               transition: 'all 0.2s ease',
-              backgroundColor: data.metadata?.bgColor || 'transparent',
             }}
           >
             {!isPreview && !hideHandles && (
@@ -369,15 +362,13 @@ export const GroupNode = memo(
               </>
             )}
 
-            {!isPreview && !hideActions && !readonly && (
+            {!isPreview && !hideActions && !isDragging && !readonly && (
               <>
-                {!isDragging && (
-                  <ActionButtons type="group" nodeId={id} isNodeHovered={selected && isHovered} />
-                )}
+                <ActionButtons type="group" nodeId={id} isNodeHovered={selected && isHovered} />
                 <GroupActionButtons
                   nodeId={id}
                   isTemporary={data.metadata?.isTemporary}
-                  isNodeHovered={isHovered}
+                  isNodeHovered={selected && isHovered}
                 />
               </>
             )}
@@ -389,6 +380,14 @@ export const GroupNode = memo(
               readonly={readonly}
               bgColor={data.metadata?.bgColor || 'rgba(255, 255, 255, 0)'}
               onChangeBgColor={handleChangeBgColor}
+            />
+
+            <div
+              className="absolute top-0 left-0 w-full h-full"
+              style={{
+                backgroundColor: data.metadata?.bgColor || 'transparent',
+                opacity: selected ? 0.5 : 1,
+              }}
             />
           </div>
         </div>

--- a/packages/ai-workspace-common/src/components/canvas/nodes/index.ts
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/index.ts
@@ -61,6 +61,7 @@ export const prepareNodeData = <T extends CanvasNodeType>({
   className,
   style,
   draggable = true,
+  zIndex = 0,
 }: {
   type: T;
   data: CanvasNodeData<NodeMetadataMap[T]>;
@@ -71,6 +72,7 @@ export const prepareNodeData = <T extends CanvasNodeType>({
   className?: string;
   style?: React.CSSProperties;
   draggable?: boolean;
+  zIndex?: number;
 }) => {
   return {
     id: `node-${genUniqueId()}`,
@@ -83,6 +85,7 @@ export const prepareNodeData = <T extends CanvasNodeType>({
     className,
     style,
     draggable,
+    zIndex,
   };
 };
 

--- a/packages/ai-workspace-common/src/components/canvas/nodes/index.ts
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/index.ts
@@ -61,7 +61,7 @@ export const prepareNodeData = <T extends CanvasNodeType>({
   className,
   style,
   draggable = true,
-  zIndex = 0,
+  zIndex,
 }: {
   type: T;
   data: CanvasNodeData<NodeMetadataMap[T]>;

--- a/packages/ai-workspace-common/src/components/canvas/nodes/shared/color-picker.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/shared/color-picker.tsx
@@ -33,7 +33,7 @@ const CommonColorPicker: FC<CommonColorPickerProps> = ({ color, onChange, classN
 
   return (
     <AntdColorPicker
-      className={`memo-color-picker items-center border-none rounded-none hover:bg-gray-100 ${className}`}
+      className={`memo-color-picker items-center border-none rounded-lg hover:bg-gray-100 ${className}`}
       defaultValue={color}
       onChange={handleColorChange}
       showText={false}

--- a/packages/ai-workspace-common/src/components/canvas/nodes/shared/color-picker.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/shared/color-picker.tsx
@@ -21,13 +21,18 @@ interface CommonColorPickerProps {
   color: string;
   onChange?: (color: string) => void;
   className?: string;
+  disabledAlpha?: boolean;
 }
 
-const CommonColorPicker: FC<CommonColorPickerProps> = ({ color, onChange, className = '' }) => {
+const CommonColorPicker: FC<CommonColorPickerProps> = ({
+  color,
+  onChange,
+  className = '',
+  disabledAlpha = false,
+}) => {
   const { t } = useTranslation();
 
   const handleColorChange = (_color: Color, css: string) => {
-    console.log('css', css);
     onChange?.(css);
   };
 
@@ -38,6 +43,7 @@ const CommonColorPicker: FC<CommonColorPickerProps> = ({ color, onChange, classN
       onChange={handleColorChange}
       showText={false}
       presets={[{ label: t('common.presetColors'), colors: presetColors }]}
+      disabledAlpha={disabledAlpha}
     />
   );
 };

--- a/packages/ai-workspace-common/src/context/canvas.tsx
+++ b/packages/ai-workspace-common/src/context/canvas.tsx
@@ -15,6 +15,7 @@ interface CanvasContextType {
   provider: HocuspocusProvider | null;
   localProvider: IndexeddbPersistence | null;
   readonly: boolean;
+  shareLoading: boolean;
   shareNotFound?: boolean;
   shareData?: RawCanvasData;
 }
@@ -78,9 +79,11 @@ export const CanvasProvider = ({
   }));
 
   // Use the hook to fetch canvas data when in readonly mode
-  const { data: canvasData, error: canvasError } = useFetchShareData<RawCanvasData>(
-    readonly ? canvasId : undefined,
-  );
+  const {
+    data: canvasData,
+    error: canvasError,
+    loading: shareLoading,
+  } = useFetchShareData<RawCanvasData>(readonly ? canvasId : undefined);
 
   // Check if it's a 404 error
   const shareNotFound = useMemo(() => {
@@ -288,10 +291,11 @@ export const CanvasProvider = ({
       provider,
       localProvider,
       readonly,
+      shareLoading,
       shareNotFound,
       shareData: canvasData,
     }),
-    [canvasId, provider, localProvider, readonly, shareNotFound, canvasData],
+    [canvasId, provider, localProvider, readonly, shareNotFound, canvasData, shareLoading],
   );
 
   return <CanvasContext.Provider value={canvasContext}>{children}</CanvasContext.Provider>;

--- a/packages/ai-workspace-common/src/hooks/canvas/use-batch-nodes-selection/use-group-nodes.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-batch-nodes-selection/use-group-nodes.ts
@@ -23,6 +23,7 @@ export const useGroupNodes = () => {
     // Prepare the new group node
     const newGroupNode = prepareNodeData({
       ...groupNode,
+      zIndex: -1,
       data: {
         ...groupNode.data,
         entityId: genUniqueId(),

--- a/packages/ai-workspace-common/src/hooks/canvas/use-node-hover.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-node-hover.ts
@@ -13,7 +13,12 @@ export const useNodeHoverEffect = (nodeId: string) => {
       const newEdgeStyle = isHovered ? edgeStyles.hover : edgeStyles.default;
 
       setNodes((nodes) =>
-        nodes.map((node) => (node.id === nodeId ? { ...node, zIndex: newZIndex } : node)),
+        nodes.map((node) => {
+          if (node.id === nodeId) {
+            return node.type === 'group' ? { ...node, zIndex: -1 } : { ...node, zIndex: newZIndex };
+          }
+          return node;
+        }),
       );
 
       setEdges((eds) =>


### PR DESCRIPTION
- Add `shareLoading` to canvas context for better loading state management
- Enable color picker for group nodes
- Set group nodes to have a lower z-index for better visual layering
- Adjust color picker styling with rounded corners

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
