### PR TITLE
fix paste error

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/launchpad/chat-input.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/chat-input.tsx
@@ -267,7 +267,6 @@ const ChatInputComponent = forwardRef<HTMLDivElement, ChatInputProps>(
           isDragging && 'ring-2 ring-green-500 ring-opacity-50 rounded-lg',
           readonly && 'opacity-70 cursor-not-allowed',
         )}
-        onPaste={handlePaste}
         onDragOver={(e) => {
           e.preventDefault();
           e.stopPropagation();
@@ -331,18 +330,7 @@ const ChatInputComponent = forwardRef<HTMLDivElement, ChatInputProps>(
               value={query ?? ''}
               onChange={handleInputChange}
               onKeyDownCapture={handleKeyDown}
-              onPaste={(e) => {
-                if (readonly) return;
-                if (e.clipboardData?.items) {
-                  for (const item of e.clipboardData.items) {
-                    if (item.type.startsWith('image/')) {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      break;
-                    }
-                  }
-                }
-              }}
+              onPaste={handlePaste}
               className={cn(
                 '!m-0 bg-transparent outline-none box-border border-none resize-none focus:outline-none focus:shadow-none focus:border-none',
                 inputClassName,
@@ -378,18 +366,7 @@ const ChatInputComponent = forwardRef<HTMLDivElement, ChatInputProps>(
             value={query ?? ''}
             onChange={handleInputChange}
             onKeyDownCapture={handleKeyDown}
-            onPaste={(e) => {
-              if (readonly) return;
-              if (e.clipboardData?.items) {
-                for (const item of e.clipboardData.items) {
-                  if (item.type.startsWith('image/')) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    break;
-                  }
-                }
-              }
-            }}
+            onPaste={handlePaste}
             className={cn(
               '!m-0 bg-transparent outline-none box-border border-none resize-none focus:outline-none focus:shadow-none focus:border-none',
               inputClassName,


### PR DESCRIPTION
# Summary

Fix issue with image pasting functionality in ChatInput component. Previously, users were unable to paste images into the chat input as the TextArea's onPaste event handler only prevented the default behavior without actually uploading the image. After fixing this initial issue, a secondary problem emerged where each paste operation would upload the same image twice. This PR addresses both issues by:

1. Properly configuring the TextArea components to use the handlePaste function
2. Removing the duplicate paste handler from the parent div to prevent double uploads

This ensures that images can be properly pasted into the chat input and are uploaded exactly once per paste operation.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [x] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [x] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| Unable to paste images into chat input | Images can be pasted normally |
| Images uploaded twice when pasted | Images uploaded once per paste operation |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
