### PR TITLE
fix(canvas): enhance connection timeout handling and UI feedback

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useEffect, useState, useRef, memo } from 'react';
+import { Modal, Result } from 'antd';
 import { useTranslation } from 'react-i18next';
 import {
   ReactFlow,
@@ -385,19 +386,50 @@ const Flow = memo(({ canvasId }: { canvasId: string }) => {
 
   const [connectionTimeout, setConnectionTimeout] = useState(false);
 
-  useEffect(() => {
-    let timeoutId: NodeJS.Timeout;
+  // Track when provider first became unhealthy
+  const unhealthyStartTimeRef = useRef<number | null>(null);
 
-    if (provider?.status !== 'connected') {
-      timeoutId = setTimeout(() => {
-        setConnectionTimeout(true);
-      }, 10000);
+  useEffect(() => {
+    // Skip if no provider
+    if (!provider) return;
+
+    // Clear timeout state if provider becomes connected
+    if (provider.status === 'connected') {
+      setConnectionTimeout(false);
+      unhealthyStartTimeRef.current = null;
+      return;
     }
 
-    return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
+    // If provider is unhealthy and we haven't started tracking, start now
+    if (unhealthyStartTimeRef.current === null) {
+      unhealthyStartTimeRef.current = Date.now();
+    }
+
+    // Check status every two seconds after provider becomes unhealthy
+    const intervalId = setInterval(() => {
+      // Skip if provider is gone
+      if (!provider) return;
+
+      if (unhealthyStartTimeRef.current) {
+        const unhealthyDuration = Date.now() - unhealthyStartTimeRef.current;
+
+        // If provider has been unhealthy for more than 10 seconds, set timeout
+        if (unhealthyDuration > 10000) {
+          setConnectionTimeout(true);
+          clearInterval(intervalId);
+        }
       }
+
+      // Provider became healthy, reset everything
+      if (provider.status === 'connected') {
+        clearInterval(intervalId);
+        unhealthyStartTimeRef.current = null;
+        setConnectionTimeout(false);
+      }
+    }, 2000);
+
+    return () => {
+      clearInterval(intervalId);
     };
   }, [provider?.status]);
 
@@ -750,6 +782,20 @@ const Flow = memo(({ canvasId }: { canvasId: string }) => {
       }
       tip={connectionTimeout ? t('common.connectionFailed') : t('common.loading')}
     >
+      <Modal
+        centered
+        open={connectionTimeout}
+        onOk={() => window.location.reload()}
+        onCancel={() => setConnectionTimeout(false)}
+        okText={t('common.retry')}
+        cancelText={t('common.cancel')}
+      >
+        <Result
+          status="warning"
+          title={t('canvas.connectionTimeout.title')}
+          extra={t('canvas.connectionTimeout.extra')}
+        />
+      </Modal>
       <div className="w-full h-screen relative flex flex-col overflow-hidden">
         {!readonly && (
           <CanvasToolbar onToolSelect={handleToolSelect} nodeLength={nodes?.length || 0} />

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/buttons.tsx
@@ -2,7 +2,6 @@ import { useState, useCallback, memo } from 'react';
 import { Button, Tooltip, Popover } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { MdOutlineImage, MdOutlineAspectRatio } from 'react-icons/md';
-import { BiErrorCircle } from 'react-icons/bi';
 import {
   IconDownloadFile,
   IconSearch,
@@ -133,23 +132,3 @@ export const ToolbarButtons = memo(
     );
   },
 );
-
-export const WarningButton = memo(({ show }: { show: boolean }) => {
-  const { t } = useTranslation();
-
-  if (!show) return null;
-
-  return (
-    <Tooltip title={t('canvas.connectionTimeout.extra')}>
-      <Button
-        type="text"
-        danger
-        icon={<BiErrorCircle style={{ fontSize: '16px' }} />}
-        onClick={() => window.location.reload()}
-        className="flex items-center gap-1 ml-2 text-red-500 hover:text-red-600"
-      >
-        {t('canvas.connectionTimeout.title')}
-      </Button>
-    </Tooltip>
-  );
-});

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/canvas-title.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/canvas-title.tsx
@@ -15,12 +15,14 @@ export const CanvasTitle = memo(
     canvasId,
     canvasTitle,
     hasCanvasSynced,
+    providerStatus,
     debouncedUnsyncedChanges,
     language,
   }: {
     canvasId: string;
     canvasTitle?: string;
     hasCanvasSynced: boolean;
+    providerStatus: string;
     debouncedUnsyncedChanges: number;
     language: LOCALE;
   }) => {
@@ -56,6 +58,8 @@ export const CanvasTitle = memo(
       }
     }, [canvasTitle, hasCanvasSynced, canvasId]);
 
+    const isSyncing = providerStatus !== 'connected' || debouncedUnsyncedChanges > 0;
+
     return (
       <>
         <div
@@ -65,7 +69,7 @@ export const CanvasTitle = memo(
         >
           <Tooltip
             title={
-              debouncedUnsyncedChanges > 0
+              isSyncing
                 ? t('canvas.toolbar.syncingChanges')
                 : t('canvas.toolbar.synced', {
                     time: time(new Date(), language)?.utc()?.fromNow(),
@@ -76,7 +80,7 @@ export const CanvasTitle = memo(
               className={`
               relative w-2.5 h-2.5 rounded-full
               transition-colors duration-700 ease-in-out
-              ${debouncedUnsyncedChanges > 0 ? 'bg-yellow-500 animate-pulse' : 'bg-green-400'}
+              ${isSyncing ? 'bg-yellow-500 animate-pulse' : 'bg-green-400'}
             `}
             />
           </Tooltip>

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/index.tsx
@@ -11,7 +11,7 @@ import { useCanvasStoreShallow } from '@refly-packages/ai-workspace-common/store
 import { Helmet } from 'react-helmet';
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 import { CanvasTitle, ReadonlyCanvasTitle } from './canvas-title';
-import { ToolbarButtons, WarningButton } from './buttons';
+import { ToolbarButtons } from './buttons';
 import { CanvasActionDropdown } from '@refly-packages/ai-workspace-common/components/workspace/canvas-list-modal/canvasActionDropdown';
 import ShareSettings from './share-settings';
 import { useUserStoreShallow } from '@refly-packages/ai-workspace-common/stores/user';
@@ -65,33 +65,8 @@ export const TopToolbar: FC<TopToolbarProps> = memo(({ canvasId }) => {
       setShowMaxRatio: state.setShowMaxRatio,
     }));
 
-  const [connectionTimeout, setConnectionTimeout] = useState(false);
-
-  useEffect(() => {
-    if (readonly) {
-      return;
-    }
-
-    let timeoutId: NodeJS.Timeout;
-
-    if (provider?.status !== 'connected') {
-      timeoutId = setTimeout(() => {
-        setConnectionTimeout(true);
-      }, 10000);
-    } else {
-      setConnectionTimeout(false);
-    }
-
-    return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    };
-  }, [readonly, provider?.status]);
-
   const canvasTitle = data?.title;
   const hasCanvasSynced = config?.localSyncedAt > 0 && config?.remoteSyncedAt > 0;
-  const showWarning = connectionTimeout && !hasCanvasSynced && provider?.status !== 'connected';
 
   const { duplicateCanvas, loading: duplicating } = useDuplicateCanvas();
   const handleDuplicate = () => {
@@ -139,11 +114,11 @@ export const TopToolbar: FC<TopToolbarProps> = memo(({ canvasId }) => {
               canvasId={canvasId}
               canvasTitle={canvasTitle}
               hasCanvasSynced={hasCanvasSynced}
+              providerStatus={provider?.status}
               debouncedUnsyncedChanges={debouncedUnsyncedChanges}
               language={language}
             />
           )}
-          <WarningButton show={showWarning} />
         </div>
 
         <div className="flex items-center gap-2 relative z-10">

--- a/packages/ai-workspace-common/src/context/canvas.tsx
+++ b/packages/ai-workspace-common/src/context/canvas.tsx
@@ -139,6 +139,7 @@ export const CanvasProvider = ({
       token,
       document: doc,
       connect: true,
+      forceSyncInterval: 5000,
       onAuthenticationFailed: (data) => {
         console.log('onAuthenticationFailed', data);
         refreshToken();

--- a/packages/ai-workspace-common/src/context/document.tsx
+++ b/packages/ai-workspace-common/src/context/document.tsx
@@ -97,6 +97,7 @@ export const DocumentProvider = ({
       token,
       document: doc,
       connect: true,
+      forceSyncInterval: 5000,
       onAuthenticationFailed: () => {
         console.log('Authentication failed, refreshing token');
         refreshToken();

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -928,7 +928,7 @@ const translations = {
     },
     connectionTimeout: {
       title: 'Connection Timeout',
-      extra: 'The server seems to be busy, please try again.',
+      extra: 'We have some issues connecting to the Refly server, please refresh and try again.',
     },
     action: {
       nodeAlreadyExists: 'The {{type}} with the same entity already exists',

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -912,7 +912,7 @@ const translations = {
     },
     connectionTimeout: {
       title: '连接超时',
-      extra: '服务器似乎繁忙，请稍后再试。',
+      extra: '似乎无法连接到 Refly 服务器，请刷新重试。',
     },
     action: {
       nodeAlreadyExists: '该{{type}}已存在于当前画布中',


### PR DESCRIPTION
# Summary

- Implement a modal to notify users of connection timeouts with retry options
- Track provider health status and update connection timeout state accordingly
- Remove deprecated WarningButton component and integrate its functionality into the canvas component
- Update translations for connection timeout messages in English and Chinese
- Set a force sync interval for improved connection management

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | <img width="2142" alt="image" src="https://github.com/user-attachments/assets/77c47727-1129-4ed5-8087-9a82c116f29a" /> |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
