### PR TITLE
fix(api): remove auto subscription update logic

### DIFF
--- a/cypress/e2e/canvas.cy.ts
+++ b/cypress/e2e/canvas.cy.ts
@@ -17,11 +17,14 @@ describe('Canvas Flow', () => {
   beforeEach(() => {
     cy.login('bob@example.com', 'testPassword123');
     // Add a small wait after login to ensure app is fully loaded
-    cy.wait(1000);
+    cy.wait(2000);
   });
 
   it('should create and interact with canvas', () => {
-    // Create new canvas from empty state - use multiple strategies for better stability
+    // Wait for the page to be fully loaded
+    cy.url().should('include', '/canvas');
+
+    // Create new canvas from empty state
     cy.get('[data-cy="empty-canvas-create-button"]')
       .should('be.visible')
       .and('exist')


### PR DESCRIPTION
# Summary

- Remove unnecessary plan change tracking
- Streamline subscription update process
- Eliminate redundant usage meter refresh logic

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
