### PR TITLE
refactor(dependencies): remove '@tiptap-pro/extension-table-of-conten…

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,6 @@
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/typography": "^0.5.10",
     "@tanstack/react-query": "^5.61.3",
-    "@tiptap-pro/extension-table-of-contents": "~2.11.2",
     "@tiptap-pro/extension-unique-id": "~2.11.2",
     "@types/aos": "^3.0.7",
     "@types/is-hotkey": "~0.1.7",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,6 @@
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/typography": "^0.5.10",
     "@tanstack/react-query": "^5.61.3",
-    "@tiptap-pro/extension-unique-id": "~2.11.2",
     "@types/aos": "^3.0.7",
     "@types/is-hotkey": "~0.1.7",
     "@types/lodash.throttle": "^4.1.9",

--- a/packages/ai-workspace-common/package.json
+++ b/packages/ai-workspace-common/package.json
@@ -35,7 +35,6 @@
     "@tailwindcss/forms": "^0.5.3",
     "@tanstack/react-query": "^5.61.3",
     "@tippyjs/react": "^4.2.6",
-    "@tiptap-pro/extension-table-of-contents": "~2.11.2",
     "@tiptap/core": "2.7.4",
     "@tiptap/extension-character-count": "2.7.4",
     "@tiptap/extension-code-block-lowlight": "2.7.4",

--- a/packages/ai-workspace-common/src/components/document/collab-editor.tsx
+++ b/packages/ai-workspace-common/src/components/document/collab-editor.tsx
@@ -29,7 +29,6 @@ import {
   handleImageDrop,
   handleImagePaste,
 } from '@refly-packages/ai-workspace-common/components/editor/core/plugins';
-import { getHierarchicalIndexes, TableOfContents } from '@tiptap-pro/extension-table-of-contents';
 import {
   useDocumentStore,
   useDocumentStoreShallow,
@@ -102,7 +101,6 @@ export const CollaborativeEditor = memo(
     const documentActions = useDocumentStoreShallow((state) => ({
       setHasEditorSelection: state.setHasEditorSelection,
       updateDocumentCharsCount: state.updateDocumentCharsCount,
-      updateTocItems: state.updateTocItems,
       updateLastCursorPosRef: state.updateLastCursorPosRef,
       setActiveDocumentId: state.setActiveDocumentId,
     }));
@@ -232,12 +230,6 @@ export const CollaborativeEditor = memo(
         createPlaceholderExtension(),
         Collaboration.configure({
           document: ydoc,
-        }),
-        TableOfContents.configure({
-          getIndex: getHierarchicalIndexes,
-          onUpdate(content) {
-            documentActions.updateTocItems(docId, content);
-          },
         }),
       ];
     }, [ydoc, docId, documentActions, createPlaceholderExtension]);

--- a/packages/ai-workspace-common/src/components/document/readonly-editor.tsx
+++ b/packages/ai-workspace-common/src/components/document/readonly-editor.tsx
@@ -9,7 +9,6 @@ import {
 
 import { handleCommandNavigation } from '@refly-packages/ai-workspace-common/components/editor/core/extensions';
 import { defaultExtensions } from '@refly-packages/ai-workspace-common/components/editor/components/extensions';
-import { getHierarchicalIndexes, TableOfContents } from '@tiptap-pro/extension-table-of-contents';
 import { useDocumentStoreShallow } from '@refly-packages/ai-workspace-common/stores/document';
 import { ImagePreview } from '@refly-packages/ai-workspace-common/components/common/image-preview';
 import UpdatedImage from '@refly-packages/ai-workspace-common/components/editor/core/extensions/updated-image';
@@ -82,12 +81,7 @@ export const ReadonlyEditor = memo(
 
       const filteredExtensions = defaultExtensions.filter((ext) => ext.name !== 'image');
 
-      return [
-        ...filteredExtensions,
-        centeredImage,
-        Markdown,
-        TableOfContents.configure({ getIndex: getHierarchicalIndexes }),
-      ];
+      return [...filteredExtensions, centeredImage, Markdown];
     }, [docId]);
 
     useEffect(() => {

--- a/packages/ai-workspace-common/src/stores/document.ts
+++ b/packages/ai-workspace-common/src/stores/document.ts
@@ -42,7 +42,6 @@ interface DocumentBaseState {
   updateDocument: (docId: string, document: Document) => void;
   updateDocumentCharsCount: (docId: string, count: number) => void;
   updateLastCursorPosRef: (docId: string, pos: number) => void;
-  updateTocItems: (docId: string, items: TableOfContentsItem[]) => void;
   setActiveDocumentId: (docId: string) => void;
 
   setDocumentReadOnly: (docId: string, readOnly: boolean) => void;
@@ -88,12 +87,6 @@ export const useDocumentStore = create<DocumentBaseState>()(
         set((state) => {
           state.data[docId] ??= {};
           state.data[docId].lastCursorPosRef = pos;
-        }),
-
-      updateTocItems: (docId: string, items: TableOfContentsItem[]) =>
-        set((state) => {
-          state.data[docId] ??= {};
-          state.data[docId].tocItems = items;
         }),
 
       setActiveDocumentId: (docId: string) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -634,9 +634,6 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.61.3
         version: 5.61.3(react@18.3.1)
-      '@tiptap-pro/extension-table-of-contents':
-        specifier: ~2.11.2
-        version: 2.11.7(@tiptap/core@2.7.4)(@tiptap/pm@2.7.4)
       '@tiptap-pro/extension-unique-id':
         specifier: ~2.11.2
         version: 2.11.7(@tiptap/core@2.7.4)(@tiptap/pm@2.7.4)
@@ -938,9 +935,6 @@ importers:
       '@tippyjs/react':
         specifier: ^4.2.6
         version: 4.2.6(react-dom@18.3.1)(react@18.3.1)
-      '@tiptap-pro/extension-table-of-contents':
-        specifier: ~2.11.2
-        version: 2.11.7(@tiptap/core@2.7.4)(@tiptap/pm@2.7.4)
       '@tiptap/core':
         specifier: 2.7.4
         version: 2.7.4(@tiptap/pm@2.7.4)
@@ -8319,17 +8313,6 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tippy.js: 6.3.7
-    dev: false
-
-  /@tiptap-pro/extension-table-of-contents@2.11.7(@tiptap/core@2.7.4)(@tiptap/pm@2.7.4):
-    resolution: {integrity: sha512-Thb9Kou3J1/Bppc8SVnWUrMtANgqH7iPc/s+fYzxBLzQ2ZIWlPozMA8w9Qq7FN3GoJHyPUsaQK94hzoanQphmA==}
-    peerDependencies:
-      '@tiptap/core': ^2.0.0
-      '@tiptap/pm': ^2.0.0
-    dependencies:
-      '@tiptap/core': 2.7.4(@tiptap/pm@2.7.4)
-      '@tiptap/pm': 2.7.4
-      uuid: 10.0.0
     dev: false
 
   /@tiptap-pro/extension-unique-id@2.11.7(@tiptap/core@2.7.4)(@tiptap/pm@2.7.4):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -634,9 +634,6 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.61.3
         version: 5.61.3(react@18.3.1)
-      '@tiptap-pro/extension-unique-id':
-        specifier: ~2.11.2
-        version: 2.11.7(@tiptap/core@2.7.4)(@tiptap/pm@2.7.4)
       '@types/aos':
         specifier: ^3.0.7
         version: 3.0.7
@@ -8313,17 +8310,6 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tippy.js: 6.3.7
-    dev: false
-
-  /@tiptap-pro/extension-unique-id@2.11.7(@tiptap/core@2.7.4)(@tiptap/pm@2.7.4):
-    resolution: {integrity: sha512-TJxn2Leea1+D65dm26rLXHdPbVgfBOT+trHr1mIDvER1lotD6ArHGo4HYWU8jhe+r5rS2uncxiWA2tgWAdC0pg==}
-    peerDependencies:
-      '@tiptap/core': ^2.0.0
-      '@tiptap/pm': ^2.0.0
-    dependencies:
-      '@tiptap/core': 2.7.4(@tiptap/pm@2.7.4)
-      '@tiptap/pm': 2.7.4
-      uuid: 10.0.0
     dev: false
 
   /@tiptap/core@2.7.4(@tiptap/pm@2.7.4):


### PR DESCRIPTION
…ts' from project

- Removed the '@tiptap-pro/extension-table-of-contents' dependency from package.json files in both the web and ai-workspace-common packages.
- Updated the collab-editor and readonly-editor components to eliminate references to the TableOfContents, ensuring compliance with code style rules.
- Ensured proper cleanup of related state management in the document store.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
