### PR TITLE
chore(ci): add --ignore-workspace flag to docs action

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -29,5 +29,10 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'docs/pnpm-lock.yaml'
 
-      - name: Install dependencies and build
-        run: cd docs && pnpm install && pnpm build
+      - name: Install dependencies
+        run: pnpm install --ignore-workspace
+        working-directory: docs
+
+      - name: Build
+        run: pnpm build
+        working-directory: docs

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,7 +29,12 @@ jobs:
           cache-dependency-path: 'docs/pnpm-lock.yaml'
 
       - name: Install dependencies
-        run: cd docs && pnpm install && pnpm build
+        run: pnpm install --ignore-workspace
+        working-directory: docs
+
+      - name: Build
+        run: pnpm build
+        working-directory: docs
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/pages-action@v1.5.0

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "refly-docs",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vitepress dev",


### PR DESCRIPTION
# Summary

- Updated CI and deployment workflows to split the installation and build commands into distinct steps for clarity and maintainability.
- Specified working directory for installation and build steps to ensure proper execution context.
- Added "name" and "private" fields to the package.json for better project identification.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
