### PR TITLE
fix(web): hide slide button in shared canvases

### DIFF
--- a/apps/api/src/utils/stream.ts
+++ b/apps/api/src/utils/stream.ts
@@ -1,4 +1,11 @@
-export async function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+export async function streamToBuffer(
+  stream: NodeJS.ReadableStream | null | undefined,
+): Promise<Buffer> {
+  // Return empty buffer if stream is null or undefined
+  if (!stream) {
+    return Buffer.alloc(0);
+  }
+
   const buffers = [];
 
   for await (const data of stream) {
@@ -8,6 +15,8 @@ export async function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buf
   return Buffer.concat(buffers);
 }
 
-export async function streamToString(stream: NodeJS.ReadableStream): Promise<string> {
+export async function streamToString(
+  stream: NodeJS.ReadableStream | null | undefined,
+): Promise<string> {
   return (await streamToBuffer(stream)).toString();
 }

--- a/apps/web/src/pages/pages/components/PageLayout.tsx
+++ b/apps/web/src/pages/pages/components/PageLayout.tsx
@@ -80,7 +80,7 @@ const PageLayout: React.FC<PageLayoutProps> = ({
           {/* Button to show minimap */}
           {!showMinimap && (
             <div className="fixed left-0 top-60 z-500">
-              <Tooltip title={t('pages.preview.navigationDirectory')} placement="right">
+              <Tooltip title={t('pages.components.navigationDirectory')} placement="right">
                 <Button
                   type="default"
                   icon={<UnorderedListOutlined />}

--- a/apps/web/src/pages/pages/index.tsx
+++ b/apps/web/src/pages/pages/index.tsx
@@ -736,7 +736,7 @@ export function SlideshowEdit(props: PageEditProps) {
                 size={minimalMode ? 'small' : 'middle'}
                 onClick={handleShare}
                 icon={<ShareAltOutlined />}
-                className={`flex items-center mr-2 text-gray-600 hover:!text-green-600 hover:bg-gray-50 ${
+                className={`flex items-center text-gray-600 hover:!text-green-600 hover:bg-gray-50 ${
                   minimalMode ? 'text-xs' : ''
                 }`}
               >

--- a/packages/ai-workspace-common/src/components/canvas/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/index.tsx
@@ -455,7 +455,9 @@ const Flow = memo(({ canvasId }: { canvasId: string }) => {
   }, [provider?.status]);
 
   useEffect(() => {
-    getPageByCanvasId();
+    if (!readonly) {
+      getPageByCanvasId();
+    }
     if (showSlideshow) {
       setShowSlideshow(false);
     }

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/index.tsx
@@ -22,6 +22,7 @@ import { Slideshow } from '@refly-packages/ai-workspace-common/components/canvas
 import { EnhancedSkillResponse } from './skill-response/enhanced-skill-response';
 import { useReactFlow } from '@xyflow/react';
 import { useSearchParams } from 'react-router-dom';
+import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 
 // DnD item type constant
 const ITEM_TYPE = 'node-preview';
@@ -362,6 +363,7 @@ export const NodePreviewContainer = memo(
     canvasId: string;
     nodes: CanvasNode<any>[];
   }) => {
+    const { readonly } = useCanvasContext();
     const { getNodes } = useReactFlow<CanvasNode<any>>();
     const { rawNodePreviews, reorderNodePreviews, showReflyPilot, showSlideshow } =
       useCanvasStoreShallow((state) => ({
@@ -415,7 +417,7 @@ export const NodePreviewContainer = memo(
       <DndProvider backend={HTML5Backend}>
         <div className="flex h-full w-full">
           <ScrollingComponent {...scrollingComponentProps}>
-            {showSlideshow && <Slideshow canvasId={canvasId} />}
+            {showSlideshow && !readonly && <Slideshow canvasId={canvasId} />}
             {showReflyPilot && <ReflyPilot />}
             {nodePreviewsRendered}
           </ScrollingComponent>

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/buttons.tsx
@@ -16,6 +16,7 @@ import { useHoverCard } from '@refly-packages/ai-workspace-common/hooks/use-hove
 import { useExportCanvasAsImage } from '@refly-packages/ai-workspace-common/hooks/use-export-canvas-as-image';
 import { useCanvasStoreShallow } from '@refly-packages/ai-workspace-common/stores/canvas';
 import { IconAskAI } from '@refly-packages/ai-workspace-common/components/common/icon';
+import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 
 export const ToolbarButtons = memo(
   ({
@@ -35,6 +36,7 @@ export const ToolbarButtons = memo(
     const { setNodeCenter } = useNodePosition();
     const { getNodes } = useReactFlow();
     const { hoverCardEnabled } = useHoverCard();
+    const { readonly } = useCanvasContext();
 
     const { showReflyPilot, setShowReflyPilot, showSlideshow, setShowSlideshow } =
       useCanvasStoreShallow((state) => ({
@@ -132,15 +134,18 @@ export const ToolbarButtons = memo(
 
     return (
       <>
+        {!readonly && (
+          <div className="flex items-center h-9 bg-[#ffffff] rounded-lg px-2 border border-solid border-1 border-[#EAECF0] box-shadow-[0px_2px_6px_0px_rgba(0,0,0,0.1)]">
+            {hoverCardEnabled ? (
+              <HoverCard {...pilotButtonConfig}>{pilotButton}</HoverCard>
+            ) : (
+              <Tooltip title={pilotButtonConfig.title}>{pilotButton}</Tooltip>
+            )}
+          </div>
+        )}
+
         <div className="flex items-center h-9 bg-[#ffffff] rounded-lg px-2 border border-solid border-1 border-[#EAECF0] box-shadow-[0px_2px_6px_0px_rgba(0,0,0,0.1)]">
-          {!hoverCardEnabled ? (
-            <HoverCard {...pilotButtonConfig}>{pilotButton}</HoverCard>
-          ) : (
-            <Tooltip title={pilotButtonConfig.title}>{pilotButton}</Tooltip>
-          )}
-        </div>
-        <div className="flex items-center h-9 bg-[#ffffff] rounded-lg px-2 border border-solid border-1 border-[#EAECF0] box-shadow-[0px_2px_6px_0px_rgba(0,0,0,0.1)]">
-          <Tooltip title={t('canvas.toolbar.slideshow')}>{slideshowButton}</Tooltip>
+          {!readonly && <Tooltip title={t('canvas.toolbar.slideshow')}>{slideshowButton}</Tooltip>}
 
           <Popover
             open={searchOpen}

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -1173,7 +1173,7 @@ const translations = {
       hideTemplates: 'Hide Templates',
       showTemplates: 'Show Templates',
       exportImage: 'Export Image',
-      slideshow: 'Slide',
+      slideshow: 'Slideshow',
       copyLink: 'Copy Link',
       createWebsite: 'Create Website Node',
       createWebsiteDescription: 'Create a website node to embed a website in your canvas',


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
