### PR TITLE
refactor(templates-guide): remove private scope from canvas templates…

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/empty-guide/templates-guide.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/empty-guide/templates-guide.tsx
@@ -20,9 +20,8 @@ export const TemplatesGuide = ({ canvasId }: { canvasId: string }) => {
     setShowTemplates: state.setShowTemplates,
   }));
   const { data, refetch } = useListCanvasTemplates({
-    // TODO: scope = private for testing
     // TODO: add search
-    query: { scope: 'private', page: 1, pageSize: 3 },
+    query: { page: 1, pageSize: 3 },
   });
 
   const debouncedRefetch = useDebouncedCallback(() => refetch(), 300);

--- a/packages/ai-workspace-common/src/components/editor/extensions/Table/menus/TableRow/index.tsx
+++ b/packages/ai-workspace-common/src/components/editor/extensions/Table/menus/TableRow/index.tsx
@@ -64,7 +64,7 @@ export const TableRowMenu = React.memo(({ editor, appendTo }: MenuProps): JSX.El
         <PopoverMenu.Item
           icon="Trash"
           label={t('editor.table.deleteRow')}
-          className="text-red-500"
+          className="!text-red-500"
           onClick={onDeleteRow}
         />
       </Toolbar.Wrapper>


### PR DESCRIPTION
… query

- Updated the query in the TemplatesGuide component to remove the private scope, simplifying the data fetching logic.
- Adjusted the class name for the delete row item in the TableRowMenu component to use a more specific utility class for styling.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
