### PR TITLE
fix(web): remove auto redirect in home page

### DIFF
--- a/apps/web/src/pages/canvas/index.tsx
+++ b/apps/web/src/pages/canvas/index.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { Canvas } from '@refly-packages/ai-workspace-common/components/canvas';
 import { Button, Empty } from 'antd';
 import { useTranslation } from 'react-i18next';
@@ -7,22 +7,14 @@ import { useCreateCanvas } from '@refly-packages/ai-workspace-common/hooks/canva
 import { useSiderStoreShallow } from '@refly-packages/ai-workspace-common/stores/sider';
 import { SiderPopover } from '@refly-packages/ai-workspace-common/components/sider/popover';
 import { AiOutlineMenuUnfold } from 'react-icons/ai';
-import { useEffect } from 'react';
 const CanvasPage = () => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
-
   const { canvasId = '' } = useParams();
   const { debouncedCreateCanvas, isCreating } = useCreateCanvas();
-  const { collapse, setCollapse, canvasList } = useSiderStoreShallow((state) => ({
-    canvasList: state.canvasList ?? [],
+  const { collapse, setCollapse } = useSiderStoreShallow((state) => ({
     collapse: state.collapse,
     setCollapse: state.setCollapse,
   }));
-
-  useEffect(() => {
-    // Removed automatic navigation logic
-  }, [canvasId, canvasList, navigate]);
 
   return canvasId && canvasId !== 'empty' ? (
     <Canvas canvasId={canvasId} />

--- a/apps/web/src/pages/canvas/index.tsx
+++ b/apps/web/src/pages/canvas/index.tsx
@@ -21,9 +21,7 @@ const CanvasPage = () => {
   }));
 
   useEffect(() => {
-    if (canvasId === 'empty' && canvasList.length > 0) {
-      navigate(`/canvas/${canvasList[0].id}`, { replace: true });
-    }
+    // Removed automatic navigation logic
   }, [canvasId, canvasList, navigate]);
 
   return canvasId && canvasId !== 'empty' ? (

--- a/packages/ai-workspace-common/src/components/home-redirect/index.tsx
+++ b/packages/ai-workspace-common/src/components/home-redirect/index.tsx
@@ -4,7 +4,6 @@ import { SuspenseLoading } from '@refly-packages/ai-workspace-common/components/
 import { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
 import { useUserStoreShallow } from '@refly-packages/ai-workspace-common/stores/user';
-import { useCanvasStore } from '@refly-packages/ai-workspace-common/stores/canvas';
 
 export const HomeRedirect = ({ defaultNode }: { defaultNode: ReactNode }) => {
   const [element, setElement] = useState<ReactNode | null>(null);
@@ -14,12 +13,6 @@ export const HomeRedirect = ({ defaultNode }: { defaultNode: ReactNode }) => {
 
   const handleHomeRedirect = async () => {
     if (isLogin) {
-      const { currentCanvasId } = useCanvasStore.getState();
-
-      if (currentCanvasId) {
-        return <Navigate to={`/canvas/${currentCanvasId}`} replace />;
-      }
-
       return <Navigate to={'/canvas/empty'} replace />;
     }
     return defaultNode;


### PR DESCRIPTION
# Summary
This PR removes the automatic navigation logic from the canvas page, giving users more control over their navigation flow. The change was made in`apps/web/src/pages/canvas/index.tsx` by removing the useEffect hook that previously handled automatic redirects.

# Impact Areas
- Free-form Canvas Interface
# Checklist
- I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- I ran`cd web && npx lint-staged` to appease the lint gods
