### PR TITLE
fix(canvas-menu): update project items deletion to use updateProjectI…

### DIFF
--- a/apps/api/src/modules/common/object-storage/backend/interface.ts
+++ b/apps/api/src/modules/common/object-storage/backend/interface.ts
@@ -44,16 +44,18 @@ export interface ObjectStorageBackend {
   /**
    * Remove an object from storage
    * @param key The storage key
+   * @param force Whether to force the removal of the object
    * @returns true if the object was removed, false if it didn't exist
    */
-  removeObject(key: string): Promise<boolean>;
+  removeObject(key: string, force?: boolean): Promise<boolean>;
 
   /**
    * Remove multiple objects from storage
    * @param keys The storage keys
+   * @param force Whether to force the removal of the objects
    * @returns true if the objects were removed, false if they didn't exist
    */
-  removeObjects(keys: string[]): Promise<boolean>;
+  removeObjects(keys: string[], force?: boolean): Promise<boolean>;
 
   /**
    * Get object info

--- a/apps/api/src/modules/common/object-storage/index.ts
+++ b/apps/api/src/modules/common/object-storage/index.ts
@@ -92,17 +92,21 @@ export class ObjectStorageService implements OnModuleInit {
 export const createObjectStorageServiceFactory = (options?: { visibility: FileVisibility }) => {
   return (configService: ConfigService) => {
     const backendType = configService.get('objectStorage.backend');
+    const reclaimPolicy = configService.get('objectStorage.reclaimPolicy');
 
     let backend: ObjectStorageBackend;
     switch (backendType) {
       case 'fs':
-        backend = new FsStorageBackend(configService.get('objectStorage.fs'));
+        backend = new FsStorageBackend(configService.get('objectStorage.fs'), {
+          reclaimPolicy,
+        });
         break;
       case 'minio': {
         backend = new MinioStorageBackend(
           options?.visibility === 'public'
             ? configService.get('objectStorage.minio.external')
             : configService.get('objectStorage.minio.internal'),
+          { reclaimPolicy },
         );
         break;
       }

--- a/apps/api/src/modules/config/app.config.ts
+++ b/apps/api/src/modules/config/app.config.ts
@@ -33,6 +33,7 @@ export default () => ({
     password: process.env.REDIS_PASSWORD,
   },
   objectStorage: {
+    reclaimPolicy: process.env.OBJECT_STORAGE_RECLAIM_POLICY || 'retain', // 'retain' or 'delete'
     backend: process.env.OBJECT_STORAGE_BACKEND || 'minio',
     fs: {
       root: process.env.OBJECT_STORAGE_FS_ROOT || path.join(process.cwd(), 'storage'),

--- a/packages/ai-workspace-common/src/components/project/canvas-menu/index.tsx
+++ b/packages/ai-workspace-common/src/components/project/canvas-menu/index.tsx
@@ -198,7 +198,7 @@ export const CanvasMenu = ({
 
   const removeCanvasFromProject = useCallback(
     async (canvasId: string) => {
-      const res = await getClient().deleteProjectItems({
+      const res = await getClient().updateProjectItems({
         body: {
           projectId,
           items: [


### PR DESCRIPTION
…tems method

- Changed the method from deleteProjectItems to updateProjectItems for better functionality.
- Ensured consistent use of optional chaining and nullish coalescing for safer property access.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
