### PR TITLE
feat(skill): add current time to system prompts

### DIFF
--- a/packages/skill-template/src/scheduler/module/commonQnA/prompt.ts
+++ b/packages/skill-template/src/scheduler/module/commonQnA/prompt.ts
@@ -9,7 +9,10 @@ import { buildContextDisplayInstruction } from '../common/context';
 import { buildCommonQnAExamples, buildCommonQnAChatHistoryExamples } from './examples';
 import { buildCitationRules } from '../common/citationRules';
 import { buildLocaleFollowInstruction } from '../common/locale-follow';
-import { buildQueryIntentAnalysisInstruction } from '../../utils/common-prompt';
+import {
+  buildQueryIntentAnalysisInstruction,
+  buildCurrentTimeInfo,
+} from '../../utils/common-prompt';
 import { buildFormatDisplayInstruction } from '../common/format';
 import {
   buildSimpleDetailedExplanationInstruction,
@@ -18,6 +21,8 @@ import {
 
 export const buildNoContextCommonQnASystemPrompt = () => {
   return `You are an AI assistant developed by Refly. Your task is to provide helpful, accurate, and concise information to users' queries.
+
+${buildCurrentTimeInfo()}
 
 Guidelines:
 1. ALWAYS directly address the user's specific question
@@ -47,6 +52,8 @@ ${buildSpecificQueryInstruction()}
 
 export const buildContextualCommonQnASystemPrompt = () => {
   const systemPrompt = `You are an advanced AI assistant developed by Refly, specializing in knowledge management, reading comprehension, and answering questions based on context. Your core mission is to help users effectively understand and utilize information.
+
+  ${buildCurrentTimeInfo()}
 
   ## Query Priority and Context Relevance:
   1. ALWAYS prioritize the user's original query intent above all else

--- a/packages/skill-template/src/scheduler/module/librarySearch/prompt.ts
+++ b/packages/skill-template/src/scheduler/module/librarySearch/prompt.ts
@@ -8,7 +8,10 @@ import { buildLibrarySearchExamples, buildLibrarySearchChatHistoryExamples } fro
 import { buildQueryPriorityInstruction, buildSpecificQueryInstruction } from '../common/query';
 import { buildContextFormat } from './context';
 import { buildLocaleFollowInstruction } from '../common/locale-follow';
-import { buildQueryIntentAnalysisInstruction } from '../../utils/common-prompt';
+import {
+  buildQueryIntentAnalysisInstruction,
+  buildCurrentTimeInfo,
+} from '../../utils/common-prompt';
 import { buildFormatDisplayInstruction } from '../common/format';
 import {
   buildSimpleDetailedExplanationInstruction,
@@ -17,6 +20,8 @@ import {
 
 export const buildLibrarySearchSystemPrompt = (_locale: string, _needPrepareContext: boolean) => {
   const systemPrompt = `You are an AI assistant developed by Refly, specializing in knowledge base search and information retrieval. Your task is to provide accurate answers based on the organization's internal knowledge base.
+
+${buildCurrentTimeInfo()}
 
 ${buildCitationRules()}
 

--- a/packages/skill-template/src/scheduler/module/webSearch/prompt.ts
+++ b/packages/skill-template/src/scheduler/module/webSearch/prompt.ts
@@ -9,7 +9,10 @@ import { buildWebSearchChatHistoryExamples } from './examples';
 import { buildQueryPriorityInstruction, buildSpecificQueryInstruction } from '../common/query';
 import { buildContextFormat } from './context';
 import { buildLocaleFollowInstruction } from '../common/locale-follow';
-import { buildQueryIntentAnalysisInstruction } from '../../utils/common-prompt';
+import {
+  buildQueryIntentAnalysisInstruction,
+  buildCurrentTimeInfo,
+} from '../../utils/common-prompt';
 import { buildFormatDisplayInstruction } from '../common/format';
 import {
   buildSimpleDetailedExplanationInstruction,
@@ -18,6 +21,8 @@ import {
 
 export const buildWebSearchSystemPrompt = (_locale: string, _needPrepareContext: boolean) => {
   const systemPrompt = `You are an AI assistant developed by Refly, specializing in providing accurate information based on web search results and internal knowledge base. Your task is to synthesize information from multiple sources to provide comprehensive, actionable, and accurate answers.
+
+${buildCurrentTimeInfo()}
 
 ${buildCitationRules()}
 

--- a/packages/skill-template/src/scheduler/utils/common-prompt.ts
+++ b/packages/skill-template/src/scheduler/utils/common-prompt.ts
@@ -18,3 +18,19 @@ export const buildQueryIntentAnalysisInstruction = () => {
    - Fill gaps with reliable common knowledge when needed
    - Maintain focus on user's primary goal`;
 };
+
+/**
+ * Provides the current time information to be included in system prompts
+ * @returns A string with current time information in various formats
+ */
+export const buildCurrentTimeInfo = () => {
+  const now = new Date();
+
+  // Format: YYYY-MM-DD HH:MM:SS in UTC and local time
+  const utcTimeString = now.toISOString();
+  const localTimeString = now.toString();
+
+  return `## Current Time Information
+Current UTC time: ${utcTimeString}
+Current local time: ${localTimeString}`;
+};


### PR DESCRIPTION
Fix: Add current time to system prompts #732

# Summary

This pull request introduces the current time information into the system prompts for various AI assistant functionalities. This enhancement allows the AI to have time-sensitive context during interactions, which can be beneficial for providing more relevant and accurate responses, especially for time-dependent queries. The `buildCurrentTimeInfo` function in `common-prompt.ts` now generates a string containing the current UTC and local times, which is then integrated into the system prompts of the Common QnA, Library Search, and Web Search modules.

# Impact Areas

- [x] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| No current time information in system prompts. | Current UTC and local time are included in the system prompts. |

# Checklist

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods