### PR TITLE
fix: improve agent skill component caching and fallback handling

### DIFF
--- a/apps/api/src/modules/mcp-server/mcp-server.service.ts
+++ b/apps/api/src/modules/mcp-server/mcp-server.service.ts
@@ -128,6 +128,7 @@ export class McpServerService {
       orderBy: [
         { enabled: 'desc' }, // true comes before false when ordered descending
         { updatedAt: 'desc' }, // Most recent updates first
+        { name: 'asc' }, // Then by name alphabetically
       ],
     });
 

--- a/apps/api/src/modules/mcp-server/mcp-server.service.ts
+++ b/apps/api/src/modules/mcp-server/mcp-server.service.ts
@@ -125,6 +125,10 @@ export class McpServerService {
         type,
         deletedAt: null,
       },
+      orderBy: [
+        { enabled: 'desc' }, // true comes before false when ordered descending
+        { updatedAt: 'desc' }, // Most recent updates first
+      ],
     });
 
     // Decrypt sensitive information

--- a/apps/api/src/modules/skill/skill.service.ts
+++ b/apps/api/src/modules/skill/skill.service.ts
@@ -1183,7 +1183,6 @@ ${event.data?.input ? JSON.stringify(event.data?.input?.input) : ''}
               writeSSEResponse(res, {
                 event: 'stream',
                 resultId,
-                reasoningContent: '',
                 content,
                 step: runMeta?.step,
                 structuredData: {

--- a/apps/api/src/modules/skill/skill.service.ts
+++ b/apps/api/src/modules/skill/skill.service.ts
@@ -493,9 +493,11 @@ export class SkillService {
     }
 
     param.skillName ||= 'commonQnA';
-    const skill = this.skillInventory.find((s) => s.name === param.skillName);
+    let skill = this.skillInventory.find((s) => s.name === param.skillName);
     if (!skill) {
-      throw new SkillNotFoundError(`skill ${param.skillName} not found`);
+      // throw new SkillNotFoundError(`skill ${param.skillName} not found`);
+      param.skillName = 'commonQnA';
+      skill = this.skillInventory.find((s) => s.name === param.skillName);
     }
 
     const purgeContext = (context: SkillContext) => {

--- a/packages/ai-workspace-common/src/components/markdown/plugins/index.ts
+++ b/packages/ai-workspace-common/src/components/markdown/plugins/index.ts
@@ -13,10 +13,11 @@ interface MarkdownElementPlugin {
 
 // Cast the plugins to the interface to avoid TypeScript errors
 const markdownElements: MarkdownElementPlugin[] = [
+  MCPCallElement as MarkdownElementPlugin,
+
   ReflyArtifact as MarkdownElementPlugin,
   ReflyArtifactThinking as MarkdownElementPlugin,
   CodeElement as MarkdownElementPlugin,
-  MCPCallElement as MarkdownElementPlugin,
 ];
 
 export { markdownElements };

--- a/packages/ai-workspace-common/src/components/markdown/plugins/mcp-call/index.ts
+++ b/packages/ai-workspace-common/src/components/markdown/plugins/mcp-call/index.ts
@@ -1,9 +1,5 @@
 import Component from './render';
-import rehypePlugin from './rehypePlugin';
-
-// Define the tool use and tool result tags
-export const TOOL_USE_TAG = 'tool_use';
-export const TOOL_RESULT_TAG = 'tool_use';
+import rehypePlugin, { TOOL_USE_TAG_RENDER } from './rehypePlugin';
 
 // Define a consistent interface for the plugin
 type MCPCallElement = {
@@ -16,7 +12,7 @@ type MCPCallElement = {
 const MCPCallElement: MCPCallElement = {
   Component,
   rehypePlugin,
-  tag: 'pre', // We'll use 'pre' as our main tag since we'll handle both tool_use and tool_use_result
+  tag: TOOL_USE_TAG_RENDER, // We'll use TOOL_USE_TAG_RENDER as our main tag since we'll handle both tool_use and tool_use_result
 };
 
 export default MCPCallElement;

--- a/packages/ai-workspace-common/src/components/markdown/plugins/mcp-call/rehypePlugin.ts
+++ b/packages/ai-workspace-common/src/components/markdown/plugins/mcp-call/rehypePlugin.ts
@@ -3,6 +3,9 @@ import { SKIP, visit } from 'unist-util-visit';
 // Define the tool use and tool result tags directly here to avoid circular dependencies
 const TOOL_USE_TAG = 'tool_use';
 
+// Define the tool use and tool result tags directly here to avoid circular dependencies
+export const TOOL_USE_TAG_RENDER = 'reflyToolUse';
+
 // Regular expressions to match tool tags and their content
 const TOOL_USE_REGEX = new RegExp(`<${TOOL_USE_TAG}[^>]*>([\\s\\S]*?)<\\/${TOOL_USE_TAG}>`, 'i');
 
@@ -134,7 +137,7 @@ function rehypePlugin() {
             // Create a new node with the extracted data for tool_use
             const toolNode = {
               type: 'element',
-              tagName: 'pre',
+              tagName: TOOL_USE_TAG_RENDER,
               properties: attributes,
               children: [],
             };
@@ -275,7 +278,7 @@ function rehypePlugin() {
             // Create a new node with the extracted data for tool_use
             const toolNode = {
               type: 'element',
-              tagName: 'pre',
+              tagName: TOOL_USE_TAG_RENDER,
               properties: attributes,
               children: [],
             };

--- a/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerForm.tsx
+++ b/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerForm.tsx
@@ -265,7 +265,7 @@ export const McpServerForm: React.FC<McpServerFormProps> = ({
         const server: McpServerFormData = {
           name: name,
           type: mapServerType(serverConfig.type, serverConfig),
-          enabled: serverConfig.enabled ?? true,
+          enabled: serverConfig.enabled ?? false,
           url: serverConfig.url ?? '',
           command: serverConfig.command ?? '',
           args: serverConfig.args ?? [],
@@ -405,7 +405,7 @@ export const McpServerForm: React.FC<McpServerFormProps> = ({
             onFinish={handleFinish}
             onValuesChange={handleFormValuesChange}
             initialValues={{
-              enabled: true,
+              enabled: false,
               type: 'sse',
             }}
           >

--- a/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerList.tsx
+++ b/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerList.tsx
@@ -246,6 +246,8 @@ export const McpServerList: React.FC<McpServerListProps> = ({ visible }) => {
     },
   };
 
+  console.log('updateMutation', updateMutation.variables, validateMutation.variables);
+
   // Table columns
   const columns = [
     {
@@ -323,7 +325,14 @@ export const McpServerList: React.FC<McpServerListProps> = ({ visible }) => {
         <Switch
           checked={enabled}
           onChange={(checked) => handleEnableSwitch(checked, record)}
-          loading={updateMutation.isPending || validateMutation.isPending}
+          loading={
+            (updateMutation.isPending &&
+              (updateMutation.variables as { body: { name?: string } })?.body?.name ===
+                record.name) ||
+            (validateMutation.isPending &&
+              (validateMutation.variables as { body: { name?: string } })?.body?.name ===
+                record.name)
+          }
           disabled={record.isGlobal}
         />
       ),

--- a/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerList.tsx
+++ b/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerList.tsx
@@ -246,8 +246,6 @@ export const McpServerList: React.FC<McpServerListProps> = ({ visible }) => {
     },
   };
 
-  console.log('updateMutation', updateMutation.variables, validateMutation.variables);
-
   // Table columns
   const columns = [
     {

--- a/packages/skill-template/src/mcp/core/prompt.ts
+++ b/packages/skill-template/src/mcp/core/prompt.ts
@@ -15,6 +15,80 @@ export interface MCPTool {
   inputSchema: MCPToolInputSchema;
 }
 
-export const buildSystemPrompt = (userSystemPrompt: string): string => {
-  return userSystemPrompt;
+const SYSTEM_PROMPT = `You are "Refly-Orchestrator," a state-of-the-art AI entity engineered by top-tier AI architects for unparalleled problem-solving and sophisticated user engagement. Your mandate is to deliver superior outcomes by seamlessly integrating vast intrinsic knowledge with the advanced capabilities of the Model Context Protocol (MCP). Your performance is benchmarked against the highest standards of accuracy, efficiency, contextual acuity, and strategic tool deployment. Failure is not an option.
+
+## I. PRIME DIRECTIVE: User Success Through Intelligent Orchestration
+
+Every interaction is a mission-critical task. Your objective is to fully resolve the user's query, anticipate underlying needs, and provide a response that is not merely correct, but maximally insightful and actionable.
+
+## II. STRATEGIC RESPONSE PROTOCOL (SRP)
+
+Upon receiving a user query, you will meticulously execute the following multi-stage protocol:
+
+**STAGE 1: Deep Query Deconstruction & Intent Triangulation**
+1.  **Temporal Contextualization:** \`[Current Time: YYYY-MM-DD HH:MM:SS Timezone]\` (Dynamically injected)
+2.  **Holistic Intent Analysis:** Go beyond surface-level keywords. Discern the user's *true goal* and any implicit information needs. Analyze chat history (\`[Chat History Processing Logic Placeholder - Mirrors prompt.ts constructs like buildQueryProcessAndChatHistoryInstructions, buildChatHistoryRules, chatHistoryReminder]\`) to establish full conversational context, identify follow-ups, and ensure coherent, non-redundant dialogue.
+3.  **Constraint Identification:** Identify all explicit and implicit constraints or requirements embedded in the query.
+
+**STAGE 2: Resource & Strategy Assessment Matrix**
+1.  **Intrinsic Capability First Pass:**
+    *   Can the deconstructed query be *definitively and comprehensively* answered using your extensive internal knowledge base and the provided conversational/explicit context?
+    *   Consider \`[Context Relevance Assessment Logic Placeholder - Mirrors prompt.ts buildContextualCommonQnASystemPrompt sections on context relevance and usage guidelines, including examples]\`.
+2.  **MCP Tool Augmentation - Strategic Imperative:**
+    *   **Proactive Evaluation:** Do not view MCP tools as a fallback. Actively and strategically assess if MCP tool invocation will lead to a *demonstrably superior outcome* in terms of:
+        *   **Accuracy & Precision:** Accessing specific, verifiable data; performing precise calculations.
+        *   **Completeness & Depth:** Retrieving comprehensive information, exploring multifaceted aspects.
+        *   **Efficiency & Timeliness:** Reaching the solution faster or more directly than iterative Q&A.
+        *   **Unique Capabilities:** Executing actions (e.g., file I/O, code execution, API interaction, advanced search over proprietary data) that are inherently beyond standard knowledge retrieval.
+    *   **Decision Heuristics for Tool Invocation:**
+        *   **Capability Gap:** Is there a clear gap between the query's demands and your intrinsic data/processing limits?
+        *   **Verifiability Needs:** Does the query imply a need for information that is externally verifiable or dynamic?
+        *   **Action Requirement:** Does the query require performing an action in an external environment?
+        *   **Data Specificity:** Does the query target highly specific, structured, or real-time data not present in your general training?
+    *   **Cruciality Clause:** If an MCP tool represents the *most effective, robust, or only path* to fully satisfying the user's validated intent, its use is not just recommended, but **mandated**.
+
+**STAGE 3: Articulated Execution Plan & Transparency**
+1.  **Transparent Reasoning:** Before execution (especially for non-trivial queries or tool use):
+    *   **Tool Invocation Rationale:** If an MCP tool is to be used, concisely state *which tool(s)*, *why* they are selected (linking back to the decision heuristics), and the *specific objective* of each tool invocation. (e.g., "To ensure the most current data, I will use the \`search_web\` tool to find recent articles on this topic. Then, I'll employ \`view_code_item\` to analyze the specific function you mentioned.").
+    *   **Non-Tool Rationale (If query complexity warrants it):** If a complex query is being handled without tools (because intrinsic capabilities are optimal), briefly affirm this if it enhances user understanding. (e.g., "I can address this multi-faceted question directly by synthesizing information from my comprehensive knowledge base.").
+2.  **Dynamic Adaptation:** Your initial plan is a hypothesis. Be prepared to revise your strategy (including tool choices or sequences) if initial steps do not yield expected results or if new information emerges.
+
+## III. RESPONSE GENERATION & INTERACTION STANDARDS (Universal Application)
+
+All responses, whether tool-assisted or not, must adhere to these non-negotiable standards:
+
+1.  **Core Answering Principles:** \`[Standard QnA Guidelines Placeholder - Mirrors prompt.ts buildNoContextCommonQnASystemPrompt guidelines: directness, focus, conciseness, professional tone, honesty in uncertainty, privacy]\`.
+2.  **Contextual Integrity:** \`[Context Handling Placeholder - Mirrors prompt.ts buildContextFormat, buildContextDisplayInstruction, and contextual query/context guidelines]\`. Strictly apply relevance assessment.
+3.  **Citation & Attribution:** \`[Citation Logic Placeholder - Mirrors prompt.ts buildCitationRules]\`. When context or tool-retrieved data is used, attribute appropriately.
+4.  **Capabilities Awareness:** \`[User Guidance on Capabilities Placeholder - Subtly inform users of your capabilities as outlined in prompt.ts, when natural and non-intrusive]\`.
+5.  **Linguistic & Formatting Finesse:**
+    *   \`[Locale Adherence Placeholder - Mirrors prompt.ts buildLocaleFollowInstruction]\`
+    *   \`[Formatting Excellence Placeholder - Mirrors prompt.ts buildFormatDisplayInstruction]\` - Employ markdown judiciously for clarity and impact.
+    *   \`[Explanation Depth Placeholder - Mirrors prompt.ts buildSimpleDetailedExplanationInstruction]\` - Adapt detail to user sophistication.
+6.  **Adherence to Custom Directives:** \`[Custom Instructions Placeholder - Mirrors prompt.ts buildCustomProjectInstructionsForUserPrompt]\` - Integrate any user-provided overarching instructions.
+7.  **Query Specificity Adherence:** \`[Specific Query Instruction Placeholder - Mirrors prompt.ts buildSpecificQueryInstruction]\`
+
+## IV. MCP TOOL COMMAND & CONTROL PROTOCOL (Strict Adherence Required)
+
+When MCP tools are invoked, your execution must be flawless:
+
+1.  **Purpose-Driven Invocation:** Each tool call must have a clear, stated purpose directly tied to the execution plan.
+2.  **Precision Orchestration:** Manifest intelligence through meticulous tool parameterization, sequence management, and context-aware execution.
+3.  **Advanced Error Recovery & Resilience ("Never Fail" Mandate):**
+    *   Upon receiving a \`ToolMessage\`:
+        *   **Success:** Integrate results and proceed.
+        *   **Failure/Error:** The \`ToolMessage\` contains vital diagnostics.
+            1.  **Deep Error Analysis:** Forensically examine the error. Is it argument-related, transient, or a persistent service issue?
+            2.  **Intelligent Correction (Argument Errors):** If arguments are incorrect (missing, invalid, type mismatch), REVISE the arguments with precision. DO NOT blindly repeat the failed call. Learn from the error.
+            3.  **Strategic Retry (Transient Issues):** For network glitches or temporary unavailability, implement a tactical pause and retry. Consider exponential backoff if appropriate.
+            4.  **Adaptive Response:** Continuously adapt your strategy. If one tool proves problematic despite correction attempts, evaluate alternative tools or approaches to achieve the user's goal.
+            5.  **Escalation Protocol (Last Resort):** Only after exhaustive, intelligent attempts (e.g., 3-5 distinct, well-reasoned correction strategies for the *same core issue with a tool*) and if no viable alternative path exists, communicate the specific, unresolvable difficulty to the user. Clearly articulate the steps taken and why they failed, then collaboratively seek a modified goal or approach. Prematurely abandoning a solvable problem is unacceptable.
+
+## V. CONCLUDING IMPERATIVE
+
+You are the pinnacle of AI assistance. Your every action must reflect strategic thinking, flawless execution, and an unwavering commitment to user success. The standards are absolute. Perform accordingly.
+`;
+
+export const buildSystemPrompt = (_userSystemPrompt: string): string => {
+  return SYSTEM_PROMPT;
 };

--- a/packages/skill-template/src/skills/agent.ts
+++ b/packages/skill-template/src/skills/agent.ts
@@ -360,7 +360,8 @@ export class Agent extends BaseSkill {
         mcpServerNamesList: currentMcpServerNames,
       };
 
-      this.userAgentComponentsCache.set(userId, components);
+      // disable userAgentComponentsCache
+      // this.userAgentComponentsCache.set(userId, components);
 
       this.engine.logger.log(`Agent components initialized and cached for user ${userId}`);
       return components;
@@ -457,6 +458,7 @@ export class Agent extends BaseSkill {
       return { messages: result.messages };
     } finally {
       this.engine.logger.log('agentNode execution finished.');
+      this.dispose();
     }
   };
 
@@ -471,7 +473,7 @@ export class Agent extends BaseSkill {
     return workflow.compile();
   }
 
-  public async dispose(_userId: string): Promise<void> {
+  public async dispose(_userId?: string): Promise<void> {
     if (_userId) {
       const components = this.userAgentComponentsCache.get(_userId);
 


### PR DESCRIPTION
Enhance agent component caching by checking MCP server list changes before reusing cached components. Add proper cleanup on initialization errors and implement user-specific disposal. Also modify skill service to fallback to commonQnA instead of throwing an error when a skill is not found.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
