### PR TITLE
fix(api): revert swc build and correct npm script paths

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -6,10 +6,8 @@ WORKDIR /app
 RUN npm install -g pnpm
 
 # Set environment variables to skip gyp-related installations
-# ENV npm_config_build_from_source=true
 ENV npm_config_gyp_ignore=true
 ENV CYPRESS_INSTALL_BINARY=0
-ENV SWC_BUILD=true
 
 # Copy all necessary files in one layer
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json turbo.json ./
@@ -23,8 +21,8 @@ RUN pnpm install --ignore-scripts
 # Copy remaining source code
 COPY . .
 
-# Build packages in correct order using SWC
-RUN pnpm build:api:fast
+# Build packages in correct order
+RUN pnpm build:api
 
 # # Clean up development dependencies
 # RUN rm -rf node_modules

--- a/apps/api/nodemon.json
+++ b/apps/api/nodemon.json
@@ -9,5 +9,5 @@
   ],
   "ext": "ts",
   "ignore": ["src/**/*.spec.ts"],
-  "exec": "prisma format && prisma generate && ts-node -r tsconfig-paths/register src/server/main.ts"
+  "exec": "prisma format && prisma generate && ts-node -r tsconfig-paths/register src/main.ts"
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,7 @@
     "dev": "nodemon",
     "dev:electron": "nodemon --config nodemon.electron.json",
     "dev:debug": "nodemon --inspect",
-    "start": "node --env-file=.env dist/scripts/sync-db-schema.js && node --env-file=.env dist/server/main.js",
+    "start": "node --env-file=.env dist/scripts/sync-db-schema.js && node --env-file=.env dist/main.js",
     "start:electron": "electron dist-electron/electron/main.js",
     "package:electron": "electron-builder build --config electron-builder.json",
     "test": "jest",

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,12 +2,12 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "declaration": true,
+    "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
     "target": "es2021",
-    "sourceMap": true,
+    "sourceMap": false,
     "inlineSourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist",
@@ -20,12 +20,9 @@
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,
-    "inlineSources": true,
     "paths": {
       "@/*": ["./src/*"]
     },
-    "sourceRoot": "/",
-    "composite": true,
     "types": ["jest", "node", "express", "multer", "electron"],
     "resolveJsonModule": true
   },


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
