### PR TITLE
refactor: update translations for knowledge base terminology

### DIFF
--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -2224,12 +2224,12 @@ const translations = {
     noDescription: '快来填写描述吧～',
     customInstructions: '预设提示词',
     waitingUploadCover: '暂未上传封面',
-    askProject: '基于项目提问',
+    askProject: '知识库提问',
     knowledgeToggle: {
       enabledDesc:
-        '基于项目提问当前被设置为开启，"{{projectName}}"内的文件知识会在提问时作为参考内容使用',
+        '基于知识库提问当前被设置为开启，"{{projectName}}"内的文件知识会在提问时作为参考内容使用',
       disabledDesc:
-        '基于项目提问当前被设置为关闭，"{{projectName}}"内的文件知识不会在提问时作为参考内容使用',
+        '基于知识库提问当前被设置为关闭，"{{projectName}}"内的文件知识不会在提问时作为参考内容使用',
     },
     selectProject: '选择知识库',
     switchProject: '切换知识库',


### PR DESCRIPTION
- Changed '基于项目提问' to '知识库提问' for improved clarity in user instructions.
- Updated related descriptions in the knowledgeToggle section to reflect the new terminology.
- Ensured compliance with localization standards and consistency across the application.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
