### PR TITLE
refactor: integrate runtime configuration into skill components for k…

### DIFF
--- a/packages/skill-template/src/skills/code-artifacts.ts
+++ b/packages/skill-template/src/skills/code-artifacts.ts
@@ -105,14 +105,18 @@ export class CodeArtifacts extends BaseSkill {
 
   commonPreprocess = async (state: GraphState, config: SkillRunnableConfig) => {
     const { messages = [], images = [] } = state;
-    const { locale = 'en', modelInfo, tplConfig, project } = config.configurable;
+    const { locale = 'en', modelInfo, tplConfig, project, runtimeConfig } = config.configurable;
 
     // Get project-specific customInstructions if available
     const customInstructions = project?.customInstructions;
 
-    // process projectId based knowledge base search
+    // Only enable knowledge base search if both projectId AND runtimeConfig.enabledKnowledgeBase are true
     const projectId = project?.projectId;
-    const enableKnowledgeBaseSearch = !!projectId;
+    const enableKnowledgeBaseSearch = !!projectId && !!runtimeConfig?.enabledKnowledgeBase;
+
+    this.engine.logger.log(
+      `ProjectId: ${projectId}, Enable KB Search: ${enableKnowledgeBaseSearch}`,
+    );
 
     // Get configuration values
     const artifactType = tplConfig?.artifactType?.value ?? 'auto';

--- a/packages/skill-template/src/skills/custom-prompt.ts
+++ b/packages/skill-template/src/skills/custom-prompt.ts
@@ -99,14 +99,18 @@ export class CustomPrompt extends BaseSkill {
     config: SkillRunnableConfig,
   ): Promise<Partial<GraphState>> => {
     const { messages = [], images = [] } = state;
-    const { currentSkill, tplConfig, locale = 'en', project } = config.configurable;
+    const { currentSkill, tplConfig, locale = 'en', project, runtimeConfig } = config.configurable;
 
     // Set current step
     config.metadata.step = { name: 'analyzeQuery' };
 
-    // process projectId based knowledge base search
+    // Only enable knowledge base search if both projectId AND runtimeConfig.enabledKnowledgeBase are true
     const projectId = project?.projectId;
-    const enableKnowledgeBaseSearch = !!projectId;
+    const enableKnowledgeBaseSearch = !!projectId && !!runtimeConfig?.enabledKnowledgeBase;
+
+    this.engine.logger.log(
+      `ProjectId: ${projectId}, Enable KB Search: ${enableKnowledgeBaseSearch}`,
+    );
 
     // Get custom system prompt and instructions
     let customSystemPrompt = (tplConfig?.customSystemPrompt?.value as string) || '';

--- a/packages/skill-template/src/skills/generate-doc.ts
+++ b/packages/skill-template/src/skills/generate-doc.ts
@@ -65,14 +65,18 @@ export class GenerateDoc extends BaseSkill {
   ) => {
     config.metadata.step = { name: 'analyzeQuery' };
     const { messages = [], images = [] } = state;
-    const { locale = 'en', modelInfo, project } = config.configurable;
+    const { locale = 'en', modelInfo, project, runtimeConfig } = config.configurable;
 
     // Extract customInstructions from project if available
     const customInstructions = project?.customInstructions;
 
-    // Process projectId based knowledge base search
+    // Only enable knowledge base search if both projectId AND runtimeConfig.enabledKnowledgeBase are true
     const projectId = project?.projectId;
-    const enableKnowledgeBaseSearch = !!projectId;
+    const enableKnowledgeBaseSearch = !!projectId && !!runtimeConfig?.enabledKnowledgeBase;
+
+    this.engine.logger.log(
+      `ProjectId: ${projectId}, Enable KB Search: ${enableKnowledgeBaseSearch}`,
+    );
 
     // Update tplConfig with knowledge base search setting
     config.configurable.tplConfig = {

--- a/packages/skill-template/src/skills/web-search.ts
+++ b/packages/skill-template/src/skills/web-search.ts
@@ -61,7 +61,7 @@ export class WebSearch extends BaseSkill {
     config: SkillRunnableConfig,
   ): Promise<Partial<GraphState>> => {
     const { messages = [], images = [] } = state;
-    const { locale = 'en', currentSkill, project } = config.configurable;
+    const { locale = 'en', currentSkill, project, runtimeConfig } = config.configurable;
 
     // Extract customInstructions from project if available
     const customInstructions = project?.customInstructions;
@@ -69,9 +69,13 @@ export class WebSearch extends BaseSkill {
     // Set current step
     config.metadata.step = { name: 'analyzeQuery' };
 
-    // process projectId based knowledge base search
+    // Only enable knowledge base search if both projectId AND runtimeConfig.enabledKnowledgeBase are true
     const projectId = project?.projectId;
-    const enableKnowledgeBaseSearch = !!projectId;
+    const enableKnowledgeBaseSearch = !!projectId && !!runtimeConfig?.enabledKnowledgeBase;
+
+    this.engine.logger.log(
+      `ProjectId: ${projectId}, Enable KB Search: ${enableKnowledgeBaseSearch}`,
+    );
 
     // Force enable web search
     config.configurable.tplConfig = {


### PR DESCRIPTION
…nowledge base search

- Updated multiple skill components to include runtimeConfig, enhancing the logic for enabling knowledge base search based on projectId and runtimeConfig.enabledKnowledgeBase.
- Improved logging to provide better insights into the knowledge base search status.
- Ensured compliance with React performance optimizations and code style guidelines, including optional chaining and nullish coalescing.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
