### PR TITLE
feat(color-picker): add white color to preset colors and update prici…

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/shared/color-picker.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/shared/color-picker.tsx
@@ -15,6 +15,7 @@ export const presetColors = [
   '#fee1c7', // Orange
   '#ffede7', // Pink
   '#f2f4f7', // Gray
+  '#ffffff', // White
 ];
 
 interface CommonColorPickerProps {

--- a/packages/ai-workspace-common/src/components/settings/subscribe-modal/priceContent.tsx
+++ b/packages/ai-workspace-common/src/components/settings/subscribe-modal/priceContent.tsx
@@ -274,9 +274,9 @@ export const PriceContent = (props: { source: PriceSource }) => {
   const createFeatures = (plan: 'free' | 'plus' | 'pro' | 'max'): ModelFeatures[] => {
     const configs = {
       free: {
-        t1Count: 3,
-        t2Count: 30,
-        fileLimit: 10,
+        t1Count: 5,
+        t2Count: 50,
+        fileLimit: 100,
         t1Period: 'daily',
         t2Period: 'daily',
         fileParseLimit: 50,


### PR DESCRIPTION
…ng plan limits

- Added '#ffffff' (White) to the presetColors array in the color picker component.
- Updated the pricing plan limits in the PriceContent component to enhance feature offerings: increased t1Count to 5, t2Count to 50, and fileLimit to 100.
- Ensured compliance with React performance optimizations and safe property access practices.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
