### PR TITLE
fix(api): add providers package to tsconfig and register aliases

### DIFF
--- a/apps/api/src/register-aliases.ts
+++ b/apps/api/src/register-aliases.ts
@@ -21,6 +21,7 @@ if (!getPreloadModules().includes('tsconfig-paths/register')) {
     '@refly/errors': path.resolve(__dirname, '../../../packages/errors/dist'),
     '@refly/common-types': path.resolve(__dirname, '../../../packages/common-types/dist'),
     '@refly/utils': path.resolve(__dirname, '../../../packages/utils/dist'),
+    '@refly/providers': path.resolve(__dirname, '../../../packages/providers/dist'),
     '@refly/skill-template': path.resolve(__dirname, '../../../packages/skill-template/dist'),
     '@': __dirname,
   });

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -34,6 +34,7 @@
   "references": [
     { "path": "../../packages/errors" },
     { "path": "../../packages/i18n" },
+    { "path": "../../packages/providers" },
     { "path": "../../packages/openapi-schema" },
     { "path": "../../packages/common-types" },
     { "path": "../../packages/utils" },

--- a/packages/providers/tsconfig.json
+++ b/packages/providers/tsconfig.json
@@ -24,9 +24,6 @@
     "baseUrl": "./",
     "rootDir": "./src",
     "sourceRoot": "/",
-    "paths": {
-      "@refly-packages/*": ["../*/src"]
-    },
     "composite": true,
     "noEmit": false,
     "declaration": true,


### PR DESCRIPTION
# Summary

- Updated tsconfig.json to include the providers package reference.
- Registered the providers package alias in register-aliases.ts for improved module resolution.
- Removed unused paths configuration from providers' tsconfig.json to streamline settings.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
