### PR TITLE
Add audio URL detection and processing in markdown plugins

### DIFF
--- a/packages/ai-workspace-common/src/components/markdown/plugins/mcp-call/render.tsx
+++ b/packages/ai-workspace-common/src/components/markdown/plugins/mcp-call/render.tsx
@@ -1,8 +1,166 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MarkdownMode } from '../../types';
-import { ToolOutlined } from '@ant-design/icons';
+import { ToolOutlined, SoundOutlined, PauseOutlined } from '@ant-design/icons';
 import { ImagePreview } from '@refly-packages/ai-workspace-common/components/common/image-preview';
+
+// Audio Player Component
+interface AudioPlayerProps {
+  audioUrl: string;
+  audioName?: string;
+  audioFormat?: string;
+}
+
+const AudioPlayer: React.FC<AudioPlayerProps> = ({
+  audioUrl,
+  audioName = 'audio',
+  audioFormat = 'flac',
+}) => {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [volume, setVolume] = useState(1);
+
+  // Format time to display as MM:SS
+  const formatTime = (time: number) => {
+    if (Number.isNaN(time)) return '0:00';
+    const minutes = Math.floor(time / 60);
+    const seconds = Math.floor(time % 60);
+    return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
+  };
+
+  // Handle play/pause toggle
+  const togglePlay = () => {
+    if (audioRef.current) {
+      if (isPlaying) {
+        audioRef.current.pause();
+      } else {
+        audioRef.current.play();
+      }
+      setIsPlaying(!isPlaying);
+    }
+  };
+
+  // Handle time update
+  const handleTimeUpdate = () => {
+    if (audioRef.current) {
+      setCurrentTime(audioRef.current.currentTime);
+    }
+  };
+
+  // Handle metadata loaded
+  const handleLoadedMetadata = () => {
+    if (audioRef.current) {
+      setDuration(audioRef.current.duration);
+    }
+  };
+
+  // Handle volume change
+  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newVolume = Number.parseFloat(e.target.value);
+    setVolume(newVolume);
+    if (audioRef.current) {
+      audioRef.current.volume = newVolume;
+    }
+  };
+
+  // Handle progress bar change
+  const handleProgressChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newTime = Number.parseFloat(e.target.value);
+    setCurrentTime(newTime);
+    if (audioRef.current) {
+      audioRef.current.currentTime = newTime;
+    }
+  };
+
+  // Handle audio ended
+  const handleEnded = () => {
+    setIsPlaying(false);
+    setCurrentTime(0);
+    if (audioRef.current) {
+      audioRef.current.currentTime = 0;
+    }
+  };
+
+  return (
+    <div className="my-3 rounded-lg border border-gray-300 dark:border-gray-700 overflow-hidden bg-white dark:bg-gray-800 shadow-sm">
+      <div className="flex items-center justify-between px-4 py-2">
+        <div className="flex items-center">
+          <SoundOutlined className="mr-2 text-gray-500 dark:text-gray-400" />
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{audioName}</span>
+        </div>
+        <div className="text-xs text-gray-500 dark:text-gray-400">{audioFormat.toUpperCase()}</div>
+      </div>
+
+      <div className="px-4 pb-3 pt-1">
+        <div className="flex items-center gap-2 mb-1">
+          <button
+            type="button"
+            onClick={togglePlay}
+            className="flex items-center justify-center w-8 h-8 rounded-full bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+            aria-label={isPlaying ? 'Pause' : 'Play'}
+          >
+            {isPlaying ? (
+              <PauseOutlined className="text-gray-700 dark:text-gray-300" />
+            ) : (
+              <span className="text-gray-700 dark:text-gray-300 ml-0.5">▶</span>
+            )}
+          </button>
+
+          <div className="text-xs text-gray-600 dark:text-gray-400 w-10 text-center">
+            {formatTime(currentTime)}
+          </div>
+
+          <div className="flex-1 mx-1">
+            <input
+              type="range"
+              min="0"
+              max={duration || 0}
+              value={currentTime}
+              onChange={handleProgressChange}
+              className="w-full h-1.5 bg-gray-200 dark:bg-gray-600 rounded-full appearance-none cursor-pointer"
+              style={{
+                background: `linear-gradient(to right, #2563eb ${(currentTime / (duration || 1)) * 100}%, #e5e7eb ${(currentTime / (duration || 1)) * 100}%)`,
+              }}
+            />
+          </div>
+
+          <div className="text-xs text-gray-600 dark:text-gray-400 w-10 text-center">
+            {formatTime(duration)}
+          </div>
+
+          <div className="flex items-center">
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              value={volume}
+              onChange={handleVolumeChange}
+              className="w-14 h-1.5 bg-gray-200 dark:bg-gray-600 rounded-full appearance-none cursor-pointer"
+              style={{
+                background: `linear-gradient(to right, #2563eb ${volume * 100}%, #e5e7eb ${volume * 100}%)`,
+              }}
+              aria-label="Volume"
+            />
+          </div>
+        </div>
+      </div>
+
+      <audio
+        ref={audioRef}
+        src={audioUrl}
+        onTimeUpdate={handleTimeUpdate}
+        onLoadedMetadata={handleLoadedMetadata}
+        onEnded={handleEnded}
+        className="hidden"
+      >
+        <track kind="captions" src="" label="English" />
+      </audio>
+    </div>
+  );
+};
 
 // SVG icons for the component
 const CheckIcon = () => (
@@ -30,6 +188,9 @@ interface MCPCallProps {
   'data-tool-image-base64-url'?: string;
   'data-tool-image-http-url'?: string;
   'data-tool-image-name'?: string;
+  'data-tool-audio-http-url'?: string;
+  'data-tool-audio-name'?: string;
+  'data-tool-audio-format'?: string;
   id?: string;
   mode?: MarkdownMode;
 }
@@ -66,11 +227,16 @@ const MCPCall: React.FC<MCPCallProps> = (props) => {
   // Check if result exists
   const hasResult = !!resultContent;
 
+  // Image props
   const imageBase64Url = props['data-tool-image-base64-url'];
   const imageHttpUrl = props['data-tool-image-http-url'];
   const imageName = props['data-tool-image-name'];
-
   const imageUrl = imageBase64Url || imageHttpUrl;
+
+  // Audio props
+  const audioHttpUrl = props['data-tool-audio-http-url'];
+  const audioName = props['data-tool-audio-name'];
+  const audioFormat = props['data-tool-audio-format'];
 
   return (
     <>
@@ -160,6 +326,11 @@ const MCPCall: React.FC<MCPCallProps> = (props) => {
             />
           </div>
         </div>
+      )}
+
+      {/* Audio Player section */}
+      {audioHttpUrl && audioFormat && (
+        <AudioPlayer audioUrl={audioHttpUrl} audioName={audioName} audioFormat={audioFormat} />
       )}
     </>
   );

--- a/packages/ai-workspace-common/src/components/markdown/plugins/mcp-call/render.tsx
+++ b/packages/ai-workspace-common/src/components/markdown/plugins/mcp-call/render.tsx
@@ -304,12 +304,12 @@ const MCPCall: React.FC<MCPCallProps> = (props) => {
 
       {/* Image Preview section - styled as a separate card below the main MCPCall card */}
       {imageUrl && imageName && (
-        <div className="my-3 rounded-lg border border-gray-300 dark:border-gray-700 overflow-hidden cursor-pointer bg-white dark:bg-gray-800">
-          <div className="px-4 flex flex-col items-center py-2">
+        <div className="mb-3 rounded-lg border border-gray-300 dark:border-gray-700 overflow-hidden cursor-pointer bg-white dark:bg-gray-800">
+          <div className="px-2 py-2 flex flex-col items-center">
             <img
               src={imageUrl}
               alt={imageName}
-              className="max-w-full h-auto rounded-md mb-2 shadow-md max-h-[300px]"
+              className="max-w-full h-auto rounded-md shadow-md max-h-[300px]"
               onClick={() => {
                 setPreviewImageUrl(imageUrl);
                 setIsPreviewModalVisible(true);


### PR DESCRIPTION
Enhance the markdown plugin to detect and process audio URLs in tool call results, supporting formats like mp3, wav, ogg, flac, m4a, and aac. This implementation follows the same pattern as image URL handling, extracting audio URLs from results and setting appropriate data attributes.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
