### PR TITLE
refactor: enhance usePublicAccessPage hook to include preview page de…

### DIFF
--- a/packages/ai-workspace-common/src/hooks/use-is-share-page.ts
+++ b/packages/ai-workspace-common/src/hooks/use-is-share-page.ts
@@ -3,7 +3,8 @@ import { useLocation } from 'react-router-dom';
 export const usePublicAccessPage = () => {
   const location = useLocation();
   const isSharePage = location?.pathname?.startsWith('/share/') ?? false;
+  const isPreviewPage = location?.pathname?.startsWith('/preview/') ?? false;
   const isArtifactGalleryPage = location?.pathname?.startsWith('/artifact-gallery') ?? false;
   const isUseCasesGalleryPage = location?.pathname?.startsWith('/use-cases-gallery') ?? false;
-  return isSharePage || isArtifactGalleryPage || isUseCasesGalleryPage;
+  return isPreviewPage || isSharePage || isArtifactGalleryPage || isUseCasesGalleryPage;
 };


### PR DESCRIPTION
…tection

- Added logic to detect if the current page is a preview page by checking the pathname.
- Updated the return statement to include the new preview page condition alongside existing checks for share, artifact gallery, and use cases gallery pages.
- Ensured compliance with Tailwind CSS styling and performance optimizations, including the use of optional chaining and nullish coalescing.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
