### PR TITLE
feat: make MCP server names unique per user

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1151,7 +1151,7 @@ model McpServer {
   /// Primary key
   pk        Int       @id @default(autoincrement())
   /// Server name
-  name      String    @unique @map("name")
+  name      String    @map("name")
   /// Server type (sse, streamable, stdio)
   type      String    @map("type")
   /// Whether the server is global
@@ -1181,6 +1181,7 @@ model McpServer {
   /// Deletion timestamp
   deletedAt DateTime? @map("deleted_at") @db.Timestamptz()
 
+  @@unique([uid, name])
   @@index([uid, deletedAt])
   @@index([isGlobal])
   @@map("mcp_servers")

--- a/apps/api/src/modules/mcp-server/mcp-server.service.ts
+++ b/apps/api/src/modules/mcp-server/mcp-server.service.ts
@@ -158,6 +158,7 @@ export class McpServerService {
     const existingServer = await this.prisma.mcpServer.findFirst({
       where: {
         name,
+        uid: user.uid,
       },
     });
 
@@ -240,7 +241,7 @@ export class McpServerService {
     const server = await this.prisma.mcpServer.findFirst({
       where: {
         name,
-        OR: [{ uid: user.uid }, { isGlobal: true }],
+        uid: user.uid,
         deletedAt: null,
       },
     });
@@ -302,7 +303,7 @@ export class McpServerService {
     const server = await this.prisma.mcpServer.findFirst({
       where: {
         name,
-        OR: [{ uid: user.uid }, { isGlobal: true }],
+        uid: user.uid,
         deletedAt: null,
       },
     });

--- a/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerBatchImport.tsx
+++ b/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerBatchImport.tsx
@@ -15,10 +15,14 @@ export const McpServerBatchImport: React.FC<McpServerBatchImportProps> = ({ onSu
   // Remove tab state
 
   // Query existing MCP server list
-  const { data: mcpServersData, isLoading: isLoadingServers } = useListMcpServers({}, [], {
-    enabled: isModalVisible, // Only query when the modal is visible
-    refetchOnWindowFocus: false,
-  });
+  const { data: mcpServersData, isLoading: isLoadingServers } = useListMcpServers(
+    {},
+    [isModalVisible],
+    {
+      enabled: isModalVisible, // Only query when the modal is visible
+      refetchOnWindowFocus: false,
+    },
+  );
 
   // Create MCP server mutation
   const createMutation = useCreateMcpServer([], {
@@ -56,7 +60,6 @@ export const McpServerBatchImport: React.FC<McpServerBatchImportProps> = ({ onSu
       mcpServers[server.name] = {
         type: server.type,
         description: server.config?.description || '',
-        enabled: server.enabled,
         url: server.url || '',
         command: server.command || '',
         args: server.args || [],
@@ -124,7 +127,6 @@ export const McpServerBatchImport: React.FC<McpServerBatchImportProps> = ({ onSu
         const server: McpServerFormData = {
           name: name, // Use the key as the name
           type: mapServerType(serverConfig.type, serverConfig),
-          enabled: serverConfig.enabled ?? false,
           url: serverConfig.url || '',
           command: serverConfig.command || '',
           args: serverConfig.args || [],
@@ -172,7 +174,6 @@ export const McpServerBatchImport: React.FC<McpServerBatchImportProps> = ({ onSu
         name: server.name,
         type: server.type,
         url: server.url,
-        enabled: false, // Default to 'enabled: false' if not specified in jsonData
         headers: server.headers || {},
         reconnect: server.reconnect || { enabled: false },
         args: server.args || [],

--- a/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerBatchImport.tsx
+++ b/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerBatchImport.tsx
@@ -15,14 +15,10 @@ export const McpServerBatchImport: React.FC<McpServerBatchImportProps> = ({ onSu
   // Remove tab state
 
   // Query existing MCP server list
-  const { data: mcpServersData, isLoading: isLoadingServers } = useListMcpServers(
-    {},
-    [isModalVisible],
-    {
-      enabled: isModalVisible, // Only query when the modal is visible
-      refetchOnWindowFocus: false,
-    },
-  );
+  const { data: mcpServersData, isLoading: isLoadingServers } = useListMcpServers({}, [], {
+    enabled: isModalVisible, // Only query when the modal is visible
+    refetchOnWindowFocus: false,
+  });
 
   // Create MCP server mutation
   const createMutation = useCreateMcpServer([], {

--- a/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerForm.tsx
+++ b/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerForm.tsx
@@ -236,7 +236,6 @@ export const McpServerForm: React.FC<McpServerFormProps> = ({
     mcpServers[server.name] = {
       type: server.type,
       description: server.config?.description ?? '',
-      enabled: server.enabled,
       url: server.url ?? '',
       command: server.command ?? '',
       args: filteredArgs,
@@ -265,7 +264,6 @@ export const McpServerForm: React.FC<McpServerFormProps> = ({
         const server: McpServerFormData = {
           name: name,
           type: mapServerType(serverConfig.type, serverConfig),
-          enabled: serverConfig.enabled ?? false,
           url: serverConfig.url ?? '',
           command: serverConfig.command ?? '',
           args: serverConfig.args ?? [],


### PR DESCRIPTION
Update schema to enforce unique server names per user instead of globally. Modify server service to properly scope queries by user ID when finding, creating, and updating MCP servers.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
