### PR TITLE
fix(api): replace entities when duplicating skill responses nodes in canvases

### DIFF
--- a/packages/ai-workspace-common/src/requests/types.gen.ts
+++ b/packages/ai-workspace-common/src/requests/types.gen.ts
@@ -2622,6 +2622,10 @@ export type DuplicateShareRequest = {
    * Share ID
    */
   shareId: string;
+  /**
+   * Project ID to duplicate the share to
+   */
+  projectId?: string;
 };
 
 export type DuplicateShareResponse = BaseResponse & {

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -4941,6 +4941,9 @@ components:
         shareId:
           type: string
           description: Share ID
+        projectId:
+          type: string
+          description: Project ID to duplicate the share to
     DuplicateShareResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -3657,6 +3657,10 @@ export const DuplicateShareRequestSchema = {
       type: 'string',
       description: 'Share ID',
     },
+    projectId: {
+      type: 'string',
+      description: 'Project ID to duplicate the share to',
+    },
   },
 } as const;
 

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -2622,6 +2622,10 @@ export type DuplicateShareRequest = {
    * Share ID
    */
   shareId: string;
+  /**
+   * Project ID to duplicate the share to
+   */
+  projectId?: string;
 };
 
 export type DuplicateShareResponse = BaseResponse & {


### PR DESCRIPTION
# Summary

- Refactored duplicateSharedDocument, duplicateSharedResource, duplicateSharedCodeArtifact, duplicateSharedSkillResponse, and duplicateSharedCanvas methods to accept a DuplicateShareRequest parameter, allowing for projectId to be passed along.
- Updated related OpenAPI schema and types to include projectId in the DuplicateShareRequest.
- Ensured safe property access and consistent handling of parameters throughout the service methods.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
