### PR TITLE
feat(canvas): implement grid snapping and enhance collaborative edito…

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/index.tsx
@@ -63,6 +63,8 @@ import { useCanvasSync } from '@refly-packages/ai-workspace-common/hooks/canvas/
 import { EmptyGuide } from './empty-guide';
 import HelperLines from './common/helper-line/index';
 
+const GRID_SIZE = 10;
+
 const selectionStyles = `
   .react-flow__selection {
     background: rgba(0, 150, 143, 0.03) !important;
@@ -869,6 +871,8 @@ const Flow = memo(({ canvasId }: { canvasId: string }) => {
           )}
           <ReactFlow
             {...flowConfig}
+            snapToGrid={true}
+            snapGrid={[GRID_SIZE, GRID_SIZE]}
             edgeTypes={edgeTypes}
             panOnScroll={interactionMode === 'touchpad'}
             panOnDrag={interactionMode === 'mouse'}

--- a/packages/ai-workspace-common/src/components/document/collab-editor.tsx
+++ b/packages/ai-workspace-common/src/components/document/collab-editor.tsx
@@ -326,8 +326,20 @@ export const CollaborativeEditor = memo(
         }
 
         const isFocused = editor.isFocused;
-
         const { activeDocumentId } = useDocumentStore.getState();
+
+        if (content === '\n' && !isFocused) {
+          editor
+            ?.chain()
+            .focus(0)
+            .insertContentAt(0, { type: 'paragraph' })
+            .setTextSelection(1)
+            .run();
+
+          documentActions.setActiveDocumentId(docId);
+          return;
+        }
+
         if (activeDocumentId !== docId) {
           return;
         }

--- a/packages/ai-workspace-common/src/components/document/index.tsx
+++ b/packages/ai-workspace-common/src/components/document/index.tsx
@@ -28,6 +28,7 @@ import { useDocumentSync } from '@refly-packages/ai-workspace-common/hooks/use-d
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 import { getShareLink } from '@refly-packages/ai-workspace-common/utils/share';
 import getClient from '@refly-packages/ai-workspace-common/requests/proxiedRequest';
+import { editorEmitter } from '@refly-packages/utils/event-emitter/editor';
 
 const StatusBar = memo(
   ({ docId }: { docId: string }) => {
@@ -242,6 +243,13 @@ const DocumentEditorHeader = memo(
       );
     };
 
+    const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        editorEmitter.emit('insertBelow', '\n');
+      }
+    }, []);
+
     return (
       <div className="w-full">
         <div className="mx-0 mt-4 max-w-screen-lg">
@@ -252,6 +260,7 @@ const DocumentEditorHeader = memo(
             value={document?.title}
             style={{ paddingLeft: 6 }}
             onChange={onTitleChange}
+            onKeyDown={handleKeyDown}
           />
         </div>
       </div>


### PR DESCRIPTION
…r behavior

- Added grid snapping functionality to the Flow component, allowing elements to align with a defined grid size for improved layout precision.
- Enhanced the CollaborativeEditor to automatically focus and insert a new paragraph when the Enter key is pressed without the Shift key, improving user experience during document editing.
- Introduced a keydown handler in the DocumentEditorHeader to facilitate this behavior, ensuring a smoother editing process.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
