### PR TITLE
#767 Remove the dotted border

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/launchpad/context-manager/context-item.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/context-manager/context-item.tsx
@@ -91,7 +91,6 @@ export const ContextItem = ({
             'border-green-500': isActive,
             'border-red-300 bg-red-50 text-red-500': isLimit,
             'bg-gray-100 border-gray-200': disabled,
-            'border-dashed': item?.isPreview,
           },
         )}
         onClick={() => handleItemClick()}


### PR DESCRIPTION
Fix #767: Remove dotted border from preview context items

# Summary

This change removes the dotted border styling previously applied to context items marked as 'preview' in the context panel.

**Motivation and Context:**
As reported in issue #767, the dotted border on preview context items was perceived as visually inconsistent or unnecessary, potentially causing visual clutter. Removing this specific border style improves the clarity and consistency of the context panel UI.

**Issue Fixed:** Fixes #767

**Dependencies:**
No new dependencies are required for this change.

# Impact Areas

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [x] Knowledge Base Integration & RAG (Assuming context items relate to knowledge)
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [x] Free-form Canvas Interface (This component is part of the canvas UI)
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| *(Please add a screenshot/video showing a preview context item with the dotted border)* | *(Please add a screenshot/video showing the same preview context item

https://github.com/user-attachments/assets/d2b616c9-583f-4e8b-a7d8-8b33473eea5c

 without the dotted border)* |

# Checklist

> [!IMPORTANT]
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. *(Note: For simple style changes like this, "test" might refer to manual verification)*
- [ ] I've updated the documentation accordingly. *(Unchecked based on your input)*
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods