### PR TITLE
fix(api): remove outdated execution timeout logic

### DIFF
--- a/apps/api/src/modules/action/action.service.ts
+++ b/apps/api/src/modules/action/action.service.ts
@@ -30,22 +30,6 @@ export class ActionService {
       throw new ActionResultNotFoundError();
     }
 
-    // If the result is executing and the last updated time is more than 3 minutes ago,
-    // mark it as failed.
-    if (result.status === 'executing' && result.updatedAt < new Date(Date.now() - 1000 * 60 * 3)) {
-      const updatedResult = await this.prisma.actionResult.update({
-        where: {
-          pk: result.pk,
-          status: 'executing',
-        },
-        data: {
-          status: 'failed',
-          errors: `["Execution timeout"]`,
-        },
-      });
-      return updatedResult;
-    }
-
     const modelList = await this.subscriptionService.getModelList();
     const modelInfo = modelList.find((model) => model.name === result.modelName);
 


### PR DESCRIPTION
# Summary

- Eliminated the logic that marked executing results as failed after 3 minutes.
- Streamlined the action service for improved clarity and maintainability.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
