### PR TITLE
fix(document): add isShareDocumentLoading to context and update loadi…

### DIFF
--- a/packages/ai-workspace-common/src/components/document/index.tsx
+++ b/packages/ai-workspace-common/src/components/document/index.tsx
@@ -413,7 +413,7 @@ const DocumentEditorHeader = memo(
 const DocumentBody = memo(
   ({ docId }: { docId: string }) => {
     const { t } = useTranslation();
-    const { readonly, isLoading, provider } = useDocumentContext();
+    const { readonly, isLoading, isShareDocumentLoading, provider } = useDocumentContext();
     const [searchParams] = useSearchParams();
     const isMaximized = searchParams.get('isMaximized') === 'true';
 
@@ -421,14 +421,15 @@ const DocumentBody = memo(
       config: state.config[docId],
     }));
     const hasDocumentSynced = config?.remoteSyncedAt > 0 && config?.localSyncedAt > 0;
-    const isStillLoading = (isLoading && !hasDocumentSynced) || provider?.status !== 'connected';
+    const isStillLoading =
+      (isLoading && !hasDocumentSynced) || (!readonly && provider.status !== 'connected');
 
     return (
       <div className="overflow-auto flex-grow">
         <Spin
           className="document-editor-spin"
           tip={t('knowledgeBase.note.connecting')}
-          loading={isStillLoading}
+          loading={readonly ? isShareDocumentLoading : isStillLoading}
           style={{ height: '100%', width: '100%' }}
         >
           <div className="ai-note-editor">

--- a/packages/ai-workspace-common/src/components/document/index.tsx
+++ b/packages/ai-workspace-common/src/components/document/index.tsx
@@ -421,8 +421,7 @@ const DocumentBody = memo(
       config: state.config[docId],
     }));
     const hasDocumentSynced = config?.remoteSyncedAt > 0 && config?.localSyncedAt > 0;
-    const isStillLoading =
-      (isLoading && !hasDocumentSynced) || (!readonly && provider?.status !== 'connected');
+    const isStillLoading = (isLoading && !hasDocumentSynced) || provider?.status !== 'connected';
 
     return (
       <div className="overflow-auto flex-grow">

--- a/packages/ai-workspace-common/src/components/document/index.tsx
+++ b/packages/ai-workspace-common/src/components/document/index.tsx
@@ -422,7 +422,7 @@ const DocumentBody = memo(
     }));
     const hasDocumentSynced = config?.remoteSyncedAt > 0 && config?.localSyncedAt > 0;
     const isStillLoading =
-      (isLoading && !hasDocumentSynced) || (!readonly && provider.status !== 'connected');
+      (isLoading && !hasDocumentSynced) || (!readonly && provider?.status !== 'connected');
 
     return (
       <div className="overflow-auto flex-grow">

--- a/packages/ai-workspace-common/src/context/document.tsx
+++ b/packages/ai-workspace-common/src/context/document.tsx
@@ -15,6 +15,7 @@ interface DocumentContextType {
   provider: HocuspocusProvider | null;
   localProvider: IndexeddbPersistence | null;
   isLoading: boolean;
+  isShareDocumentLoading: boolean;
   readonly: boolean;
 }
 
@@ -55,7 +56,8 @@ export const DocumentProvider = ({
     }));
 
   // Fetch document data from API when in readonly mode
-  const { data: documentData } = useFetchShareData<Document>(shareId);
+  const { data: documentData, loading: isShareDocumentLoading } =
+    useFetchShareData<Document>(shareId);
 
   // Set document data from API response when in readonly mode
   useEffect(() => {
@@ -244,9 +246,10 @@ export const DocumentProvider = ({
       localProvider,
       ydoc: doc,
       isLoading,
+      isShareDocumentLoading,
       readonly,
     }),
-    [docId, provider, localProvider, doc, isLoading, readonly],
+    [docId, provider, localProvider, doc, isLoading, readonly, isShareDocumentLoading],
   );
 
   return <DocumentContext.Provider value={value}>{children}</DocumentContext.Provider>;


### PR DESCRIPTION
…ng logic

- Introduced isShareDocumentLoading to the DocumentContextType for better loading state management.
- Updated DocumentBody component to conditionally render loading state based on readonly status and isShareDocumentLoading.
- Ensured safe property access and improved loading logic for document synchronization.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
