### PR TITLE
refactor(workspace): implement infinite scroll for various lists

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas-template/template-list.tsx
+++ b/packages/ai-workspace-common/src/components/canvas-template/template-list.tsx
@@ -120,7 +120,7 @@ export const TemplateList = ({ language, categoryId, searchQuery }: TemplateList
   const { visible } = useCanvasTemplateModal((state) => ({
     visible: state.visible,
   }));
-  const { dataList, loadMore, reload, hasMore, isRequesting } = useFetchDataList({
+  const { dataList, loadMore, reload, hasMore, isRequesting, setDataList } = useFetchDataList({
     fetchData: async (queryPayload) => {
       const res = await getClient().listCanvasTemplates({
         query: {
@@ -139,6 +139,12 @@ export const TemplateList = ({ language, categoryId, searchQuery }: TemplateList
     if (!visible) return;
     reload();
   }, [language, categoryId, visible]);
+
+  useEffect(() => {
+    if (!visible) {
+      setDataList([]);
+    }
+  }, [visible]);
 
   const debounced = useDebouncedCallback(() => {
     reload();

--- a/packages/ai-workspace-common/src/components/canvas-template/template-list.tsx
+++ b/packages/ai-workspace-common/src/components/canvas-template/template-list.tsx
@@ -1,7 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useCallback, useMemo } from 'react';
 import { Empty, Avatar, Button, Typography } from 'antd';
 import { Spin } from '@refly-packages/ai-workspace-common/components/common/spin';
-import { ScrollLoading } from '@refly-packages/ai-workspace-common/components/workspace/scroll-loading';
+import InfiniteScroll from 'react-infinite-scroll-component';
+import {
+  Spinner,
+  EndMessage,
+} from '@refly-packages/ai-workspace-common/components/workspace/scroll-loading';
 import { useTranslation } from 'react-i18next';
 import { useFetchDataList } from '@refly-packages/ai-workspace-common/hooks/use-fetch-data-list';
 import getClient from '@refly-packages/ai-workspace-common/requests/proxiedRequest';
@@ -144,22 +148,42 @@ export const TemplateList = ({ language, categoryId, searchQuery }: TemplateList
     debounced();
   }, [searchQuery]);
 
+  const templateCards = useMemo(() => {
+    return dataList?.map((item) => <TemplateCard key={item.templateId} template={item} />);
+  }, [dataList]);
+
+  const handleLoadMore = useCallback(() => {
+    if (!isRequesting && hasMore) {
+      loadMore();
+    }
+  }, [isRequesting, hasMore, loadMore]);
+
+  const emptyState = (
+    <div className="h-full flex items-center justify-center">
+      <Empty description={t('common.empty')} />
+    </div>
+  );
+
   return (
     <div className="w-full h-full overflow-y-auto bg-[#F8F9FA] p-4">
-      <Spin className="spin" spinning={isRequesting}>
-        {isRequesting || dataList.length > 0 ? (
-          <>
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-2">
-              {dataList.map((item) => (
-                <TemplateCard key={item.templateId} template={item} />
-              ))}
-            </div>
-            <ScrollLoading isRequesting={isRequesting} hasMore={hasMore} loadMore={loadMore} />
-          </>
-        ) : (
-          <div className="h-full flex items-center justify-center">
-            <Empty description={t('common.empty')} />
+      <Spin className="spin" spinning={isRequesting && dataList.length === 0}>
+        {dataList.length > 0 ? (
+          <div id="templateScrollableDiv" className="w-full h-full overflow-y-auto">
+            <InfiniteScroll
+              dataLength={dataList.length}
+              next={handleLoadMore}
+              hasMore={hasMore}
+              loader={<Spinner />}
+              endMessage={<EndMessage />}
+              scrollableTarget="templateScrollableDiv"
+            >
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-2">
+                {templateCards}
+              </div>
+            </InfiniteScroll>
           </div>
+        ) : (
+          !isRequesting && emptyState
         )}
       </Spin>
     </div>

--- a/packages/ai-workspace-common/src/components/workspace/canvas-list-modal/index.tsx
+++ b/packages/ai-workspace-common/src/components/workspace/canvas-list-modal/index.tsx
@@ -7,7 +7,8 @@ import getClient from '@refly-packages/ai-workspace-common/requests/proxiedReque
 
 import { Canvas } from '@refly/openapi-schema';
 import { IconCanvas } from '@refly-packages/ai-workspace-common/components/common/icon';
-import { Modal, Empty, Spin, Divider, Typography } from 'antd';
+import { Modal, Empty, Divider, Typography } from 'antd';
+import { Spin } from '@refly-packages/ai-workspace-common/components/common/spin';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import {
   Spinner,
@@ -138,6 +139,12 @@ export const CanvasListModal = (props: CanvasListProps) => {
     </div>
   );
 
+  useEffect(() => {
+    if (!visible) {
+      setDataList([]);
+    }
+  }, [visible]);
+
   return (
     <Modal
       className="canvas-list"
@@ -153,9 +160,9 @@ export const CanvasListModal = (props: CanvasListProps) => {
       onCancel={() => setVisible(false)}
       focusTriggerAfterClose={false}
     >
-      <Spin className="spin" spinning={isRequesting && dataList.length === 0}>
-        {dataList.length > 0 ? (
-          <div id="canvasScrollableDiv" className="w-full h-[60vh] overflow-y-auto">
+      <Spin className="w-full h-full" spinning={isRequesting && dataList.length === 0}>
+        <div id="canvasScrollableDiv" className="w-full h-[60vh] overflow-y-auto">
+          {dataList.length > 0 ? (
             <InfiniteScroll
               dataLength={dataList.length}
               next={handleLoadMore}
@@ -168,10 +175,10 @@ export const CanvasListModal = (props: CanvasListProps) => {
                 {canvasItems}
               </div>
             </InfiniteScroll>
-          </div>
-        ) : (
-          !isRequesting && emptyState
-        )}
+          ) : (
+            !isRequesting && emptyState
+          )}
+        </div>
       </Spin>
     </Modal>
   );

--- a/packages/ai-workspace-common/src/components/workspace/canvas-list-modal/index.tsx
+++ b/packages/ai-workspace-common/src/components/workspace/canvas-list-modal/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useCallback, useMemo } from 'react';
 import { time } from '@refly-packages/ai-workspace-common/utils/time';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from '@refly-packages/ai-workspace-common/utils/router';
@@ -8,7 +8,11 @@ import getClient from '@refly-packages/ai-workspace-common/requests/proxiedReque
 import { Canvas } from '@refly/openapi-schema';
 import { IconCanvas } from '@refly-packages/ai-workspace-common/components/common/icon';
 import { Modal, Empty, Spin, Divider, Typography } from 'antd';
-import { ScrollLoading } from '../scroll-loading';
+import InfiniteScroll from 'react-infinite-scroll-component';
+import {
+  Spinner,
+  EndMessage,
+} from '@refly-packages/ai-workspace-common/components/workspace/scroll-loading';
 import { useFetchDataList } from '@refly-packages/ai-workspace-common/hooks/use-fetch-data-list';
 import { LOCALE } from '@refly/common-types';
 import './index.scss';
@@ -110,6 +114,30 @@ export const CanvasListModal = (props: CanvasListProps) => {
     setDataList(dataList.map((n) => (n.canvasId === canvasId ? { ...n, title: newTitle } : n)));
   };
 
+  const canvasItems = useMemo(() => {
+    return dataList?.map((item) => (
+      <CanvasItem
+        key={item.canvasId}
+        canvas={item}
+        handleClickCanvas={handleClickCanvas}
+        afterDelete={afterDelete}
+        afterRename={afterRename}
+      />
+    ));
+  }, [dataList, handleClickCanvas, afterDelete, afterRename]);
+
+  const handleLoadMore = useCallback(() => {
+    if (!isRequesting && hasMore) {
+      loadMore();
+    }
+  }, [isRequesting, hasMore, loadMore]);
+
+  const emptyState = (
+    <div className="h-full flex items-center justify-center">
+      <Empty description={t('common.empty')} />
+    </div>
+  );
+
   return (
     <Modal
       className="canvas-list"
@@ -125,26 +153,24 @@ export const CanvasListModal = (props: CanvasListProps) => {
       onCancel={() => setVisible(false)}
       focusTriggerAfterClose={false}
     >
-      <Spin className="spin" spinning={isRequesting}>
-        {isRequesting || dataList.length > 0 ? (
-          <>
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4">
-              {dataList.map((item) => (
-                <CanvasItem
-                  key={item.canvasId}
-                  canvas={item}
-                  handleClickCanvas={handleClickCanvas}
-                  afterDelete={afterDelete}
-                  afterRename={afterRename}
-                />
-              ))}
-            </div>
-            <ScrollLoading isRequesting={isRequesting} hasMore={hasMore} loadMore={loadMore} />
-          </>
-        ) : (
-          <div className="h-full flex items-center justify-center">
-            <Empty description={t('common.empty')} />
+      <Spin className="spin" spinning={isRequesting && dataList.length === 0}>
+        {dataList.length > 0 ? (
+          <div id="canvasScrollableDiv" className="w-full h-[60vh] overflow-y-auto">
+            <InfiniteScroll
+              dataLength={dataList.length}
+              next={handleLoadMore}
+              hasMore={hasMore}
+              loader={<Spinner />}
+              endMessage={<EndMessage />}
+              scrollableTarget="canvasScrollableDiv"
+            >
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4">
+                {canvasItems}
+              </div>
+            </InfiniteScroll>
           </div>
+        ) : (
+          !isRequesting && emptyState
         )}
       </Spin>
     </Modal>

--- a/packages/ai-workspace-common/src/components/workspace/document-list/index.tsx
+++ b/packages/ai-workspace-common/src/components/workspace/document-list/index.tsx
@@ -189,6 +189,8 @@ const DocumentList = () => {
   useEffect(() => {
     if (showLibraryModal) {
       reload();
+    } else {
+      setDataList([]);
     }
   }, [showLibraryModal]);
 
@@ -211,7 +213,7 @@ const DocumentList = () => {
 
   return (
     <Spin className="w-full h-full" spinning={isRequesting && dataList.length === 0}>
-      <div id="documentScrollableDiv" className="w-full h-[calc(60vh-60px)] overflow-y-auto">
+      <div id="documentScrollableDiv" className="w-full h-[calc(60vh] overflow-y-auto">
         {dataList.length > 0 ? (
           <InfiniteScroll
             dataLength={dataList.length}

--- a/packages/ai-workspace-common/src/components/workspace/document-list/index.tsx
+++ b/packages/ai-workspace-common/src/components/workspace/document-list/index.tsx
@@ -1,5 +1,10 @@
 import { time } from '@refly-packages/ai-workspace-common/utils/time';
 import { Dropdown, Button, Popconfirm, message, Empty, Divider, Typography } from 'antd';
+import InfiniteScroll from 'react-infinite-scroll-component';
+import {
+  Spinner,
+  EndMessage,
+} from '@refly-packages/ai-workspace-common/components/workspace/scroll-loading';
 import type { MenuProps, DropdownProps } from 'antd';
 
 import {
@@ -9,7 +14,7 @@ import {
   IconCreateDocument,
 } from '@refly-packages/ai-workspace-common/components/common/icon';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
 import getClient from '@refly-packages/ai-workspace-common/requests/proxiedRequest';
 import type { Document } from '@refly/openapi-schema';
 import { LOCALE } from '@refly/common-types';
@@ -17,7 +22,6 @@ import { useTranslation } from 'react-i18next';
 
 import { useFetchDataList } from '@refly-packages/ai-workspace-common/hooks/use-fetch-data-list';
 import { Spin } from '@refly-packages/ai-workspace-common/components/common/spin';
-import { ScrollLoading } from '@refly-packages/ai-workspace-common/components/workspace/scroll-loading';
 import { useSiderStoreShallow } from '@refly-packages/ai-workspace-common/stores/sider';
 import { useAddNode } from '@refly-packages/ai-workspace-common/hooks/canvas/use-add-node';
 import { useDeleteDocument } from '@refly-packages/ai-workspace-common/hooks/canvas/use-delete-document';
@@ -148,7 +152,7 @@ const DocumentCard = ({ item, onDelete }: { item: Document; onDelete: () => void
   );
 };
 
-export const DocumentList = () => {
+const DocumentList = () => {
   const { t } = useTranslation();
   const { createSingleDocumentInCanvas } = useCreateDocument();
   const { showLibraryModal, setShowLibraryModal } = useSiderStoreShallow((state) => ({
@@ -166,45 +170,67 @@ export const DocumentList = () => {
     pageSize: 12,
   });
 
+  const documentCards = useMemo(() => {
+    return dataList?.map((item) => (
+      <DocumentCard
+        key={item.docId}
+        item={item}
+        onDelete={() => setDataList(dataList.filter((n) => n.docId !== item.docId))}
+      />
+    ));
+  }, [dataList, setDataList]);
+
+  const handleLoadMore = useCallback(() => {
+    if (!isRequesting && hasMore) {
+      loadMore();
+    }
+  }, [isRequesting, hasMore, loadMore]);
+
   useEffect(() => {
     if (showLibraryModal) {
       reload();
     }
   }, [showLibraryModal]);
 
+  const emptyState = (
+    <div className="h-full flex items-center justify-center">
+      <Empty description={t('common.empty')}>
+        <Button
+          className="text-[#00968F]"
+          icon={<IconCreateDocument className="-mr-1 flex items-center justify-center" />}
+          onClick={() => {
+            createSingleDocumentInCanvas();
+            setShowLibraryModal(false);
+          }}
+        >
+          {t('canvas.toolbar.createDocument')}
+        </Button>
+      </Empty>
+    </div>
+  );
+
   return (
-    <Spin className="w-full h-full" spinning={isRequesting}>
-      <div className="w-full h-[calc(60vh-60px)] overflow-y-auto">
-        {isRequesting || dataList.length > 0 ? (
-          <>
+    <Spin className="w-full h-full" spinning={isRequesting && dataList.length === 0}>
+      <div id="documentScrollableDiv" className="w-full h-[calc(60vh-60px)] overflow-y-auto">
+        {dataList.length > 0 ? (
+          <InfiniteScroll
+            dataLength={dataList.length}
+            next={handleLoadMore}
+            hasMore={hasMore}
+            loader={<Spinner />}
+            endMessage={<EndMessage />}
+            scrollableTarget="documentScrollableDiv"
+          >
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4">
-              {dataList.map((item) => (
-                <DocumentCard
-                  key={item.docId}
-                  item={item}
-                  onDelete={() => setDataList(dataList.filter((n) => n.docId !== item.docId))}
-                />
-              ))}
+              {documentCards}
             </div>
-            <ScrollLoading isRequesting={isRequesting} hasMore={hasMore} loadMore={loadMore} />
-          </>
+          </InfiniteScroll>
         ) : (
-          <div className="h-full flex items-center justify-center">
-            <Empty description={t('common.empty')}>
-              <Button
-                className="text-[#00968F]"
-                icon={<IconCreateDocument className="-mr-1 flex items-center justify-center" />}
-                onClick={() => {
-                  createSingleDocumentInCanvas();
-                  setShowLibraryModal(false);
-                }}
-              >
-                {t('canvas.toolbar.createDocument')}
-              </Button>
-            </Empty>
-          </div>
+          !isRequesting && emptyState
         )}
       </div>
     </Spin>
   );
 };
+
+export { DocumentList };

--- a/packages/ai-workspace-common/src/components/workspace/resource-list/index.tsx
+++ b/packages/ai-workspace-common/src/components/workspace/resource-list/index.tsx
@@ -276,6 +276,8 @@ const ResourceList = () => {
   useEffect(() => {
     if (showLibraryModal) {
       reload();
+    } else {
+      setDataList([]);
     }
   }, [showLibraryModal]);
 
@@ -298,7 +300,7 @@ const ResourceList = () => {
 
   return (
     <Spin className="w-full h-full" spinning={isRequesting && dataList.length === 0}>
-      <div id="resourceScrollableDiv" className="w-full h-[calc(60vh-60px)] overflow-y-auto">
+      <div id="resourceScrollableDiv" className="w-full h-[60vh-60px)] overflow-y-auto">
         {dataList.length > 0 ? (
           <InfiniteScroll
             dataLength={dataList.length}

--- a/packages/ai-workspace-common/src/components/workspace/scroll-loading/index.tsx
+++ b/packages/ai-workspace-common/src/components/workspace/scroll-loading/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Button } from 'antd';
+import { Spin } from '@refly-packages/ai-workspace-common/components/common/spin';
 
 export interface ScrollLoadingProps {
   isRequesting: boolean;
@@ -27,6 +28,23 @@ export const ScrollLoading = (props: ScrollLoadingProps) => {
   return (
     <div className="w-full flex justify-center my-6">
       <Button onClick={() => loadMore()}>{t('common.loadMore')}</Button>
+    </div>
+  );
+};
+
+export const Spinner = () => {
+  return (
+    <div className="flex justify-center py-4">
+      <Spin />
+    </div>
+  );
+};
+
+export const EndMessage = () => {
+  const { t } = useTranslation();
+  return (
+    <div className="w-full flex justify-center py-6">
+      <span>{t('knowledgeLibrary.archive.item.noMoreText')}</span>
     </div>
   );
 };


### PR DESCRIPTION
- Replaced traditional loading mechanisms with InfiniteScroll in TemplateList, CanvasListModal, DocumentList, and ResourceList components to enhance user experience.
- Introduced Spinner and EndMessage components for better loading and end state representation.
- Utilized useMemo and useCallback hooks for performance optimization in rendering list items and handling load more functionality.
- Updated empty state handling to provide clearer user feedback when no data is available.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
