### PR TITLE
feat: Configure Nginx for LAN access and adjust Docker network

### DIFF
--- a/deploy/docker/docker-compose.middleware.yml
+++ b/deploy/docker/docker-compose.middleware.yml
@@ -3,7 +3,7 @@ services:
     container_name: refly_db
     image: postgres:16-alpine
     ports:
-      - 5432:5432
+      - 5435:5432
     restart: always
     volumes:
       - db_data:/var/lib/postgresql/data
@@ -17,14 +17,16 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+    networks:
+      - refly_network
   minio:
     container_name: refly_minio
     image: minio/minio:RELEASE.2025-01-20T14-49-07Z
     command: server /data --console-address ":9001"
     restart: always
     ports:
-      - 9000:9000
-      - 9001:9001
+      - 9002:9000
+      - 9003:9001
     volumes:
       - minio_data:/data
     environment:
@@ -36,12 +38,14 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
+    networks:
+      - refly_network
   redis:
     container_name: refly_redis
     image: redis/redis-stack:latest
     restart: always
     ports:
-      - 6379:6379
+      - 6381:6379
       - 8001:8001
     volumes:
       - redis_data:/data
@@ -51,6 +55,8 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+    networks:
+      - refly_network
   qdrant:
     container_name: refly_qdrant
     image: reflyai/qdrant:v1.13.1
@@ -66,11 +72,13 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
+    networks:
+      - refly_network
   elasticsearch:
     container_name: refly_elasticsearch
     image: reflyai/elasticsearch:7.10.2
     ports:
-      - 9200:9200
+      - 9210:9200
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
@@ -83,6 +91,12 @@ services:
       timeout: 10s
       retries: 3
       start_period: 20s
+    networks:
+      - refly_network
+
+networks:
+  refly_network:
+    driver: bridge
 
 volumes:
   db_data:

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -2,7 +2,7 @@ include:
   - path: docker-compose.middleware.yml
 services:
   api:
-    image: reflyai/refly-api:latest
+    image: reflyai/refly-api:nightly
     container_name: refly_api
     depends_on:
       elasticsearch:
@@ -41,8 +41,10 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
+    networks:
+      - refly_network  
   web:
-    image: reflyai/refly-web:latest
+    image: reflyai/refly-web:nightly
     container_name: refly_web
     ports:
       - 5700:80
@@ -58,3 +60,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
+    networks:
+      - refly_network  
+
+
+

--- a/deploy/docker/nginx.conf
+++ b/deploy/docker/nginx.conf
@@ -1,9 +1,9 @@
 server {
     listen 80;
-    server_name localhost;
+    server_name _;
     root /usr/share/nginx/html;
     index index.html;
-
+    
     # API proxy
     location /api/ {
         proxy_pass http://api:5800/;


### PR DESCRIPTION
- Modify nginx.conf, setting server_name to _ to allow access via LAN IP.
- Define and use refly_network in docker-compose.yml and docker-compose.middleware.yml for coexistence with other projects (e.g., Dify).

