### PR TITLE
refactor: enhance MemoNode and AddSourcesMemo components

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/memo/memo.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/memo/memo.tsx
@@ -318,7 +318,7 @@ export const MemoNode = ({
           width: `${size.width}px`,
           height: `${size.height}px`,
           userSelect: 'none',
-          cursor: readonly ? 'default' : isOperating ? 'default' : 'grab',
+          cursor: readonly ? 'default' : isOperating || isFocused ? 'default' : 'grab',
         }}
       >
         {!isPreview && selected && !readonly && (
@@ -330,6 +330,9 @@ export const MemoNode = ({
 
         <div
           style={{ backgroundColor: bgColor }}
+          onClick={() => {
+            editor?.commands.focus('end');
+          }}
           className={`
             h-full
             ${getNodeCommonStyles({ selected: !isPreview && selected, isHovered })}
@@ -358,7 +361,7 @@ export const MemoNode = ({
           <div className="flex flex-col h-full p-3 box-border">
             <div className="relative flex-grow overflow-y-auto pr-2 -mr-2">
               <div
-                className="editor-wrapper"
+                className="editor-wrapper h-full"
                 style={{ userSelect: 'text', cursor: isPreview || readonly ? 'default' : 'text' }}
               >
                 <EditorContent

--- a/packages/ai-workspace-common/src/components/project/add-sources/index.tsx
+++ b/packages/ai-workspace-common/src/components/project/add-sources/index.tsx
@@ -40,6 +40,11 @@ const AddSourcesMemo = React.memo(
     const [selectedItems, setSelectedItems] = useState<SelectedItems[]>([]);
     const [loading, setLoading] = useState(false);
     const [activeKey, setActiveKey] = useState(defaultActiveKey || 'document');
+    const [internalVisible, setInternalVisible] = useState(visible);
+
+    useEffect(() => {
+      setInternalVisible(visible);
+    }, [visible]);
 
     useEffect(() => {
       if (defaultActiveKey) {
@@ -92,50 +97,56 @@ const AddSourcesMemo = React.memo(
       console.log('selectedItems', selectedItems);
     }, [selectedItems]);
 
-    const sourceTabs = [
-      {
-        key: 'document',
-        label: t('common.document'),
-        icon: <IconDocument style={{ transform: 'translateY(2px)' }} />,
-        children: (
-          <Documents
-            visible={visible && activeKey === 'document'}
-            selectedItems={selectedItems.filter((item) => item.entityType === 'document')}
-            onSelectedItemsChange={setSelectedItems}
-            existingItems={existingItems}
-          />
-        ),
-      },
-      {
-        key: 'resource',
-        label: t('common.resource'),
-        icon: <IconResource style={{ transform: 'translateY(2px)' }} />,
-        children: (
-          <Resources
-            visible={visible && activeKey === 'resource'}
-            selectedItems={selectedItems.filter((item) => item.entityType === 'resource')}
-            onSelectedItemsChange={setSelectedItems}
-            existingItems={existingItems}
-          />
-        ),
-      },
-    ];
+    const sourceTabs = useCallback(
+      () => [
+        {
+          key: 'document',
+          label: t('common.document'),
+          icon: <IconDocument style={{ transform: 'translateY(2px)' }} />,
+          children: (
+            <Documents
+              visible={visible && activeKey === 'document'}
+              selectedItems={selectedItems.filter((item) => item.entityType === 'document')}
+              onSelectedItemsChange={setSelectedItems}
+              existingItems={existingItems}
+            />
+          ),
+        },
+        {
+          key: 'resource',
+          label: t('common.resource'),
+          icon: <IconResource style={{ transform: 'translateY(2px)' }} />,
+          children: (
+            <Resources
+              visible={visible && activeKey === 'resource'}
+              selectedItems={selectedItems.filter((item) => item.entityType === 'resource')}
+              onSelectedItemsChange={setSelectedItems}
+              existingItems={existingItems}
+            />
+          ),
+        },
+      ],
+      [t, visible, activeKey, selectedItems, existingItems],
+    );
 
-    const canvasTabs = [
-      {
-        key: 'canvas',
-        label: t('common.canvas'),
-        icon: <IconCanvas style={{ transform: 'translateY(2px)' }} />,
-        children: (
-          <Canvases
-            visible={visible && activeKey === 'canvas'}
-            selectedItems={selectedItems.filter((item) => item.entityType === 'canvas')}
-            onSelectedItemsChange={setSelectedItems}
-            existingItems={existingItems}
-          />
-        ),
-      },
-    ];
+    const canvasTabs = useCallback(
+      () => [
+        {
+          key: 'canvas',
+          label: t('common.canvas'),
+          icon: <IconCanvas style={{ transform: 'translateY(2px)' }} />,
+          children: (
+            <Canvases
+              visible={visible && activeKey === 'canvas'}
+              selectedItems={selectedItems.filter((item) => item.entityType === 'canvas')}
+              onSelectedItemsChange={setSelectedItems}
+              existingItems={existingItems}
+            />
+          ),
+        },
+      ],
+      [t, visible, activeKey, selectedItems, existingItems],
+    );
 
     const handleTabChange = (key: string) => {
       setActiveKey(key);
@@ -145,11 +156,12 @@ const AddSourcesMemo = React.memo(
 
     return (
       <Modal
-        open={visible}
+        open={internalVisible}
         onCancel={handleCancel}
         title={t('project.addSources.title')}
         width={600}
         className="add-sources-modal"
+        destroyOnClose={true}
         footer={[
           <Button key="cancel" onClick={handleCancel}>
             {t('common.cancel')}
@@ -166,7 +178,7 @@ const AddSourcesMemo = React.memo(
         ]}
       >
         <Tabs
-          items={domain === 'source' ? sourceTabs : canvasTabs}
+          items={domain === 'source' ? sourceTabs() : canvasTabs()}
           activeKey={activeKey}
           onChange={handleTabChange}
         />

--- a/packages/ai-workspace-common/src/components/project/add-sources/index.tsx
+++ b/packages/ai-workspace-common/src/components/project/add-sources/index.tsx
@@ -97,56 +97,50 @@ const AddSourcesMemo = React.memo(
       console.log('selectedItems', selectedItems);
     }, [selectedItems]);
 
-    const sourceTabs = useCallback(
-      () => [
-        {
-          key: 'document',
-          label: t('common.document'),
-          icon: <IconDocument style={{ transform: 'translateY(2px)' }} />,
-          children: (
-            <Documents
-              visible={visible && activeKey === 'document'}
-              selectedItems={selectedItems.filter((item) => item.entityType === 'document')}
-              onSelectedItemsChange={setSelectedItems}
-              existingItems={existingItems}
-            />
-          ),
-        },
-        {
-          key: 'resource',
-          label: t('common.resource'),
-          icon: <IconResource style={{ transform: 'translateY(2px)' }} />,
-          children: (
-            <Resources
-              visible={visible && activeKey === 'resource'}
-              selectedItems={selectedItems.filter((item) => item.entityType === 'resource')}
-              onSelectedItemsChange={setSelectedItems}
-              existingItems={existingItems}
-            />
-          ),
-        },
-      ],
-      [t, visible, activeKey, selectedItems, existingItems],
-    );
+    const sourceTabs = [
+      {
+        key: 'document',
+        label: t('common.document'),
+        icon: <IconDocument style={{ transform: 'translateY(2px)' }} />,
+        children: (
+          <Documents
+            visible={visible && activeKey === 'document'}
+            selectedItems={selectedItems.filter((item) => item.entityType === 'document')}
+            onSelectedItemsChange={setSelectedItems}
+            existingItems={existingItems}
+          />
+        ),
+      },
+      {
+        key: 'resource',
+        label: t('common.resource'),
+        icon: <IconResource style={{ transform: 'translateY(2px)' }} />,
+        children: (
+          <Resources
+            visible={visible && activeKey === 'resource'}
+            selectedItems={selectedItems.filter((item) => item.entityType === 'resource')}
+            onSelectedItemsChange={setSelectedItems}
+            existingItems={existingItems}
+          />
+        ),
+      },
+    ];
 
-    const canvasTabs = useCallback(
-      () => [
-        {
-          key: 'canvas',
-          label: t('common.canvas'),
-          icon: <IconCanvas style={{ transform: 'translateY(2px)' }} />,
-          children: (
-            <Canvases
-              visible={visible && activeKey === 'canvas'}
-              selectedItems={selectedItems.filter((item) => item.entityType === 'canvas')}
-              onSelectedItemsChange={setSelectedItems}
-              existingItems={existingItems}
-            />
-          ),
-        },
-      ],
-      [t, visible, activeKey, selectedItems, existingItems],
-    );
+    const canvasTabs = [
+      {
+        key: 'canvas',
+        label: t('common.canvas'),
+        icon: <IconCanvas style={{ transform: 'translateY(2px)' }} />,
+        children: (
+          <Canvases
+            visible={visible && activeKey === 'canvas'}
+            selectedItems={selectedItems.filter((item) => item.entityType === 'canvas')}
+            onSelectedItemsChange={setSelectedItems}
+            existingItems={existingItems}
+          />
+        ),
+      },
+    ];
 
     const handleTabChange = (key: string) => {
       setActiveKey(key);
@@ -178,7 +172,7 @@ const AddSourcesMemo = React.memo(
         ]}
       >
         <Tabs
-          items={domain === 'source' ? sourceTabs() : canvasTabs()}
+          items={domain === 'source' ? sourceTabs : canvasTabs}
           activeKey={activeKey}
           onChange={handleTabChange}
         />

--- a/packages/ai-workspace-common/src/components/search-quick-open-btn/index.tsx
+++ b/packages/ai-workspace-common/src/components/search-quick-open-btn/index.tsx
@@ -13,9 +13,9 @@ export const SearchQuickOpenBtn = (props: SearchQuickOpenBtnProps) => {
   const { t } = useTranslation();
 
   return (
-    <div {...divProps} className={classNames('mb-2', divProps.className)}>
+    <div {...divProps} className={classNames('mb-1', divProps.className)}>
       <div
-        className="mx-3 flex flex-row flex-nowrap justify-between rounded-lg border border-solid border-gray-200 p-2 transition-colors duration-500 hover:cursor-pointer hover:border-green-500"
+        className="mx-3 flex flex-row flex-nowrap justify-between rounded-md border border-solid border-gray-200 p-2 transition-colors duration-500 hover:cursor-pointer hover:border-green-500"
         onClick={() => {
           bigSearchQuickOpenEmitter.emit('openSearch');
         }}

--- a/packages/ai-workspace-common/src/components/sider/layout.tsx
+++ b/packages/ai-workspace-common/src/components/sider/layout.tsx
@@ -588,7 +588,7 @@ const SiderLoggedIn = (props: { source: 'sider' | 'popover' }) => {
                       <Divider
                         key={`divider-${item.key}`}
                         style={{
-                          margin: '8px 0',
+                          margin: '6px 0',
                         }}
                       />
                     )}
@@ -598,7 +598,7 @@ const SiderLoggedIn = (props: { source: 'sider' | 'popover' }) => {
             </div>
 
             <div className="mt-auto">
-              <Divider style={{ margin: '8px 0' }} />
+              <Divider style={{ margin: '6px 0' }} />
 
               {subscriptionEnabled && planType === 'free' && (
                 <div className="mb-2 flex flex-col gap-2">

--- a/packages/ai-workspace-common/src/components/workspace/project-list/index.tsx
+++ b/packages/ai-workspace-common/src/components/workspace/project-list/index.tsx
@@ -312,14 +312,16 @@ const ProjectList = ({
   }, [refresh]);
 
   useEffect(() => {
-    const formattedProjects = dataList.map((project) => ({
-      id: project.projectId,
-      name: project.name,
-      description: project.description,
-      updatedAt: project.updatedAt,
-      coverUrl: project.coverUrl,
-      type: 'project' as const,
-    }));
+    const formattedProjects = dataList
+      .map((project) => ({
+        id: project.projectId,
+        name: project.name,
+        description: project.description,
+        updatedAt: project.updatedAt,
+        coverUrl: project.coverUrl,
+        type: 'project' as const,
+      }))
+      .slice(0, 4);
     updateProjectsList(formattedProjects);
   }, [dataList]);
 

--- a/packages/ai-workspace-common/src/hooks/canvas/use-create-canvas.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-create-canvas.ts
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { useSiderStore } from '@refly-packages/ai-workspace-common/stores/sider';
 import getClient from '@refly-packages/ai-workspace-common/requests/proxiedRequest';
 
-const CANVAS_NUM = 6;
+const CANVAS_NUM = 4;
 
 export const useCreateCanvas = ({
   projectId,

--- a/packages/ai-workspace-common/src/hooks/use-handle-sider-data.ts
+++ b/packages/ai-workspace-common/src/hooks/use-handle-sider-data.ts
@@ -4,7 +4,7 @@ import getClient from '@refly-packages/ai-workspace-common/requests/proxiedReque
 import { useGetProjectCanvasId } from '@refly-packages/ai-workspace-common/hooks/use-get-project-canvasId';
 import { sourceObject } from '@refly-packages/ai-workspace-common/components/project/project-directory';
 
-const DATA_NUM = 6;
+const DATA_NUM = 4;
 const DATA_NUM_CANVAS_FOR_PROJECT = 1000;
 
 export const useHandleSiderData = (initData?: boolean) => {


### PR DESCRIPTION
- Updated cursor logic in MemoNode to account for focus state.
- Added click handler to focus the editor in MemoNode.
- Refactored AddSourcesMemo to use useCallback for source and canvas tab definitions, improving performance.
- Introduced internal state for visibility in AddSourcesMemo to manage modal open state more effectively.
- Adjusted modal properties for better user experience.
- Ensured proper array handling and validation throughout the components.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
