### PR TITLE
refactor(skills): remove MAX_OUTPUT_TOKENS constants from chat model …

### DIFF
--- a/packages/skill-template/src/skills/code-artifacts.ts
+++ b/packages/skill-template/src/skills/code-artifacts.ts
@@ -30,7 +30,6 @@ import {
   buildArtifactsContextUserPrompt,
   buildArtifactsFullSystemPrompt,
 } from '../scheduler/module/artifacts';
-import { MAX_OUTPUT_TOKENS_LEVEL3 } from '../scheduler/utils/constants';
 /**
  * Code Artifacts Skill
  *
@@ -220,7 +219,7 @@ export class CodeArtifacts extends BaseSkill {
     }
 
     // Use a slightly higher temperature for more creative code generation
-    const model = this.engine.chatModel({ temperature: 0.1, maxTokens: MAX_OUTPUT_TOKENS_LEVEL3 });
+    const model = this.engine.chatModel({ temperature: 0.1 });
 
     // Let the front-end know we're generating an artifact
     this.emitEvent(

--- a/packages/skill-template/src/skills/common-qna.ts
+++ b/packages/skill-template/src/skills/common-qna.ts
@@ -24,7 +24,6 @@ import { isValidUrl } from '@refly-packages/utils';
 // prompts
 import * as commonQnA from '../scheduler/module/commonQnA';
 import { checkModelContextLenSupport } from '../scheduler/utils/model';
-import { MAX_OUTPUT_TOKENS_LEVEL2 } from '../scheduler/utils/constants';
 
 export class CommonQnA extends BaseSkill {
   name = 'commonQnA';
@@ -203,7 +202,7 @@ export class CommonQnA extends BaseSkill {
       );
     }
 
-    const model = this.engine.chatModel({ temperature: 0.1, maxTokens: MAX_OUTPUT_TOKENS_LEVEL2 });
+    const model = this.engine.chatModel({ temperature: 0.1 });
     const responseMessage = await model.invoke(requestMessages, {
       ...config,
       metadata: {

--- a/packages/skill-template/src/skills/custom-prompt.ts
+++ b/packages/skill-template/src/skills/custom-prompt.ts
@@ -19,7 +19,6 @@ import { extractAndCrawlUrls } from '../scheduler/utils/extract-weblink';
 import { processContextUrls } from '../utils/url-processing';
 // prompts
 import * as customPrompt from '../scheduler/module/customPrompt/index';
-import { MAX_OUTPUT_TOKENS_LEVEL2 } from '../scheduler/utils/constants';
 
 export class CustomPrompt extends BaseSkill {
   name = 'customPrompt';
@@ -236,7 +235,6 @@ export class CustomPrompt extends BaseSkill {
     const model = this.engine.chatModel({
       temperature: Number(tplConfig?.temperature?.value ?? 0.1),
       topP: Number(tplConfig?.topP?.value ?? 1),
-      maxTokens: MAX_OUTPUT_TOKENS_LEVEL2,
     });
     const responseMessage = await model.invoke(requestMessages, {
       ...config,

--- a/packages/skill-template/src/skills/library-search.ts
+++ b/packages/skill-template/src/skills/library-search.ts
@@ -19,7 +19,6 @@ import * as librarySearch from '../scheduler/module/librarySearch';
 import { processQuery } from '../scheduler/utils/queryProcessor';
 import { extractAndCrawlUrls } from '../scheduler/utils/extract-weblink';
 import { processContextUrls } from '../utils/url-processing';
-import { MAX_OUTPUT_TOKENS_LEVEL2 } from '../scheduler/utils/constants';
 
 export class LibrarySearch extends BaseSkill {
   name = 'librarySearch';
@@ -166,7 +165,7 @@ export class LibrarySearch extends BaseSkill {
     });
 
     // Generate answer using the model
-    const model = this.engine.chatModel({ temperature: 0.1, maxTokens: MAX_OUTPUT_TOKENS_LEVEL2 });
+    const model = this.engine.chatModel({ temperature: 0.1 });
     const responseMessage = await model.invoke(requestMessages, {
       ...config,
       metadata: {

--- a/packages/skill-template/src/skills/web-search.ts
+++ b/packages/skill-template/src/skills/web-search.ts
@@ -19,7 +19,6 @@ import { processQuery } from '../scheduler/utils/queryProcessor';
 import { extractAndCrawlUrls } from '../scheduler/utils/extract-weblink';
 import { safeStringifyJSON } from '@refly-packages/utils';
 import { processContextUrls } from '../utils/url-processing';
-import { MAX_OUTPUT_TOKENS_LEVEL2 } from '../scheduler/utils/constants';
 
 export class WebSearch extends BaseSkill {
   name = 'webSearch';
@@ -181,7 +180,7 @@ export class WebSearch extends BaseSkill {
     });
 
     // Generate answer using the model
-    const model = this.engine.chatModel({ temperature: 0.1, maxTokens: MAX_OUTPUT_TOKENS_LEVEL2 });
+    const model = this.engine.chatModel({ temperature: 0.1 });
     const responseMessage = await model.invoke(requestMessages, {
       ...config,
       metadata: {


### PR DESCRIPTION
…configuration

- Removed the MAX_OUTPUT_TOKENS constants from the chat model configuration in multiple skill files to simplify the model initialization.
- Ensured compliance with code style rules, including the use of single quotes for string literals.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
