### PR TITLE
feat(theme): implement forced light mode and improve theme handling

### DIFF
--- a/apps/web/src/components/landing-page-partials/artifact-gallery/index.tsx
+++ b/apps/web/src/components/landing-page-partials/artifact-gallery/index.tsx
@@ -117,7 +117,7 @@ const ArtifactGallery = memo(
                 <div className="p-6 flex flex-col h-[calc(100%-12rem)]">
                   <Title
                     level={4}
-                    className="!mb-2 !mt-0 line-clamp-2 bg-gray-700 text-white dark:bg-gray-200 dark:text-black"
+                    className="!mb-2 !mt-0 line-clamp-2 text-white dark:bg-gray-200 dark:text-black"
                   >
                     {artifact.title[currentLang]}
                   </Title>

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -122,9 +122,10 @@ if (sentryEnabled) {
 // Update App component to remove Suspense (moved to router definition)
 export const App = () => {
   const setRuntime = useUserStoreShallow((state) => state.setRuntime);
-  const { isDarkMode, initTheme } = useThemeStoreShallow((state) => ({
+  const { isDarkMode, initTheme, isForcedLightMode } = useThemeStoreShallow((state) => ({
     isDarkMode: state.isDarkMode,
     initTheme: state.initTheme,
+    isForcedLightMode: state.isForcedLightMode,
   }));
 
   useEffect(() => {
@@ -133,13 +134,16 @@ export const App = () => {
     initTheme();
   }, [setRuntime, initTheme]);
 
+  // Use light theme when forced, otherwise use the user's preference
+  const shouldUseDarkTheme = isDarkMode && !isForcedLightMode;
+
   return (
     <ConfigProvider
       theme={{
         token: {
           colorPrimary: '#00968F',
           borderRadius: 6,
-          ...(isDarkMode
+          ...(shouldUseDarkTheme
             ? {
                 controlItemBgActive: 'rgba(255, 255, 255, 0.08)',
                 controlItemBgActiveHover: 'rgba(255, 255, 255, 0.12)',
@@ -149,7 +153,7 @@ export const App = () => {
                 controlItemBgActiveHover: '#e0e0e0',
               }),
         },
-        algorithm: isDarkMode ? theme.darkAlgorithm : theme.defaultAlgorithm,
+        algorithm: shouldUseDarkTheme ? theme.darkAlgorithm : theme.defaultAlgorithm,
       }}
     >
       <Outlet />

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -15,6 +15,7 @@ import { SuspenseLoading } from '@refly-packages/ai-workspace-common/components/
 import { HomeRedirect } from '@refly-packages/ai-workspace-common/components/home-redirect';
 import { usePublicAccessPage } from '@refly-packages/ai-workspace-common/hooks/use-is-share-page';
 import { isDesktop } from '@refly-packages/ai-workspace-common/utils/env';
+import { useForcedLightMode } from '@refly-packages/ai-workspace-common/hooks/use-forced-light-mode';
 
 // Lazy load components
 const Home = lazy(() => import('@/pages/home'));
@@ -39,6 +40,10 @@ const prefetchRoutes = () => {
 
 export const AppRouter = (props: { layout?: any }) => {
   const { layout: Layout } = props;
+
+  // Apply forced light mode for specific routes
+  useForcedLightMode();
+
   const userStore = useUserStoreShallow((state) => ({
     isLogin: state.isLogin,
     userProfile: state.userProfile,

--- a/packages/ai-workspace-common/src/components/canvas/node-action-menu/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-action-menu/index.tsx
@@ -879,7 +879,7 @@ export const NodeActionMenu: FC<NodeActionMenuProps> = ({
       >
         {menuItems.map((item) => {
           if (item?.type === 'divider') {
-            return <Divider key={item.key} className="my-1 h-[1px] bg-gray-100" />;
+            return <Divider key={item.key} className="my-1 h-[1px] bg-gray-100 dark:bg-gray-900" />;
           }
 
           const button = (

--- a/packages/ai-workspace-common/src/components/document/index.tsx
+++ b/packages/ai-workspace-common/src/components/document/index.tsx
@@ -265,7 +265,7 @@ const StatusBar = memo(
     }, [ydoc, docId, t]);
 
     return (
-      <div className="w-full h-10 p-3 border-x-0 border-t-0 border-b border-solid border-gray-100 flex flex-row items-center justify-between">
+      <div className="w-full h-10 p-3 border-x-0 border-t-0 border-b border-solid border-gray-100 dark:border-gray-700 flex flex-row items-center justify-between">
         <div className="flex items-center gap-2">
           <div
             className={`

--- a/packages/ai-workspace-common/src/components/import-resource/index.scss
+++ b/packages/ai-workspace-common/src/components/import-resource/index.scss
@@ -156,7 +156,6 @@
     padding: 16px 12px;
     border-top: 1px solid var(--color-neutral-3);
     width: 100%;
-    background-color: #fff;
     border-bottom-left-radius: 20px;
     border-bottom-right-radius: 20px;
 

--- a/packages/ai-workspace-common/src/components/import-resource/index.scss
+++ b/packages/ai-workspace-common/src/components/import-resource/index.scss
@@ -115,7 +115,7 @@
     .intergation-import-from-weblink {
       .intergation-result-list-item {
         border-radius: 0;
-        border-bottom: 1px solid #f1f1f0;
+        border-bottom: 1px solid;
         padding: 10px 0;
 
         .arco-list-item {
@@ -129,7 +129,6 @@
 
       .intergation-result-url {
         font-size: 12px;
-        color: rgba(0, 0, 0, 0.5);
         display: inline-block;
         max-width: 250px;
         overflow: hidden;

--- a/packages/ai-workspace-common/src/components/import-resource/intergrations/import-from-file.tsx
+++ b/packages/ai-workspace-common/src/components/import-resource/intergrations/import-from-file.tsx
@@ -260,7 +260,7 @@ export const ImportFromFile = () => {
       </div>
 
       {/* footer */}
-      <div className="w-full flex justify-between items-center border-t border-solid border-[#e5e5e5] border-x-0 border-b-0 p-[16px] rounded-none">
+      <div className="w-full flex justify-between items-center border-t border-solid border-[#e5e5e5] dark:border-[#2f2f2f] border-x-0 border-b-0 p-[16px] rounded-none">
         <div className="flex items-center gap-x-[8px]">
           <p className="font-bold whitespace-nowrap text-md text-[#00968f]">
             {t('resource.import.fileCount', { count: fileList?.length || 0 })}

--- a/packages/ai-workspace-common/src/components/import-resource/intergrations/import-from-image.tsx
+++ b/packages/ai-workspace-common/src/components/import-resource/intergrations/import-from-image.tsx
@@ -8,24 +8,12 @@ import { useTranslation } from 'react-i18next';
 import { useSubscriptionUsage } from '@refly-packages/ai-workspace-common/hooks/use-subscription-usage';
 import type { RcFile } from 'antd/es/upload/interface';
 import { genResourceID, genImageID } from '@refly/utils/id';
-import { LuInfo } from 'react-icons/lu';
-import { useSubscriptionStoreShallow } from '@refly-packages/ai-workspace-common/stores/subscription';
-import { GrUnlock } from 'react-icons/gr';
-import { useUserStoreShallow } from '@refly-packages/ai-workspace-common/stores/user';
-import { subscriptionEnabled } from '@refly-packages/ai-workspace-common/utils/env';
 import { useGetProjectCanvasId } from '@refly-packages/ai-workspace-common/hooks/use-get-project-canvasId';
 import { nodeOperationsEmitter } from '@refly-packages/ai-workspace-common/events/nodeOperations';
 import { cn } from '@refly/utils/cn';
+import { ImageItem } from '@refly-packages/ai-workspace-common/stores/import-resource';
 
 const { Dragger } = Upload;
-
-interface ImageItem {
-  title: string;
-  url: string;
-  storageKey: string;
-  uid?: string;
-  status?: 'uploading' | 'done' | 'error';
-}
 
 const ALLOWED_IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.webp', '.gif', '.tiff', '.bmp'];
 
@@ -34,16 +22,13 @@ export const ImportFromImage = () => {
   const {
     setImportResourceModalVisible,
     insertNodePosition,
-    fileList: storageFileList,
-    setFileList: setStorageFileList,
+    imageList: storageImageList,
+    setImageList: setStorageImageList,
   } = useImportResourceStoreShallow((state) => ({
     setImportResourceModalVisible: state.setImportResourceModalVisible,
     insertNodePosition: state.insertNodePosition,
-    setFileList: state.setFileList,
-    fileList: state.fileList,
-  }));
-  const { setSubscribeModalVisible } = useSubscriptionStoreShallow((state) => ({
-    setSubscribeModalVisible: state.setSubscribeModalVisible,
+    imageList: state.imageList,
+    setImageList: state.setImageList,
   }));
 
   const { isCanvasOpen, canvasId } = useGetProjectCanvasId();
@@ -51,14 +36,9 @@ export const ImportFromImage = () => {
   const { refetchUsage, fileParsingUsage } = useSubscriptionUsage();
 
   const [saveLoading, setSaveLoading] = useState(false);
-  const [imageList, setImageList] = useState<ImageItem[]>(storageFileList);
+  const [imageList, setImageList] = useState<ImageItem[]>(storageImageList);
   const [isDragging, setIsDragging] = useState(false);
 
-  const { userProfile } = useUserStoreShallow((state) => ({
-    userProfile: state.userProfile,
-  }));
-
-  const planType = userProfile?.subscription?.planType || 'free';
   const uploadLimit = fileParsingUsage?.fileUploadLimit ?? -1;
   const maxFileSize = `${uploadLimit}MB`;
   const maxFileSizeBytes = uploadLimit * 1024 * 1024;
@@ -229,8 +209,8 @@ export const ImportFromImage = () => {
   };
 
   useEffect(() => {
-    setStorageFileList(imageList);
-  }, [imageList, setStorageFileList]);
+    setStorageImageList(imageList);
+  }, [imageList, setStorageImageList]);
 
   return (
     <div
@@ -253,16 +233,6 @@ export const ImportFromImage = () => {
           <TbPhoto className="text-lg" />
         </span>
         <div className="text-base font-bold">{t('resource.import.fromImage')}</div>
-        {subscriptionEnabled && planType === 'free' && (
-          <Button
-            type="text"
-            icon={<GrUnlock className="flex items-center justify-center" />}
-            onClick={() => setSubscribeModalVisible(true)}
-            className="text-green-600 font-medium"
-          >
-            {t('resource.import.unlockUploadLimit')}
-          </Button>
-        )}
       </div>
 
       {/* content */}
@@ -281,21 +251,12 @@ export const ImportFromImage = () => {
             <p className="ant-upload-hint text-gray-400 dark:text-gray-500 mt-2">
               {genUploadHint()}
             </p>
-            {fileParsingUsage?.pagesLimit >= 0 && (
-              <div className="text-green-500 dark:text-green-400 mt-2 text-xs font-medium flex items-center justify-center gap-1">
-                <LuInfo />
-                {t('resource.import.imageParsingUsage', {
-                  used: fileParsingUsage?.pagesParsed,
-                  limit: fileParsingUsage?.pagesLimit,
-                })}
-              </div>
-            )}
           </Dragger>
         </div>
       </div>
 
       {/* footer */}
-      <div className="w-full flex justify-between items-center border-t border-solid border-[#e5e5e5] border-x-0 border-b-0 p-[16px] rounded-none">
+      <div className="w-full flex justify-between items-center border-t border-solid border-[#e5e5e5] dark:border-[#2f2f2f] border-x-0 border-b-0 p-[16px] rounded-none">
         <div className="flex items-center gap-x-[8px]">
           <p className="font-bold whitespace-nowrap text-md text-[#00968f]">
             {t('resource.import.imageCount', {

--- a/packages/ai-workspace-common/src/components/import-resource/intergrations/import-from-text.tsx
+++ b/packages/ai-workspace-common/src/components/import-resource/intergrations/import-from-text.tsx
@@ -1,5 +1,4 @@
-import { Form } from '@arco-design/web-react';
-import { Button, Input, message } from 'antd';
+import { Button, Input, message, Form } from 'antd';
 import { useEffect, useState } from 'react';
 
 // utils
@@ -113,20 +112,20 @@ export const ImportFromText = () => {
 
       {/* content */}
       <div className="flex-grow overflow-y-auto px-6 box-border">
-        <Form>
-          <FormItem layout="vertical" label={t('resource.import.textTitlePlaceholder')}>
+        <Form layout="vertical">
+          <FormItem label={t('resource.import.textTitlePlaceholder')}>
             <Input
               value={copiedTextPayload?.title}
               onChange={(e) => setCopiedTextPayload({ title: e.target.value })}
             />
           </FormItem>
-          <FormItem layout="vertical" label={t('resource.import.textUrlPlaceholder')}>
+          <FormItem label={t('resource.import.textUrlPlaceholder')}>
             <Input
               value={copiedTextPayload?.url}
               onChange={(e) => setCopiedTextPayload({ url: e.target.value })}
             />
           </FormItem>
-          <FormItem required layout="vertical" label={t('resource.import.textContentPlaceholder')}>
+          <FormItem required label={t('resource.import.textContentPlaceholder')}>
             <TextArea
               rows={4}
               autoSize={{
@@ -143,7 +142,7 @@ export const ImportFromText = () => {
       </div>
 
       {/* footer */}
-      <div className="w-full flex justify-between items-center border-t border-solid border-[#e5e5e5] border-x-0 border-b-0 p-[16px] rounded-none">
+      <div className="w-full flex justify-between items-center border-t border-solid border-[#e5e5e5] dark:border-[#2f2f2f] border-x-0 border-b-0 p-[16px] rounded-none">
         <div className="flex items-center gap-x-[8px]">
           <StorageLimit
             resourceCount={1}

--- a/packages/ai-workspace-common/src/components/import-resource/intergrations/import-from-weblink.tsx
+++ b/packages/ai-workspace-common/src/components/import-resource/intergrations/import-from-weblink.tsx
@@ -218,7 +218,9 @@ export const ImportFromWeblink = () => {
         </div>
 
         <div className="mt-[24px]">
-          <h2 className="text-sm font-bold text-[#00000080]">{t('resource.import.waitingList')}</h2>
+          <h2 className="text-sm font-bold text-[#00000080] dark:text-[#ffffff80]">
+            {t('resource.import.waitingList')}
+          </h2>
           <div className="mt-[12px]">
             {scrapeLinks?.length > 0 ? (
               <List
@@ -234,7 +236,7 @@ export const ImportFromWeblink = () => {
       </div>
 
       {/* footer */}
-      <div className="w-full flex justify-between items-center border-t border-solid border-[#e5e5e5] border-x-0 border-b-0 p-[16px] rounded-none">
+      <div className="w-full flex justify-between items-center border-t border-solid border-[#e5e5e5] dark:border-[#2f2f2f] border-x-0 border-b-0 p-[16px] rounded-none">
         <div className="flex items-center gap-x-[8px]">
           <p className="font-bold whitespace-nowrap text-md text-[#00968f]">
             {t('resource.import.linkCount', { count: scrapeLinks?.length || 0 })}
@@ -296,7 +298,7 @@ const RenderItem = (props: { item: LinkMeta }) => {
             <HiOutlineXMark strokeWidth={2} />
           </Button>,
         ]}
-        className="intergation-result-list-item"
+        className="intergation-result-list-item !border-[#f1f1f0] dark:!border-[#2f2f2f]"
       >
         <List.Item.Meta
           avatar={<Avatar src={item.image} />}
@@ -304,7 +306,7 @@ const RenderItem = (props: { item: LinkMeta }) => {
             <div className="intergation-result-intro">
               <p>
                 <span
-                  className="intergation-result-url"
+                  className="intergation-result-url dark:text-[#ffffff80] text-[#00000080]"
                   onClick={() => window.open(item?.url, '_blank')}
                 >
                   {item?.url}

--- a/packages/ai-workspace-common/src/hooks/use-forced-light-mode.ts
+++ b/packages/ai-workspace-common/src/hooks/use-forced-light-mode.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useThemeStoreShallow } from '../stores/theme';
+import { useUserStoreShallow } from '@refly-packages/ai-workspace-common/stores/user';
 
 // Routes that should always use light mode
 const LIGHT_MODE_ROUTES = ['/', '/pricing', '/artifact-gallery', '/use-cases-gallery'];
@@ -11,6 +12,9 @@ const LIGHT_MODE_ROUTES = ['/', '/pricing', '/artifact-gallery', '/use-cases-gal
 export const useForcedLightMode = () => {
   const location = useLocation();
   const currentPath = location.pathname;
+  const { isLogin } = useUserStoreShallow((state) => ({
+    isLogin: state.isLogin,
+  }));
 
   const { setForcedLightMode } = useThemeStoreShallow((state) => ({
     setForcedLightMode: state.setForcedLightMode,
@@ -21,7 +25,7 @@ export const useForcedLightMode = () => {
     const shouldForceLightMode = LIGHT_MODE_ROUTES.some((route) => {
       // For the root path, we need an exact match
       if (route === '/') {
-        return currentPath === '/';
+        return !isLogin && currentPath === '/';
       }
       // For other paths, use exact match to ensure we don't affect subpaths
       return currentPath === route;

--- a/packages/ai-workspace-common/src/hooks/use-forced-light-mode.ts
+++ b/packages/ai-workspace-common/src/hooks/use-forced-light-mode.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useThemeStoreShallow } from '../stores/theme';
+
+// Routes that should always use light mode
+const LIGHT_MODE_ROUTES = ['/', '/pricing', '/artifact-gallery', '/use-cases-gallery'];
+
+/**
+ * Custom hook to force light mode on specific routes regardless of theme settings
+ */
+export const useForcedLightMode = () => {
+  const location = useLocation();
+  const currentPath = location.pathname;
+
+  const { setForcedLightMode } = useThemeStoreShallow((state) => ({
+    setForcedLightMode: state.setForcedLightMode,
+  }));
+
+  useEffect(() => {
+    // Check if current path should force light mode
+    const shouldForceLightMode = LIGHT_MODE_ROUTES.some((route) => {
+      // For the root path, we need an exact match
+      if (route === '/') {
+        return currentPath === '/';
+      }
+      // For other paths, use exact match to ensure we don't affect subpaths
+      return currentPath === route;
+    });
+
+    // Update the forced light mode state in the store
+    setForcedLightMode(shouldForceLightMode);
+
+    // Cleanup - restore normal theme behavior when leaving these routes
+    return () => {
+      if (shouldForceLightMode) {
+        setForcedLightMode(false);
+      }
+    };
+  }, [currentPath, setForcedLightMode]);
+};

--- a/packages/ai-workspace-common/src/modules/multilingual-search/components/action-menu.scss
+++ b/packages/ai-workspace-common/src/modules/multilingual-search/components/action-menu.scss
@@ -37,9 +37,8 @@
   border-radius: 0;
   bottom: 0;
   padding: 16px 12px;
-  border-top: 1px solid var(--color-neutral-3);
+  border-top: 1px solid;
   width: 100%;
-  background-color: #fff;
   border-bottom-left-radius: 20px;
   border-bottom-right-radius: 20px;
 

--- a/packages/ai-workspace-common/src/modules/multilingual-search/components/action-menu.tsx
+++ b/packages/ai-workspace-common/src/modules/multilingual-search/components/action-menu.tsx
@@ -159,7 +159,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = (props) => {
 
   return (
     <Affix offsetBottom={0} target={props.getTarget}>
-      <div className="intergation-footer dark:bg-[#1f1f1f]">
+      <div className="intergation-footer bg-white dark:bg-[#1f1f1f] border-[#e5e5e5] dark:border-[#2f2f2f]">
         <div className="footer-location">
           <Checkbox
             checked={selectedItems.length && selectedItems.length === results.length}

--- a/packages/ai-workspace-common/src/stores/import-resource.ts
+++ b/packages/ai-workspace-common/src/stores/import-resource.ts
@@ -22,6 +22,14 @@ export interface FileItem {
   status?: 'uploading' | 'done' | 'error';
 }
 
+export interface ImageItem {
+  title: string;
+  url: string;
+  storageKey: string;
+  uid?: string;
+  status?: 'uploading' | 'done' | 'error';
+}
+
 export type ImportResourceMenuItem =
   | 'import-from-file'
   | 'import-from-weblink'
@@ -37,12 +45,14 @@ interface ImportResourceState {
   // scrape
   scrapeLinks: LinkMeta[];
   fileList: FileItem[];
+  imageList: ImageItem[];
   copiedTextPayload: { content: string; title: string; url?: string };
   insertNodePosition: XYPosition | null;
 
   setImportResourceModalVisible: (visible: boolean) => void;
   setScrapeLinks: (links: LinkMeta[]) => void;
   setFileList: (fileList: FileItem[]) => void;
+  setImageList: (imageList: ImageItem[]) => void;
   setCopiedTextPayload: (
     payload: Partial<{ content: string; title: string; url?: string }>,
   ) => void;
@@ -55,6 +65,7 @@ export const defaultState = {
   copiedTextPayload: { content: '', title: '', url: '' },
   scrapeLinks: [],
   fileList: [],
+  imageList: [],
   importResourceModalVisible: false,
   selectedMenuItem: 'import-from-web-search' as ImportResourceMenuItem,
   insertNodePosition: null,
@@ -71,6 +82,7 @@ export const useImportResourceStore = create<ImportResourceState>()(
       set((state) => ({ ...state, copiedTextPayload: { ...state.copiedTextPayload, ...payload } })),
     resetState: () => set((state) => ({ ...state, ...defaultState })),
     setFileList: (fileList: FileItem[]) => set((state) => ({ ...state, fileList })),
+    setImageList: (imageList: ImageItem[]) => set((state) => ({ ...state, imageList })),
     setSelectedMenuItem: (menuItem: ImportResourceMenuItem) =>
       set((state) => ({ ...state, selectedMenuItem: menuItem })),
     setInsertNodePosition: (position: XYPosition) =>

--- a/packages/ai-workspace-common/src/stores/theme.ts
+++ b/packages/ai-workspace-common/src/stores/theme.ts
@@ -9,9 +9,13 @@ interface ThemeState {
   themeMode: ThemeMode;
   // 是否为暗色模式
   isDarkMode: boolean;
+  // 是否强制使用亮色模式
+  isForcedLightMode: boolean;
 
   // 设置主题模式
   setThemeMode: (mode: ThemeMode) => void;
+  // 设置强制亮色模式状态
+  setForcedLightMode: (isForcedLight: boolean) => void;
   // 初始化主题
   initTheme: () => void;
 }
@@ -22,8 +26,8 @@ const isSystemDarkMode = () => {
 };
 
 // 应用暗色模式到文档
-const applyDarkMode = (isDark: boolean) => {
-  if (isDark) {
+const applyDarkMode = (isDark: boolean, isForcedLight: boolean) => {
+  if (isDark && !isForcedLight) {
     document.documentElement.classList.add('dark');
   } else {
     document.documentElement.classList.remove('dark');
@@ -35,6 +39,14 @@ export const useThemeStore = create<ThemeState>()(
     (set, get) => ({
       themeMode: 'system',
       isDarkMode: false,
+      isForcedLightMode: false,
+
+      setForcedLightMode: (isForcedLight: boolean) => {
+        set({ isForcedLightMode: isForcedLight });
+
+        // Apply dark mode considering forced light mode
+        applyDarkMode(get().isDarkMode, isForcedLight);
+      },
 
       setThemeMode: (mode: ThemeMode) => {
         set({ themeMode: mode });
@@ -48,11 +60,11 @@ export const useThemeStore = create<ThemeState>()(
         }
 
         set({ isDarkMode: isDark });
-        applyDarkMode(isDark);
+        applyDarkMode(isDark, get().isForcedLightMode);
       },
 
       initTheme: () => {
-        const { themeMode } = get();
+        const { themeMode, isForcedLightMode } = get();
 
         // 根据当前主题模式初始化
         let isDark = false;
@@ -66,7 +78,7 @@ export const useThemeStore = create<ThemeState>()(
           const handleChange = (e: MediaQueryListEvent) => {
             if (get().themeMode === 'system') {
               set({ isDarkMode: e.matches });
-              applyDarkMode(e.matches);
+              applyDarkMode(e.matches, get().isForcedLightMode);
             }
           };
 
@@ -74,7 +86,7 @@ export const useThemeStore = create<ThemeState>()(
         }
 
         set({ isDarkMode: isDark });
-        applyDarkMode(isDark);
+        applyDarkMode(isDark, isForcedLightMode);
       },
     }),
     {


### PR DESCRIPTION
- Added support for forced light mode in the theme store and updated related components to utilize this feature.
- Refactored theme application logic to consider forced light mode when determining the current theme.
- Enhanced the App component to conditionally apply dark mode based on user preferences and forced settings.
- Cleaned up styling in the ArtifactGallery component to ensure consistency with Tailwind CSS.
- Ensured proper use of optional chaining and nullish coalescing for safer property access throughout the codebase.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
