### PR TITLE
feat: implement Monaco Editor preloading for better performance

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -36,6 +36,7 @@ import { useThemeStoreShallow } from '@refly-packages/ai-workspace-common/stores
 import { theme } from 'antd';
 import { SuspenseLoading } from '@refly-packages/ai-workspace-common/components/common/loading';
 import { sentryEnabled } from '@refly-packages/ai-workspace-common/utils/env';
+import { preloadMonacoEditor } from '@refly-packages/ai-workspace-common/modules/artifacts/code-runner/monaco-editor/monacoPreloader';
 
 // styles
 import '@/styles/style.css';
@@ -133,6 +134,10 @@ export const App = () => {
     // 初始化主题
     initTheme();
   }, [setRuntime, initTheme]);
+
+  useEffect(() => {
+    preloadMonacoEditor();
+  }, []);
 
   // Use light theme when forced, otherwise use the user's preference
   const shouldUseDarkTheme = isDarkMode && !isForcedLightMode;

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/index.tsx
@@ -23,6 +23,7 @@ import { EnhancedSkillResponse } from './skill-response/enhanced-skill-response'
 import { useReactFlow } from '@xyflow/react';
 import { useSearchParams } from 'react-router-dom';
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
+import { preloadMonacoEditor } from '@refly-packages/ai-workspace-common/modules/artifacts/code-runner/monaco-editor/monacoPreloader';
 
 // DnD item type constant
 const ITEM_TYPE = 'node-preview';
@@ -372,6 +373,10 @@ export const NodePreviewContainer = memo(
         showReflyPilot: state.showReflyPilot,
         showSlideshow: state.showSlideshow,
       }));
+
+    useEffect(() => {
+      preloadMonacoEditor();
+    }, []);
 
     // Compute fresh node previews using the utility function
     const nodePreviews = useMemo(() => {

--- a/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerList.tsx
+++ b/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerList.tsx
@@ -34,6 +34,7 @@ import {
 import { useListMcpServersSuspense } from '@refly-packages/ai-workspace-common/queries/suspense';
 import { McpServerForm } from '@refly-packages/ai-workspace-common/components/settings/mcp-server/McpServerForm';
 import { McpServerBatchImport } from '@refly-packages/ai-workspace-common/components/settings/mcp-server/McpServerBatchImport';
+import { preloadMonacoEditor } from '@refly-packages/ai-workspace-common/modules/artifacts/code-runner/monaco-editor/monacoPreloader';
 
 interface McpServerListProps {
   visible: boolean;
@@ -47,6 +48,10 @@ export const McpServerList: React.FC<McpServerListProps> = ({ visible }) => {
   const [deleteModalVisible, setDeleteModalVisible] = useState(false);
   const [serverToDelete, setServerToDelete] = useState<McpServerDTO | null>(null);
   const [serverTools, setServerTools] = useState<Record<string, any[]>>({});
+
+  useEffect(() => {
+    preloadMonacoEditor();
+  }, []);
 
   // Fetch MCP servers
   const { data, refetch } = useListMcpServersSuspense({}, [], {

--- a/packages/ai-workspace-common/src/modules/artifacts/code-runner/monaco-editor/monacoPreloader.ts
+++ b/packages/ai-workspace-common/src/modules/artifacts/code-runner/monaco-editor/monacoPreloader.ts
@@ -1,0 +1,91 @@
+import { loader, Monaco } from '@monaco-editor/react';
+import { PRIMARY_CDN, FALLBACK_CDN2, FALLBACK_CDN3 } from './constants';
+
+const CDNs = [
+  { name: 'PRIMARY_CDN', url: PRIMARY_CDN },
+  { name: 'FALLBACK_CDN2', url: FALLBACK_CDN2 },
+  { name: 'FALLBACK_CDN3', url: FALLBACK_CDN3 },
+];
+
+let preloadingAttempted = false;
+let preloadingSucceeded = false;
+
+/**
+ * Tries to load Monaco Editor from a list of CDNs sequentially.
+ * @param cdnIndex The current index of the CDN to try from the CDNs array.
+ */
+const tryLoadMonacoRecursive = async (cdnIndex: number): Promise<Monaco | null> => {
+  if (cdnIndex >= CDNs.length) {
+    console.warn('[MonacoPreloader] All CDN preload attempts failed.');
+    return null;
+  }
+
+  const currentCdn = CDNs[cdnIndex];
+  console.log(
+    `[MonacoPreloader] Attempting to preload Monaco Editor from: ${currentCdn.name} (${currentCdn.url})`,
+  );
+
+  try {
+    loader.config({
+      paths: {
+        vs: currentCdn.url,
+      },
+      // Fix for language bundle loading issues
+      'vs/nls': {
+        availableLanguages: {},
+      },
+    });
+
+    const monacoInstance = await loader.init();
+    console.log(
+      `[MonacoPreloader] Monaco Editor preloaded successfully from: ${currentCdn.name} (${currentCdn.url})`,
+      monacoInstance,
+    );
+    preloadingSucceeded = true;
+    return monacoInstance;
+  } catch (error) {
+    console.warn(
+      `[MonacoPreloader] Failed to preload Monaco Editor from ${currentCdn.name} (${currentCdn.url}):`,
+      error,
+    );
+    // Try the next CDN
+    return tryLoadMonacoRecursive(cdnIndex + 1);
+  }
+};
+
+/**
+ * Initializes and preloads the Monaco Editor, trying multiple CDNs if necessary.
+ * Call this function early in your application's lifecycle,
+ * e.g., in your main App component or a similar top-level component.
+ * This function ensures preloading is attempted only once.
+ */
+export const preloadMonacoEditor = (): void => {
+  if (preloadingAttempted) {
+    console.log(
+      '[MonacoPreloader] Preloading already attempted. Current status (succeeded):',
+      preloadingSucceeded,
+    );
+    return;
+  }
+  preloadingAttempted = true;
+
+  tryLoadMonacoRecursive(0)
+    .then((monacoInstance) => {
+      if (monacoInstance) {
+        // Optional: You can perform any global Monaco configurations here if needed.
+        // For example, setting global compiler options for TypeScript:
+        // if (monacoInstance.languages && monacoInstance.languages.typescript) {
+        //   monacoInstance.languages.typescript.typescriptDefaults.setCompilerOptions({
+        //     // your global compiler options here
+        //   });
+        // }
+      } else {
+        // This case is already handled by the last log in tryLoadMonacoRecursive
+      }
+    })
+    .catch((error) => {
+      // This catch is unlikely to be hit due to the recursive try-catch,
+      // but included for robustness.
+      console.error('[MonacoPreloader] Unexpected error during preload sequence:', error);
+    });
+};


### PR DESCRIPTION
Add Monaco Editor preloader utility that attempts to load from multiple CDNs with fallbacks. Integrate preloading in NodePreviewContainer and McpServerList components to improve initial load times for code editing features.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
