### PR TITLE
feat(canvas): enhance component styling and functionality

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/empty-guide/templates-guide.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/empty-guide/templates-guide.tsx
@@ -74,7 +74,7 @@ export const TemplatesGuide = ({ canvasId }: { canvasId: string }) => {
               </div>
             ))}
           <div
-            className="text-center font-bold bg-white rounded-lg m-2 flex flex-col items-center justify-center cursor-pointer shadow-sm hover:shadow-[0_4px_12px_0_rgba(0,0,0,0.12)] transform hover:-translate-y-0.5 transition-all duration-200 ease-in-out text-gray-500 hover:text-green-600 h-[260px]"
+            className="text-center font-bold bg-white rounded-lg m-2 flex flex-col items-center justify-center cursor-pointer shadow-sm hover:shadow-[0_4px_12px_0_rgba(0,0,0,0.12)] transform hover:-translate-y-0.5 transition-all duration-200 ease-in-out text-gray-500 hover:text-green-600 h-[244.5px]"
             onClick={() => setVisible(true)}
             style={{ pointerEvents: 'auto' }}
           >

--- a/packages/ai-workspace-common/src/components/canvas/front-page/action.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/front-page/action.tsx
@@ -10,6 +10,7 @@ import { cn, extractUrlsWithLinkify } from '@refly/utils/index';
 import { SkillRuntimeConfig } from '@refly/openapi-schema';
 
 export interface CustomAction {
+  content?: string;
   icon: React.ReactNode;
   title: string;
   onClick: () => void;
@@ -101,7 +102,9 @@ export const Actions = memo(
         <div className="flex flex-row items-center gap-2">
           {customActions?.map((action, index) => (
             <Tooltip title={action.title} key={index}>
-              <Button size="small" icon={action.icon} onClick={action.onClick} className="mr-0" />
+              <Button size="small" icon={action.icon} onClick={action.onClick} className="mr-0">
+                <span className="text-xs">{action?.content || ''}</span>
+              </Button>
             </Tooltip>
           ))}
 

--- a/packages/ai-workspace-common/src/components/canvas/front-page/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/front-page/index.tsx
@@ -269,8 +269,9 @@ export const FrontPage = memo(({ projectId }: { projectId: string | null }) => {
                   loading={isCreating}
                   customActions={[
                     {
-                      icon: <IconPlus />,
-                      title: t('loggedHomePage.siderMenu.newCanvas'),
+                      icon: <IconPlus className="flex items-center justify-center" />,
+                      title: '',
+                      content: t('loggedHomePage.siderMenu.newCanvas'),
                       onClick: () => debouncedCreateCanvas(),
                     },
                   ]}

--- a/packages/ai-workspace-common/src/components/canvas/front-page/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/front-page/index.tsx
@@ -8,6 +8,7 @@ import { SkillDisplay } from '@refly-packages/ai-workspace-common/components/can
 import {
   getSkillIcon,
   IconRight,
+  IconPlus,
 } from '@refly-packages/ai-workspace-common/components/common/icon';
 import { Form } from '@arco-design/web-react';
 import { Button } from 'antd';
@@ -67,7 +68,6 @@ export const FrontPage = memo(({ projectId }: { projectId: string | null }) => {
   }));
 
   const { debouncedCreateCanvas, isCreating } = useCreateCanvas({
-    source: 'front-page',
     projectId,
     afterCreateSuccess: () => {
       // When canvas is created successfully, data is already in the store
@@ -88,7 +88,7 @@ export const FrontPage = memo(({ projectId }: { projectId: string | null }) => {
 
   const handleSendMessage = useCallback(() => {
     if (!query?.trim()) return;
-    debouncedCreateCanvas();
+    debouncedCreateCanvas('front-page');
   }, [query, debouncedCreateCanvas]);
 
   const findSkillByName = useCallback(
@@ -175,11 +175,16 @@ export const FrontPage = memo(({ projectId }: { projectId: string | null }) => {
         className="w-full h-full flex bg-white/90 overflow-y-auto"
         id="front-page-scrollable-div"
       >
-        <div className="relative w-full h-full p-6 max-w-4xl mx-auto z-10">
+        <div
+          className={cn(
+            'relative w-full h-full p-6 max-w-4xl mx-auto z-10',
+            canvasTemplateEnabled ? '' : 'flex flex-col justify-center',
+          )}
+        >
           <h3
             className={cn(
               'text-3xl font-bold text-center text-gray-800 mb-6 mx-2',
-              canvasTemplateEnabled ? 'mt-48' : 'mt-96',
+              canvasTemplateEnabled ? 'mt-48' : '',
             )}
           >
             {t('frontPage.welcome')}
@@ -262,6 +267,13 @@ export const FrontPage = memo(({ projectId }: { projectId: string | null }) => {
                   handleSendMessage={handleSendMessage}
                   handleAbort={() => {}}
                   loading={isCreating}
+                  customActions={[
+                    {
+                      icon: <IconPlus />,
+                      title: t('loggedHomePage.siderMenu.newCanvas'),
+                      onClick: () => debouncedCreateCanvas(),
+                    },
+                  ]}
                 />
               </div>
             </div>

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/chat-actions/model-selector.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/chat-actions/model-selector.tsx
@@ -344,7 +344,7 @@ export const ModelSelector = memo(
             )}
           </span>
         ) : (
-          <ModelIcon model={'gpt-4o'} size={48} type={'color'} />
+          <ModelIcon model={'gpt-4o'} size={16} type={'color'} />
         )}
       </Dropdown>
     );

--- a/packages/ai-workspace-common/src/components/sider/layout.tsx
+++ b/packages/ai-workspace-common/src/components/sider/layout.tsx
@@ -156,7 +156,7 @@ export const NewCanvasItem = () => {
   const { debouncedCreateCanvas, isCreating: createCanvasLoading } = useCreateCanvas();
 
   return (
-    <div className="w-full" onClick={debouncedCreateCanvas}>
+    <div className="w-full" onClick={() => debouncedCreateCanvas()}>
       <Button
         className="w-full justify-start px-2"
         key="newCanvas"

--- a/packages/ai-workspace-common/src/hooks/canvas/use-create-canvas.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-create-canvas.ts
@@ -8,7 +8,6 @@ import getClient from '@refly-packages/ai-workspace-common/requests/proxiedReque
 import { DATA_NUM } from '@refly-packages/ai-workspace-common/hooks/use-handle-sider-data';
 
 export const useCreateCanvas = ({
-  source,
   projectId,
   afterCreateSuccess,
 }: { source?: string; projectId?: string; afterCreateSuccess?: () => void } = {}) => {
@@ -33,7 +32,7 @@ export const useCreateCanvas = ({
   };
 
   const debouncedCreateCanvas = useDebouncedCallback(
-    async () => {
+    async (source?: string) => {
       const { canvasList, setCanvasList } = useSiderStore.getState();
       const canvasTitle = '';
       const canvasId = await createCanvas(canvasTitle);

--- a/packages/ai-workspace-common/src/modules/entity-selector/components/search-list/index.tsx
+++ b/packages/ai-workspace-common/src/modules/entity-selector/components/search-list/index.tsx
@@ -190,7 +190,7 @@ export const SearchList = (props: SearchListProps) => {
 
             {!hasMore && sortedItems.length > 0 && (
               <Divider dashed plain className="my-2 px-8">
-                <div className="text-xs text-gray-400">{t('common.noMoreText')}</div>
+                <div className="text-xs text-gray-400">{t('common.noMore')}</div>
               </Divider>
             )}
 


### PR DESCRIPTION
- Adjusted height of the TemplatesGuide button for improved visual consistency.
- Updated FrontPage to include a new canvas creation action with an icon for better user interaction.
- Refined ModelSelector to optimize icon size for better presentation.
- Enhanced NewCanvasItem click handling for clarity and consistency.
- Improved useCanvasInitialActions to manage connection status and pending actions effectively.
- Ensured compliance with code standards, including optional chaining and nullish coalescing.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
