### PR TITLE
feat(markdown): add HTTP image URL support in MCP call plugin

### DIFF
--- a/packages/ai-workspace-common/src/components/markdown/index.tsx
+++ b/packages/ai-workspace-common/src/components/markdown/index.tsx
@@ -3,7 +3,6 @@ import { memo, useEffect, useRef, useState, Suspense, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 import RemarkBreaks from 'remark-breaks';
-import RemarkGfm from 'remark-gfm';
 
 import { cn, markdownCitationParse } from '@refly/utils';
 
@@ -128,7 +127,7 @@ export const Markdown = memo(
               plugins.RehypeKatex &&
               plugins.RehypeHighlight && (
                 <ReactMarkdown
-                  remarkPlugins={[RemarkGfm, RemarkBreaks, plugins.RemarkMath]}
+                  remarkPlugins={[RemarkBreaks, plugins.RemarkMath]}
                   rehypePlugins={[
                     ...rehypePlugins,
                     plugins.RehypeKatex,

--- a/packages/ai-workspace-common/src/components/markdown/plugins/mcp-call/render.tsx
+++ b/packages/ai-workspace-common/src/components/markdown/plugins/mcp-call/render.tsx
@@ -28,6 +28,7 @@ interface MCPCallProps {
   'data-tool-result'?: string;
   'data-tool-type'?: 'use' | 'result';
   'data-tool-image-base64-url'?: string;
+  'data-tool-image-http-url'?: string;
   'data-tool-image-name'?: string;
   id?: string;
   mode?: MarkdownMode;
@@ -66,7 +67,10 @@ const MCPCall: React.FC<MCPCallProps> = (props) => {
   const hasResult = !!resultContent;
 
   const imageBase64Url = props['data-tool-image-base64-url'];
+  const imageHttpUrl = props['data-tool-image-http-url'];
   const imageName = props['data-tool-image-name'];
+
+  const imageUrl = imageBase64Url || imageHttpUrl;
 
   return (
     <>
@@ -133,15 +137,15 @@ const MCPCall: React.FC<MCPCallProps> = (props) => {
       </div>
 
       {/* Image Preview section - styled as a separate card below the main MCPCall card */}
-      {imageBase64Url && imageName && (
+      {imageUrl && imageName && (
         <div className="my-3 rounded-lg border border-gray-300 dark:border-gray-700 overflow-hidden cursor-pointer bg-white dark:bg-gray-800">
           <div className="px-4 flex flex-col items-center py-2">
             <img
-              src={imageBase64Url}
+              src={imageUrl}
               alt={imageName}
               className="max-w-full h-auto rounded-md mb-2 shadow-md max-h-[300px]"
               onClick={() => {
-                setPreviewImageUrl(imageBase64Url);
+                setPreviewImageUrl(imageUrl);
                 setIsPreviewModalVisible(true);
               }}
             />


### PR DESCRIPTION
Remove remark-gfm dependency and enhance image handling in MCP call rehype plugin to support both base64 and HTTP/HTTPS image URLs with proper regex pattern matching and extraction.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
