### PR TITLE
feat(node-operations): add truncateAllNodesContent function for skill…

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/index.tsx
@@ -154,11 +154,18 @@ const Flow = memo(({ canvasId }: { canvasId: string }) => {
   }));
   const selectedNodes = nodes.filter((node) => node.selected) || [];
 
-  const { onNodesChange } = useNodeOperations();
+  const { onNodesChange, truncateAllNodesContent } = useNodeOperations();
   const { setSelectedNode } = useNodeSelection();
 
   const { onEdgesChange, onConnect } = useEdgeOperations();
   const edgeStyles = useEdgeStyles();
+
+  // Call truncateAllNodesContent when nodes are loaded
+  useEffect(() => {
+    if (nodes.length > 0) {
+      truncateAllNodesContent();
+    }
+  }, [canvasId, truncateAllNodesContent]);
 
   const { showPreview, showLaunchpad, showMaxRatio } = useCanvasStoreShallow((state) => ({
     showPreview: state.showPreview,


### PR DESCRIPTION
…-response nodes

- Implement truncateAllNodesContent to truncate content for skill-response nodes exceeding MAX_CONTENT_PREVIEW_LENGTH
- Integrate function call in Flow component to trigger truncation when nodes are loaded
- Ensure performance optimizations with useCallback and proper dependency management in useEffect

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
