### PR TITLE
feat(canvas): enhance edge styles in dark mode for canvas components

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/constants.ts
+++ b/packages/ai-workspace-common/src/components/canvas/constants.ts
@@ -1,15 +1,19 @@
 import { useCanvasStoreShallow } from '@refly-packages/ai-workspace-common/stores/canvas';
 import { useMemo } from 'react';
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
+import { useThemeStoreShallow } from '@refly-packages/ai-workspace-common/stores/theme';
 
 export const useEdgeStyles = () => {
   const { readonly } = useCanvasContext();
   const showEdges = useCanvasStoreShallow((state) => state.showEdges);
+  const { isDarkMode } = useThemeStoreShallow((state) => ({
+    isDarkMode: state.isDarkMode,
+  }));
 
   return useMemo(
     () => ({
       default: {
-        stroke: showEdges || readonly ? '#D0D5DD' : 'transparent',
+        stroke: showEdges || readonly ? (isDarkMode ? '#4b5563' : '#D0D5DD') : 'transparent',
         strokeWidth: 1,
         transition: 'stroke 0.2s, stroke-width 0.2s',
       },
@@ -28,10 +32,10 @@ export const useEdgeStyles = () => {
   );
 };
 
-export const getEdgeStyles = (showEdges: boolean) => {
+export const getEdgeStyles = (showEdges: boolean, isDarkMode?: boolean) => {
   return {
     default: {
-      stroke: showEdges ? '#D0D5DD' : 'transparent',
+      stroke: showEdges ? (isDarkMode ? '#4b5563' : '#D0D5DD') : 'transparent',
       strokeWidth: 1,
       transition: 'stroke 0.2s, stroke-width 0.2s',
     },

--- a/packages/ai-workspace-common/src/components/canvas/index.scss
+++ b/packages/ai-workspace-common/src/components/canvas/index.scss
@@ -37,3 +37,7 @@
 .react-flow__node-group {
   padding: 0 !important;
 }
+
+.react-flow__attribution {
+  background: transparent !important;
+}

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/canvas-title.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/canvas-title.tsx
@@ -63,7 +63,7 @@ export const CanvasTitle = memo(
     return (
       <>
         <div
-          className="ml-1 group flex items-center gap-2 text-sm font-bold text-gray-500 cursor-pointer hover:text-gray-700"
+          className="ml-1 group flex items-center gap-2 text-sm font-bold cursor-pointer"
           onClick={handleEditClick}
           data-cy="canvas-title-edit"
         >
@@ -87,7 +87,10 @@ export const CanvasTitle = memo(
           {!hasCanvasSynced ? (
             <Skeleton className="w-32" active paragraph={false} />
           ) : (
-            <Typography.Text className="!max-w-72 text-gray-500" ellipsis={{ tooltip: true }}>
+            <Typography.Text
+              className="!max-w-72 text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-300"
+              ellipsis={{ tooltip: true }}
+            >
               {canvasTitle || t('common.untitled')}
             </Typography.Text>
           )}

--- a/packages/ai-workspace-common/src/hooks/canvas/use-edge-operations.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-edge-operations.ts
@@ -5,6 +5,7 @@ import { useEdgeStyles, getEdgeStyles } from '../../components/canvas/constants'
 import { useCanvasSync } from './use-canvas-sync';
 import { CanvasNode } from '@refly-packages/ai-workspace-common/components/canvas/nodes';
 import { edgeEventsEmitter } from '@refly-packages/ai-workspace-common/events/edge';
+import { useThemeStore } from '@refly-packages/ai-workspace-common/stores/theme';
 
 export const useEdgeOperations = () => {
   const { getState, setState } = useStoreApi<CanvasNode<any>>();
@@ -69,7 +70,8 @@ export const useEdgeOperations = () => {
   const updateAllEdgesStyle = useCallback(
     (showEdges: boolean) => {
       const { edges } = getState();
-      const edgeStyles = getEdgeStyles(showEdges);
+      const { isDarkMode } = useThemeStore.getState();
+      const edgeStyles = getEdgeStyles(showEdges, isDarkMode);
       const updatedEdges = edges.map((edge) => ({
         ...edge,
         style: edgeStyles.default,


### PR DESCRIPTION
# Summary

- Updated edge styles to support dark mode by integrating theme context.
- Modified `getEdgeStyles` function to accept dark mode parameter.
- Improved styling in `CanvasTitle` component for better dark mode support.
- Added transparent background for attribution in canvas styles.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
