### PR TITLE
feat(api): enable promotion codes for subscription creation

### DIFF
--- a/apps/api/src/subscription/subscription.service.ts
+++ b/apps/api/src/subscription/subscription.service.ts
@@ -152,6 +152,7 @@ export class SubscriptionService implements OnModuleInit {
       client_reference_id: uid,
       customer: customerId || undefined,
       customer_email: !customerId ? userPo?.email : undefined,
+      allow_promotion_codes: true,
     });
 
     await this.prisma.$transaction([


### PR DESCRIPTION
# Summary

- Added the allow_promotion_codes flag to the subscription creation process, allowing users to utilize promotion codes during subscription sign-up.
- Ensured compliance with code style rules, including the use of single quotes for string literals.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
