### PR TITLE
feat(canvas): increase maximum nodes per canvas and adjust warning threshold

### DIFF
--- a/packages/ai-workspace-common/src/hooks/canvas/use-add-node.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-add-node.ts
@@ -21,9 +21,9 @@ import { CanvasNode } from '@refly-packages/ai-workspace-common/components/canva
 import { adoptUserNodes } from '@xyflow/system';
 
 // Define the maximum number of nodes allowed in a canvas
-const MAX_NODES_PER_CANVAS = 100;
-// Define the threshold at which to show warning (e.g., 90% of max)
-const WARNING_THRESHOLD = 0.9;
+const MAX_NODES_PER_CANVAS = 500;
+// Define the threshold at which to show warning (e.g., 98% of max)
+const WARNING_THRESHOLD = 0.98;
 
 const deduplicateNodes = (nodes: any[]) => {
   const uniqueNodesMap = new Map();


### PR DESCRIPTION
# Summary

- Updated the maximum number of nodes allowed in a canvas from 100 to 500.
- Adjusted the warning threshold from 90% to 98% of the maximum nodes to enhance user experience.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
