### PR TITLE
feat(canvas): implement read-only mode warnings and cursor adjustments

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/document.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/document.tsx
@@ -67,6 +67,7 @@ export const DocumentNode = memo(
       id,
       node,
       sizeMode,
+      readonly,
       isOperating,
       minWidth: 100,
       maxWidth: 800,

--- a/packages/ai-workspace-common/src/components/canvas/nodes/image.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/image.tsx
@@ -67,6 +67,7 @@ export const ImageNode = memo(
     const { containerStyle, handleResize } = useNodeSize({
       id,
       node,
+      readonly,
       isOperating,
       minWidth: 100,
       maxWidth: 800,
@@ -255,6 +256,7 @@ export const ImageNode = memo(
 
               <div className="w-full rounded-lg overflow-y-auto">
                 <img
+                  onClick={readonly ? handlePreview : undefined}
                   src={imageUrl}
                   alt={data.title || 'Image'}
                   className="w-full h-auto object-contain"

--- a/packages/ai-workspace-common/src/components/canvas/nodes/memo/memo.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/memo/memo.tsx
@@ -317,7 +317,7 @@ export const MemoNode = ({
           width: `${size.width}px`,
           height: `${size.height}px`,
           userSelect: 'none',
-          cursor: isOperating ? 'default' : 'grab',
+          cursor: readonly ? 'default' : isOperating ? 'default' : 'grab',
         }}
       >
         {!isPreview && selected && !readonly && (

--- a/packages/ai-workspace-common/src/components/canvas/nodes/resource.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/resource.tsx
@@ -114,6 +114,7 @@ export const ResourceNode = memo(
       id,
       node,
       sizeMode,
+      readonly,
       isOperating,
       minWidth: 100,
       maxWidth: 800,

--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
@@ -249,6 +249,7 @@ export const SkillResponseNode = memo(
       id,
       node,
       sizeMode,
+      readonly,
       isOperating,
       minWidth: 100,
       maxWidth: 800,

--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill.tsx
@@ -130,9 +130,12 @@ export const SkillNode = memo(
     const isOperating = operatingNodeId === id;
     const isDragging = draggingNodeId === id;
     const node = useMemo(() => getNode(id), [id, getNode]);
+    const { canvasId, readonly } = useCanvasContext();
+
     const { containerStyle, handleResize, updateSize } = useNodeSize({
       id,
       node,
+      readonly,
       isOperating,
       minWidth: 100,
       maxWidth: 800,
@@ -178,7 +181,6 @@ export const SkillNode = memo(
     }));
 
     const { invokeAction, abortAction } = useInvokeAction();
-    const { canvasId, readonly } = useCanvasContext();
 
     const { handleUploadImage } = useUploadImage();
 

--- a/packages/ai-workspace-common/src/hooks/canvas/use-node-size.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-node-size.ts
@@ -20,6 +20,7 @@ interface UseNodeSizeProps {
   id: string;
   node: Node;
   sizeMode?: 'compact' | 'adaptive';
+  readonly?: boolean;
   isOperating?: boolean;
   minWidth?: number;
   maxWidth?: number;
@@ -31,6 +32,7 @@ interface UseNodeSizeProps {
 export const useNodeSize = ({
   id,
   node,
+  readonly = false,
   sizeMode = 'adaptive',
   isOperating = false,
   minWidth = 100,
@@ -151,9 +153,9 @@ export const useNodeSize = ({
       minWidth: sizeMode === 'compact' ? minWidth : defaultWidth,
       maxWidth,
       userSelect: isOperating ? 'text' : 'none',
-      cursor: isOperating ? 'text' : 'grab',
+      cursor: readonly ? 'default' : isOperating ? 'text' : 'grab',
     }),
-    [size, sizeMode, minWidth, maxWidth, defaultWidth, isOperating, sizeMode],
+    [size, sizeMode, minWidth, maxWidth, defaultWidth, isOperating, sizeMode, readonly],
   );
 
   return {

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -73,6 +73,8 @@ const translations = {
     duplicate: 'Duplicate',
     shareSuccess: 'Share link copied to clipboard!',
     shareError: 'Share failed, please try again!',
+    readonlyWarning: 'Read-Only Mode',
+    readonlyDragDescription: 'Canvas is in read-only mode, modifications are not allowed.',
   },
   verifyRules: {
     emailRequired: 'Email cannot be empty',

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -81,6 +81,8 @@ const translations = {
     duplicate: '复制',
     shareSuccess: '分享链接已复制到剪贴板!',
     shareError: '分享失败，请重试！',
+    readonlyWarning: '只读模式',
+    readonlyDragDescription: '当前画布为只读模式，不支持修改',
   },
   verifyRules: {
     emailRequired: '邮箱地址不能为空',


### PR DESCRIPTION
- Add a warning message for drag actions in read-only mode to inform users of restrictions
- Update cursor styles for nodes in read-only mode to indicate non-interactivity
- Modify node components to accept and handle read-only state, ensuring consistent behavior across different node types
- Enhance internationalization support by adding relevant translations for read-only warnings

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
