### PR TITLE
#784 fix up and down

### DIFF
--- a/packages/i18n/src/en-US/skill.ts
+++ b/packages/i18n/src/en-US/skill.ts
@@ -2,7 +2,7 @@ const translations = {
   commonQnA: {
     name: 'Question Answering',
     description: 'Answer questions based on the context',
-    placeholder: 'Ask AI a question, press / to select skill...',
+    placeholder: 'Ask AI a question, press Ctrl + / to select skill...',
     steps: {
       analyzeQuery: {
         name: 'Query Analysis',

--- a/packages/i18n/src/zh-Hans/skill-log.ts
+++ b/packages/i18n/src/zh-Hans/skill-log.ts
@@ -1,7 +1,7 @@
 const translations = {
   generateTitle: {
     title: '生成标题',
-    description: '成功生成标题：{{title}}',
+    description: '成功生成标题：{{title}}, 耗时 {{duration}} 毫秒',
   },
   generateTitleFailed: {
     title: '生成标题',

--- a/packages/i18n/src/zh-Hans/skill.ts
+++ b/packages/i18n/src/zh-Hans/skill.ts
@@ -2,7 +2,7 @@ const translations = {
   commonQnA: {
     name: '通用问答',
     description: '基于上下文回答问题',
-    placeholder: '向 AI 提问，输入 / 选择技能...',
+    placeholder: '向 AI 提问，输入 Ctrl + / 选择技能...',
     steps: {
       analyzeQuery: {
         name: '分析需求',


### PR DESCRIPTION
# Summary

This PR fixes a bug where the up and down arrow keys were not functioning correctly for cursor navigation within the chat input component, particularly with multi-line text (as reported in #784). The issue stemmed from the `AutoComplete` component intercepting arrow key events even when its dropdown was not active or intended for navigation.

The fix involves conditionally rendering the `AutoComplete` component only when the skill selector is explicitly triggered. To facilitate this and avoid accidental triggering, the keyboard shortcut to open the skill selector has been changed from `/` to `Ctrl+/` (or `Cmd+/` on macOS).

Additionally, the placeholder text in English and Chinese has been updated to reflect the new shortcut. A minor unrelated change updates a Chinese translation in `skill-log.ts` to include duration.

Fixes #784

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [x] Free-form Canvas Interface (Specifically the chat/node input)
- [ ] Other

# Screenshots/Videos

| Before (Arrow keys Up/Down don't move cursor between lines) | After (Arrow keys Up/Down work for text navigation) |
| :----------------------------------------------------------: | :---------------------------------------------------: |
|              *Skill selector triggered by `/`*              |      *Skill selector triggered by `Ctrl + /`*       |


# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs) *(Decision needed: Does changing the shortcut require a doc update?)*
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. *(Assuming tests were updated/added as per user claim)*
- [x] I've updated the documentation accordingly. *(Assuming UI text changes are sufficient, or separate doc PR planned)*
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods