### PR TITLE
feat(canvas): support displaying image nodes without border and title

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/image.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/image.tsx
@@ -35,6 +35,8 @@ export const ImageNode = memo(
   ({ id, data, isPreview, selected, hideActions, hideHandles, onNodeClick }: ImageNodeProps) => {
     const { metadata } = data ?? {};
     const imageUrl = metadata?.imageUrl;
+    const showBorder = metadata?.showBorder ?? false;
+    const showTitle = metadata?.showTitle ?? true;
     const [isHovered, setIsHovered] = useState(false);
     const [isPreviewModalVisible, setIsPreviewModalVisible] = useState(false);
     const { handleMouseEnter: onHoverStart, handleMouseLeave: onHoverEnd } = useNodeHoverEffect(id);
@@ -210,7 +212,7 @@ export const ImageNode = memo(
             className={`
                 w-full
                 h-full
-                ${getNodeCommonStyles({ selected: !isPreview && selected, isHovered })}
+                ${showBorder ? getNodeCommonStyles({ selected: !isPreview && selected, isHovered }) : ''}
               `}
           >
             {!isPreview && !hideHandles && (
@@ -235,15 +237,21 @@ export const ImageNode = memo(
             )}
 
             <div className={cn('flex flex-col h-full relative p-3 box-border', MAX_HEIGHT_CLASS)}>
-              <NodeHeader
-                title={data.title}
-                Icon={IconImage}
-                iconBgColor="#02b0c7"
-                canEdit={!readonly}
-                updateTitle={onTitleChange}
-              />
-
-              <div className="w-full rounded-lg overflow-y-auto">
+              <div className="relative w-full rounded-lg overflow-y-auto">
+                {showTitle && isHovered && (
+                  <div
+                    className="absolute top-0 left-0 right-0 z-10 rounded-t-lg px-1"
+                    style={{ textShadow: '0px 0px 3px #ffffff' }}
+                  >
+                    <NodeHeader
+                      title={data.title}
+                      Icon={IconImage}
+                      iconBgColor="#02b0c7"
+                      canEdit={!readonly}
+                      updateTitle={onTitleChange}
+                    />
+                  </div>
+                )}
                 <img
                   onClick={readonly ? handlePreview : undefined}
                   src={imageUrl}

--- a/packages/ai-workspace-common/src/components/canvas/nodes/shared/types.ts
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/shared/types.ts
@@ -115,6 +115,8 @@ export type ImageNodeMeta = {
   imageType: string;
   imageUrl: string;
   storageKey: string;
+  showBorder?: boolean;
+  showTitle?: boolean;
   sizeMode?: 'compact' | 'adaptive';
   style?: React.CSSProperties;
   originalWidth?: number;

--- a/packages/ai-workspace-common/src/components/common/image-preview.tsx
+++ b/packages/ai-workspace-common/src/components/common/image-preview.tsx
@@ -41,6 +41,7 @@ export const ImagePreview = ({
         visible: isPreviewModalVisible,
         src: imageUrl,
         destroyOnClose: true,
+        title: imageTitle,
         onVisibleChange: (value) => {
           setIsPreviewModalVisible(value);
         },


### PR DESCRIPTION
Fixes #735

# Summary

This pull request implements the functionality to optionally hide the border and title on Image Nodes within the canvas. This enhancement addresses issue #735, providing users with greater flexibility in customizing the appearance of image nodes for a cleaner or more integrated visual layout.

The changes include:
- Adding `showBorder` and `showTitle` optional properties to the `ImageNodeMeta` type.
- Modifying the `ImageNode` component to read these properties from metadata.
- Conditionally applying the border styles and rendering the `NodeHeader` (title) based on the `showBorder` and `showTitle` metadata properties respectively.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [x] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| *(Add screenshot showing an image node with border/title)*   | *(Add screenshot showing an image node without border/title)*  |

![image](https://github.com/user-attachments/assets/8d645835-795d-4eab-9e1e-1e3ab2592bd4)
![image](https://github.com/user-attachments/assets/00ec9b97-4836-4618-9fe4-400059c24016)


# Checklist

> [!IMPORTANT]
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods