### PR TITLE
feat(canvas): add onResizeEnd callback to NodeResizer and CodeArtifac…

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/code-artifact.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/code-artifact.tsx
@@ -303,6 +303,12 @@ export const CodeArtifactNode = memo(
       [handleResize],
     );
 
+    const handleResizeEnd = useCallback(() => {
+      if (codeViewerRef.current) {
+        codeViewerRef.current.style.pointerEvents = '';
+      }
+    }, []);
+
     // Check if node has any connections
     const isTargetConnected = edges?.some((edge) => edge.target === id);
     const isSourceConnected = edges?.some((edge) => edge.source === id);
@@ -515,6 +521,7 @@ export const CodeArtifactNode = memo(
             isPreview={isPreview}
             sizeMode={sizeMode}
             onResize={handleEnhancedResize}
+            onResizeEnd={handleResizeEnd}
           />
         )}
       </div>

--- a/packages/ai-workspace-common/src/components/canvas/nodes/shared/node-resizer.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/shared/node-resizer.tsx
@@ -9,6 +9,7 @@ interface NodeResizerProps {
   isPreview?: boolean;
   sizeMode?: 'compact' | 'adaptive';
   onResize: (params: any) => void;
+  onResizeEnd?: () => void;
 }
 
 export const NodeResizer: React.FC<NodeResizerProps> = ({
@@ -19,6 +20,7 @@ export const NodeResizer: React.FC<NodeResizerProps> = ({
   isPreview = false,
   sizeMode = 'adaptive',
   onResize,
+  onResizeEnd,
 }) => {
   const [isResizing, setIsResizing] = React.useState(false);
 
@@ -79,6 +81,7 @@ export const NodeResizer: React.FC<NodeResizerProps> = ({
         for (const iframe of iframes) {
           iframe.style.pointerEvents = '';
         }
+        onResizeEnd?.();
       }}
       hideDefaultLines={true}
       className={`!pointer-events-auto ${!isHovered ? 'moveable-control-hidden' : 'moveable-control-show'}`}


### PR DESCRIPTION
…tNode

- Implemented an onResizeEnd callback in the NodeResizer component to handle pointer events after resizing.
- Updated CodeArtifactNode to utilize the new onResizeEnd callback, enhancing the resizing functionality and user experience.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
