### PR TITLE
feat: support sharing large code artifacts

### DIFF
--- a/apps/api/src/share/share.service.ts
+++ b/apps/api/src/share/share.service.ts
@@ -435,7 +435,15 @@ export class ShareService {
   }
 
   async createShareForRawData(user: User, param: CreateShareRequest) {
-    const { entityId, entityType, title, shareData, parentShareId, allowDuplication } = param;
+    const {
+      entityId,
+      entityType,
+      title,
+      shareData,
+      shareDataStorageKey,
+      parentShareId,
+      allowDuplication,
+    } = param;
 
     // Check if shareRecord already exists
     const existingShareRecord = await this.prisma.shareRecord.findFirst({
@@ -451,9 +459,23 @@ export class ShareService {
     const shareId =
       existingShareRecord?.shareId ?? genShareId(entityType as keyof typeof SHARE_CODE_PREFIX);
 
+    let rawData: Buffer | null;
+    if (shareData) {
+      rawData = Buffer.from(shareData);
+    } else if (shareDataStorageKey) {
+      rawData = await this.miscService.downloadFile({
+        storageKey: shareDataStorageKey,
+        visibility: 'public',
+      });
+    }
+
+    if (!rawData) {
+      throw new ParamsError('Share data is required either by shareData or shareDataStorageKey');
+    }
+
     const { storageKey } = await this.miscService.uploadBuffer(user, {
       fpath: 'rawData.json',
-      buf: Buffer.from(shareData),
+      buf: rawData,
       entityId,
       entityType,
       visibility: 'public',

--- a/packages/ai-workspace-common/src/modules/artifacts/code-runner/code-viewer.tsx
+++ b/packages/ai-workspace-common/src/modules/artifacts/code-runner/code-viewer.tsx
@@ -192,32 +192,59 @@ export default memo(
         event.stopPropagation();
         const loadingMessage = message.loading(t('codeArtifact.sharing'), 0);
 
-        const { data, error } = await getClient().createShare({
-          body: {
-            entityId,
-            entityType: 'codeArtifact',
-            shareData: JSON.stringify({
-              content: editorContent,
-              type,
-              title,
-              language,
-            }),
-          },
-        });
+        try {
+          // Prepare the JSON content
+          const fileContent = JSON.stringify({
+            content: editorContent,
+            type,
+            title,
+            language,
+          });
 
-        if (!data?.success || error) {
-          loadingMessage();
-          console.error('Failed to share code:', error);
-          message.error(t('codeArtifact.shareError'));
-        } else {
-          const shareLink = getShareLink('codeArtifact', data.data?.shareId ?? '');
+          // Create a blob with the JSON content
+          const jsonBlob = new Blob([fileContent], { type: 'application/json' });
+
+          // Upload the file
+          const { data: uploadData, error: uploadError } = await getClient().upload({
+            body: {
+              file: jsonBlob,
+            },
+          });
+
+          if (uploadError || !uploadData?.data?.storageKey) {
+            throw new Error(
+              typeof uploadError === 'string' ? uploadError : 'Failed to upload code',
+            );
+          }
+
+          // Create the share
+          const { data, error } = await getClient().createShare({
+            body: {
+              entityId,
+              entityType: 'codeArtifact',
+              shareDataStorageKey: uploadData.data.storageKey,
+            },
+          });
+
+          if (!data?.success || error) {
+            throw new Error(typeof error === 'string' ? error : 'Failed to create share');
+          }
+
+          // Generate and copy the share link
+          const shareId = data.data?.shareId ?? '';
+          const shareLink = getShareLink('codeArtifact', shareId);
 
           // Copy the sharing link to clipboard
           copyToClipboard(shareLink);
 
-          // Clear loading message and show success with the link
+          // Clear loading message and show success
           loadingMessage();
           message.success(t('codeArtifact.shareSuccess'));
+        } catch (error) {
+          // Handle any errors that occurred during the process
+          loadingMessage();
+          console.error('Failed to share code:', error);
+          message.error(t('codeArtifact.shareError'));
         }
       },
       [editorContent, type, title, language, t, entityId],

--- a/packages/ai-workspace-common/src/requests/types.gen.ts
+++ b/packages/ai-workspace-common/src/requests/types.gen.ts
@@ -2106,6 +2106,10 @@ export type CreateShareRequest = {
    * Raw share data (JSON string)
    */
   shareData?: string;
+  /**
+   * Share data storage key
+   */
+  shareDataStorageKey?: string;
 };
 
 export type CreateShareResponse = BaseResponse & {

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -3929,6 +3929,9 @@ components:
         shareData:
           type: string
           description: Raw share data (JSON string)
+        shareDataStorageKey:
+          type: string
+          description: Share data storage key
     CreateShareResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -2843,6 +2843,10 @@ export const CreateShareRequestSchema = {
       type: 'string',
       description: 'Raw share data (JSON string)',
     },
+    shareDataStorageKey: {
+      type: 'string',
+      description: 'Share data storage key',
+    },
   },
 } as const;
 

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -2106,6 +2106,10 @@ export type CreateShareRequest = {
    * Raw share data (JSON string)
    */
   shareData?: string;
+  /**
+   * Share data storage key
+   */
+  shareDataStorageKey?: string;
 };
 
 export type CreateShareResponse = BaseResponse & {


### PR DESCRIPTION
# Summary

- Updated `createShareForRawData` in `ShareService` to support sharing data via a storage key, improving flexibility in data sharing.
- Modified OpenAPI schema and types to include `shareDataStorageKey` for better API documentation and type safety.
- Implemented a new method `downloadFile` in `MiscService` to retrieve files from storage.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
