### PR TITLE
Fix/Migration from Arco Design to Ant Design ＆ Support darkmode for scrollbar

### DIFF
--- a/apps/extension/src/components/content-selector/components/hover-menu/index.tsx
+++ b/apps/extension/src/components/content-selector/components/hover-menu/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Button } from '@arco-design/web-react';
+import { Button, message } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { IconCopy, IconSave } from '@arco-design/web-react/icon';
-import { Message } from '@arco-design/web-react';
 import { copyToClipboard } from '@refly-packages/ai-workspace-common/utils';
 import { getSelectionNodesMarkdown } from '@refly/utils/html2md';
 
@@ -23,13 +22,13 @@ const HoverMenu: React.FC<HoverMenuProps> = React.memo(
         const selectedContent = getSelectionNodesMarkdown();
         if (selectedContent) {
           copyToClipboard(selectedContent);
-          Message.success(t('extension.floatingSphere.copySuccess'));
+          message.success(t('extension.floatingSphere.copySuccess'));
           onCopy?.();
           onRemove?.();
         }
       } catch (err) {
         console.error('Failed to copy content:', err);
-        Message.error(t('extension.floatingSphere.copyError'));
+        message.error(t('extension.floatingSphere.copyError'));
       }
     };
 

--- a/apps/web/src/components/landing-page-partials/Footer.tsx
+++ b/apps/web/src/components/landing-page-partials/Footer.tsx
@@ -3,7 +3,7 @@ import Logo from '@/assets/logo.svg';
 import { useTranslation } from 'react-i18next';
 import './footer.scss';
 import { Button } from 'antd';
-import { IconDown } from '@arco-design/web-react/icon';
+import { DownOutlined } from '@ant-design/icons';
 import { UILocaleList } from '@refly-packages/ai-workspace-common/components/ui-locale-list';
 import { useAuthStoreShallow } from '@refly-packages/ai-workspace-common/stores/auth';
 import {
@@ -169,7 +169,7 @@ function Footer() {
                       >
                         <IconLanguage className="h-4 w-4" />
                         {t('language')}{' '}
-                        <IconDown className="ml-1 transition-transform duration-200 group-hover:rotate-180" />
+                        <DownOutlined className="ml-1 transition-transform duration-200 group-hover:rotate-180" />
                       </Button>
                     </UILocaleList>
                   </div>

--- a/apps/web/src/components/layout/index.tsx
+++ b/apps/web/src/components/layout/index.tsx
@@ -1,4 +1,4 @@
-import { Layout } from '@arco-design/web-react';
+import { Layout } from 'antd';
 import { useMatch } from 'react-router-dom';
 import { SiderLayout } from '@refly-packages/ai-workspace-common/components/sider/layout';
 import { useBindCommands } from '@refly-packages/ai-workspace-common/hooks/use-bind-commands';

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Tabs } from '@arco-design/web-react';
+import { Tabs } from 'antd';
 import { Helmet } from 'react-helmet';
 
 // styles
@@ -19,7 +19,7 @@ import { MdOutlineSubscriptions } from 'react-icons/md';
 
 import PageTitle from '@/pages/page-title';
 
-const TabPane = Tabs.TabPane;
+const { TabPane } = Tabs;
 const iconStyle = { fontSize: 16, marginRight: 8 };
 
 const Settings = () => {
@@ -47,11 +47,11 @@ const Settings = () => {
       </Helmet>
       <PageTitle title={t('settings.title')} />
       <div className="settings-inner-container pt-4">
-        <Tabs activeTab={tab} tabPosition="left" size="large" onChange={handleTabChange}>
+        <Tabs activeKey={tab} tabPosition="left" size="large" onChange={handleTabChange}>
           <TabPane
             key="account"
             className="settings-tab"
-            title={
+            tab={
               <span className="settings-tab-title">
                 <RiAccountBoxLine style={iconStyle} />
                 {t('settings.tabs.account')}
@@ -64,7 +64,7 @@ const Settings = () => {
           <TabPane
             key="subscription"
             className="settings-tab"
-            title={
+            tab={
               <span className="settings-tab-title">
                 <MdOutlineSubscriptions style={iconStyle} />
                 {t('settings.tabs.subscription')}
@@ -77,7 +77,7 @@ const Settings = () => {
           <TabPane
             key="language"
             className="settings-tab"
-            title={
+            tab={
               <span className="settings-tab-title">
                 <HiOutlineLanguage style={iconStyle} />
                 {t('settings.tabs.language')}

--- a/apps/web/src/pages/skill/index.tsx
+++ b/apps/web/src/pages/skill/index.tsx
@@ -8,9 +8,7 @@ import { SkillInstanceList } from '@refly-packages/ai-workspace-common/component
 import { useNavigate, useSearchParams } from '@refly-packages/ai-workspace-common/utils/router';
 import './index.scss';
 
-import { Radio } from '@arco-design/web-react';
-
-const RadioGroup = Radio.Group;
+import { Radio } from 'antd';
 
 const ContentHeader = (props: {
   val: string;
@@ -20,21 +18,22 @@ const ContentHeader = (props: {
   const { t } = useTranslation();
   return (
     <div className="skill-list__header flex items-center">
-      <RadioGroup
-        type="button"
+      <Radio.Group
+        buttonStyle="solid"
+        optionType="button"
         size="large"
         className="skill-list__tabs"
         defaultValue={val}
         value={val}
-        onChange={(val) => setVal(val)}
+        onChange={(e) => setVal(e.target.value)}
       >
-        <Radio value="instance" style={{ whiteSpace: 'nowrap' }}>
+        <Radio.Button value="instance" style={{ whiteSpace: 'nowrap' }}>
           {t('skill.tab.skillInstances')}
-        </Radio>
-        <Radio value="template" style={{ whiteSpace: 'nowrap' }}>
+        </Radio.Button>
+        <Radio.Button value="template" style={{ whiteSpace: 'nowrap' }}>
           {t('skill.tab.skillTemplate')}
-        </Radio>
-      </RadioGroup>
+        </Radio.Button>
+      </Radio.Group>
     </div>
   );
 };

--- a/apps/web/src/styles/style.css
+++ b/apps/web/src/styles/style.css
@@ -62,3 +62,35 @@ select:focus {
   )::after {
   content: none !important;
 }
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #c1c1c1;
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #a8a8a8;
+}
+
+/* 暗色模式滚动条样式 */
+.dark ::-webkit-scrollbar-track {
+  background: #2d3748;
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background: #4a5568;
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: #718096;
+}

--- a/apps/web/src/styles/style.css
+++ b/apps/web/src/styles/style.css
@@ -70,7 +70,6 @@ select:focus {
 
 ::-webkit-scrollbar-track {
   background: #f1f1f1;
-  border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb {
@@ -82,15 +81,16 @@ select:focus {
   background: #a8a8a8;
 }
 
-/* 暗色模式滚动条样式 */
-.dark ::-webkit-scrollbar-track {
-  background: #2d3748;
-}
+.dark {
+  ::-webkit-scrollbar-track {
+    background: #2d2d2d;
+  }
 
-.dark ::-webkit-scrollbar-thumb {
-  background: #4a5568;
-}
+  ::-webkit-scrollbar-thumb {
+    background: #555;
+  }
 
-.dark ::-webkit-scrollbar-thumb:hover {
-  background: #718096;
+  ::-webkit-scrollbar-thumb:hover {
+    background: #777;
+  }
 }

--- a/packages/ai-workspace-common/src/components/canvas/front-page/action.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/front-page/action.tsx
@@ -1,6 +1,6 @@
 import { Button, Tooltip, Switch } from 'antd';
 import { memo, useMemo, useRef, useCallback } from 'react';
-import { IconLink, IconSend } from '@arco-design/web-react/icon';
+import { LinkOutlined, SendOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { useUserStoreShallow } from '@refly-packages/ai-workspace-common/stores/user';
 import { getRuntime } from '@refly/utils/env';
@@ -94,7 +94,7 @@ export const Actions = memo(
                   count: detectedUrls?.length,
                 })}
               >
-                <IconLink className="text-sm text-gray-500 flex items-center justify-center cursor-pointer" />
+                <LinkOutlined className="text-sm text-gray-500 flex items-center justify-center cursor-pointer" />
               </Tooltip>
             </div>
           )}
@@ -117,7 +117,7 @@ export const Actions = memo(
               onClick={handleSendMessage}
               loading={loading}
             >
-              <IconSend />
+              <SendOutlined />
               <span>{t('copilot.chatActions.send')}</span>
             </Button>
           )}

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/chat-actions/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/chat-actions/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Tooltip, Upload, Switch, FormInstance } from 'antd';
 import { memo, useMemo, useRef, useCallback } from 'react';
 import { IconImage } from '@refly-packages/ai-workspace-common/components/common/icon';
-import { IconLink, IconSend } from '@arco-design/web-react/icon';
+import { LinkOutlined, SendOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { useUserStoreShallow } from '@refly-packages/ai-workspace-common/stores/user';
 import { getRuntime } from '@refly/utils/env';
@@ -112,7 +112,7 @@ export const ChatActions = memo(
                   count: detectedUrls?.length,
                 })}
               >
-                <IconLink className="text-sm text-gray-500 flex items-center justify-center cursor-pointer" />
+                <LinkOutlined className="text-sm text-gray-500 flex items-center justify-center cursor-pointer" />
               </Tooltip>
             </div>
           )}
@@ -153,7 +153,7 @@ export const ChatActions = memo(
               className="text-xs flex items-center gap-1"
               onClick={handleSendClick}
             >
-              <IconSend />
+              <SendOutlined />
               <span>{t('copilot.chatActions.send')}</span>
             </Button>
           )}

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/chat-actions/model-selector.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/chat-actions/model-selector.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo, useCallback, memo } from 'react';
 import { Button, Divider, Dropdown, DropdownProps, MenuProps, Skeleton, Tooltip } from 'antd';
 import { useTranslation } from 'react-i18next';
-import { IconDown } from '@arco-design/web-react/icon';
+import { DownOutlined } from '@ant-design/icons';
 import { ModelIcon } from '@lobehub/icons';
 import { getPopupContainer } from '@refly-packages/ai-workspace-common/utils/ui';
 import { LLMModelConfig, ModelInfo, TokenUsageMeter } from '@refly/openapi-schema';
@@ -58,7 +58,7 @@ const SelectedModelDisplay = memo(
         icon={<ModelIcon model={model.name} type={'color'} />}
       >
         {model.label}
-        <IconDown />
+        <DownOutlined />
       </Button>
     );
   },

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/chat-input.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/chat-input.tsx
@@ -1,7 +1,7 @@
 import { AutoComplete, AutoCompleteProps, Input } from 'antd';
 import { memo, useRef, useMemo, useState, useCallback, forwardRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { RefTextAreaType } from '@arco-design/web-react/es/Input/textarea';
+import type { TextAreaRef } from 'antd/es/input/TextArea';
 import { useSearchStoreShallow } from '@refly-packages/ai-workspace-common/stores/search';
 import type { Skill } from '@refly/openapi-schema';
 import { useSkillStoreShallow } from '@refly-packages/ai-workspace-common/stores/skill';
@@ -55,7 +55,7 @@ const ChatInputComponent = forwardRef<HTMLDivElement, ChatInputProps>(
       setIsMac(navigator.platform.toUpperCase().indexOf('MAC') >= 0);
     }, []);
 
-    const inputRef = useRef<RefTextAreaType>(null);
+    const inputRef = useRef<TextAreaRef>(null);
     const hasMatchedOptions = useRef(false);
 
     const searchStore = useSearchStoreShallow((state) => ({

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/context-manager/components/add-base-mark-context/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/context-manager/components/add-base-mark-context/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Badge, Button, Popover, Tooltip } from 'antd';
-import { IconPlus } from '@arco-design/web-react/icon';
+import { PlusOutlined } from '@ant-design/icons';
 import { BaseMarkContextSelector } from '../base-mark-context-selector';
 import { useTranslation } from 'react-i18next';
 import { getPopupContainer } from '@refly-packages/ai-workspace-common/utils/ui';
@@ -66,7 +66,7 @@ export const AddBaseMarkContext = ({ contextItems, setContextItems }: AddBaseMar
           getPopupContainer={getPopupContainer}
         >
           <Button
-            icon={<IconPlus className="w-3 h-3" />}
+            icon={<PlusOutlined className="w-3 h-3" />}
             size="small"
             type="default"
             className="text-xs h-6 rounded border text-gray-500 gap-1"

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/context-manager/components/base-mark-context-selector/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/context-manager/components/base-mark-context-selector/index.tsx
@@ -8,7 +8,7 @@ import { Command } from 'cmdk';
 import { Home } from './home';
 import { getContextItemIcon } from '../../utils/icon';
 import { CanvasNodeType } from '@refly/openapi-schema';
-import { IconRefresh } from '@arco-design/web-react/icon';
+import { ReloadOutlined } from '@ant-design/icons';
 import {
   IContextItem,
   useContextPanelStoreShallow,
@@ -183,7 +183,7 @@ export const BaseMarkContextSelector = (props: BaseMarkContextSelectorProps) => 
               </div>
             </div>
             <div className="cmdk-footer-action">
-              <Button size="small" icon={<IconRefresh />} onClick={handleClear}>
+              <Button size="small" icon={<ReloadOutlined />} onClick={handleClear}>
                 {t('knowledgeBase.context.clearContext')}
               </Button>
             </div>

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/context-manager/context-item.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/context-manager/context-item.tsx
@@ -1,5 +1,5 @@
 import { Button, Popover } from 'antd';
-import { IconClose } from '@arco-design/web-react/icon';
+import { CloseOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { useReactFlow } from '@xyflow/react';
 import { getContextItemIcon } from './utils/icon';
@@ -7,7 +7,7 @@ import { IContextItem } from '@refly-packages/ai-workspace-common/stores/context
 import cn from 'classnames';
 import { ContextPreview } from './context-preview';
 import { useCallback } from 'react';
-import { Message } from '@arco-design/web-react';
+import { message } from 'antd';
 import { useNodeSelection } from '@refly-packages/ai-workspace-common/hooks/canvas/use-node-selection';
 import { useNodePosition } from '@refly-packages/ai-workspace-common/hooks/canvas/use-node-position';
 import { CanvasNode } from '@refly-packages/ai-workspace-common/components/canvas/nodes';
@@ -60,7 +60,7 @@ export const ContextItem = ({
       );
 
       if (!sourceNode) {
-        Message.warning({
+        message.warning({
           content: t('canvas.contextManager.nodeNotFound'),
         });
         return;
@@ -109,7 +109,7 @@ export const ContextItem = ({
             {title || t(`canvas.nodeTypes.${type}`)}
           </span>
           {!canNotRemove && !readonly && (
-            <IconClose
+            <CloseOutlined
               className={cn('flex-shrink-0 text-xs cursor-pointer', {
                 'text-gray-300': disabled,
                 'text-red-500': isLimit,

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/context-manager/hooks/use-context-filter-errror-tip.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/context-manager/hooks/use-context-filter-errror-tip.tsx
@@ -1,6 +1,6 @@
 import { useContextPanelStore } from '@refly-packages/ai-workspace-common/stores/context-panel';
 import { useTranslation } from 'react-i18next';
-import { Notification } from '@arco-design/web-react';
+import { notification } from 'antd';
 
 export const useContextFilterErrorTip = () => {
   const { t } = useTranslation();
@@ -27,10 +27,10 @@ export const useContextFilterErrorTip = () => {
           ))}
         </div>
       );
-      Notification.error({
+      notification.error({
         style: { width: 400 },
-        title: t('knowledgeBase.context.contextLimitTipTitle'),
-        content: Content,
+        message: t('knowledgeBase.context.contextLimitTipTitle'),
+        description: Content,
       });
       return true;
     }

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/recommend-questions-panel/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/recommend-questions-panel/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Button, Empty, message, Skeleton } from 'antd';
 import { useTranslation } from 'react-i18next';
-import { IconRefresh } from '@arco-design/web-react/icon';
+import { ReloadOutlined } from '@ant-design/icons';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useChatStore } from '@refly-packages/ai-workspace-common/stores/chat';
 import { useInvokeAction } from '@refly-packages/ai-workspace-common/hooks/canvas/use-invoke-action';
@@ -155,7 +155,7 @@ export const RecommendQuestionsPanel: React.FC<RecommendQuestionsPanelProps> = (
             <Button
               type="text"
               size="small"
-              icon={<IconRefresh className="w-4 h-4 text-gray-400 text-[12px]" />}
+              icon={<ReloadOutlined className="w-4 h-4 text-gray-400 text-[12px]" />}
               onClick={() => fetchRecommendQuestions(true)}
               loading={loading}
               className="text-[12px] text-[rgba(0,0,0,0.5)] dark:text-gray-400"

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/selected-skill-header/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/selected-skill-header/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from 'antd';
-import { IconClose } from '@arco-design/web-react/icon';
+import { CloseOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { Skill } from '@refly/openapi-schema';
 import classNames from 'classnames';
@@ -35,7 +35,7 @@ const SelectedSkillHeaderComponent = ({
         <div className="selected-skill-manage">
           <Button
             type="text"
-            icon={<IconClose />}
+            icon={<CloseOutlined />}
             onClick={() => {
               onClose?.();
               setSelectedSkill?.(null);

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/action-container.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/action-container.tsx
@@ -4,7 +4,12 @@ import { Button, message, Dropdown } from 'antd';
 import type { MenuProps } from 'antd';
 import { ActionResult, ActionStep, Source } from '@refly/openapi-schema';
 import { FilePlus, MoreHorizontal, Target, Trash2 } from 'lucide-react';
-import { IconCheckCircle, IconCopy, IconImport, IconShareAlt } from '@arco-design/web-react/icon';
+import {
+  CheckCircleOutlined,
+  CopyOutlined,
+  ImportOutlined,
+  ShareAltOutlined,
+} from '@ant-design/icons';
 import { copyToClipboard } from '@refly-packages/ai-workspace-common/utils';
 import { parseMarkdownCitationsAndCanvasTags, safeParseJSON } from '@refly/utils/parse';
 import { useDocumentStoreShallow } from '@refly-packages/ai-workspace-common/stores/document';
@@ -60,12 +65,12 @@ const ActionContainerComponent = ({ result, step, nodeId }: ActionContainerProps
   const editorActionList = useMemo(
     () => [
       {
-        icon: <IconImport style={{ fontSize: 14 }} />,
+        icon: <ImportOutlined style={{ fontSize: 14 }} />,
         key: 'insertBelow',
         enabled: step.content && activeDocumentId,
       },
       {
-        icon: <IconCheckCircle style={{ fontSize: 14 }} />,
+        icon: <CheckCircleOutlined style={{ fontSize: 14 }} />,
         key: 'replaceSelection',
         enabled: step.content && activeDocumentId && hasEditorSelection,
       },
@@ -275,7 +280,7 @@ const ActionContainerComponent = ({ result, step, nodeId }: ActionContainerProps
                 <Button
                   type="text"
                   size="small"
-                  icon={<IconCopy style={{ fontSize: 14 }} />}
+                  icon={<CopyOutlined style={{ fontSize: 14 }} />}
                   className="text-[#64645F] text-xs flex justify-center items-center h-6 px-1 rounded-lg hover:bg-[#f1f1f0] hover:text-[#00968f] transition-all duration-400 relative overflow-hidden group"
                   onClick={() => handleCopyToClipboard(step.content)}
                 >
@@ -288,7 +293,7 @@ const ActionContainerComponent = ({ result, step, nodeId }: ActionContainerProps
                   type="text"
                   size="small"
                   loading={isSharing}
-                  icon={<IconShareAlt style={{ fontSize: 14 }} />}
+                  icon={<ShareAltOutlined style={{ fontSize: 14 }} />}
                   className="text-[#64645F] text-xs flex justify-center items-center h-6 px-1 rounded-lg hover:bg-[#f1f1f0] hover:text-[#00968f] transition-all duration-400 relative overflow-hidden group"
                   onClick={handleShare}
                 >

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/action-step.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/action-step.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Steps, Button } from 'antd';
 import { ActionResult, ActionStep, Source } from '@refly/openapi-schema';
 import { Markdown } from '@refly-packages/ai-workspace-common/components/markdown';
-import { IconCheckCircle } from '@arco-design/web-react/icon';
+import { CheckCircleOutlined } from '@ant-design/icons';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { cn } from '@refly/utils/cn';
 import { IconCheck, IconLoading } from '@refly-packages/ai-workspace-common/components/common/icon';
@@ -57,7 +57,7 @@ const LogBox = memo(
             onClick={() => onCollapse(false)}
           >
             <div>
-              <IconCheckCircle /> {t('canvas.skillResponse.stepCompleted')}
+              <CheckCircleOutlined /> {t('canvas.skillResponse.stepCompleted')}
             </div>
             <div className="flex items-center">
               <ChevronDown className="w-4 h-4 text-gray-500" />
@@ -261,7 +261,7 @@ const ArtifactItem = memo(({ artifact, onSelect }: { artifact: any; onSelect: ()
         )}
         {artifact?.status === 'finish' && (
           <>
-            <IconCheckCircle />
+            <CheckCircleOutlined />
             <span>{t('artifact.completed')}</span>
           </>
         )}

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, memo, useRef } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 import { useTranslation } from 'react-i18next';
-import { IconClose } from '@arco-design/web-react/icon';
+import { CloseOutlined } from '@ant-design/icons';
 import { Button, Form } from 'antd';
 import { ModelInfo, Skill, SkillRuntimeConfig, SkillTemplateConfig } from '@refly/openapi-schema';
 import { CanvasNode, CanvasNodeData, SkillNodeMeta } from '../nodes/shared/types';
@@ -54,7 +54,7 @@ const NodeHeader = memo(
             type="text"
             size="small"
             className="p-0"
-            icon={<IconClose />}
+            icon={<CloseOutlined />}
             onClick={() => {
               setSelectedSkill?.(null);
             }}

--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill.tsx
@@ -1,7 +1,7 @@
 import { Edge, NodeProps, Position, useReactFlow } from '@xyflow/react';
 import { CanvasNode, CanvasNodeData, SkillNodeMeta } from './shared/types';
 import { Node } from '@xyflow/react';
-import { Form } from '@arco-design/web-react';
+import { Form } from 'antd';
 import { CustomHandle } from './shared/custom-handle';
 import { useState, useCallback, useEffect, useMemo, memo, useRef } from 'react';
 

--- a/packages/ai-workspace-common/src/components/common/loading/index.tsx
+++ b/packages/ai-workspace-common/src/components/common/loading/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import Logo from '@/assets/logo.svg';
-import { IconLoading } from '@arco-design/web-react/icon';
+import { LoadingOutlined } from '@ant-design/icons';
 
 export const SuspenseLoading = () => {
   const { t } = useTranslation();
@@ -12,7 +12,7 @@ export const SuspenseLoading = () => {
         <span className="text-3xl font-bold">Refly </span>
       </div>
       <div className="text-gray-600 dark:text-gray-300">
-        <IconLoading className="mr-2" />
+        <LoadingOutlined className="mr-2" />
         <span>{t('common.appStarting')}</span>
       </div>
     </div>

--- a/packages/ai-workspace-common/src/components/editor/components/generative/common/ai-selector.tsx
+++ b/packages/ai-workspace-common/src/components/editor/components/generative/common/ai-selector.tsx
@@ -24,7 +24,7 @@ import {
   useContextPanelStoreShallow,
 } from '@refly-packages/ai-workspace-common/stores/context-panel';
 import { copyToClipboard } from '@refly-packages/ai-workspace-common/utils';
-import { IconCopy } from '@arco-design/web-react/icon';
+import { CopyOutlined } from '@ant-design/icons';
 import { ModelSelector } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/chat-actions/model-selector';
 import { useDocumentStore } from '@refly-packages/ai-workspace-common/stores/document';
 
@@ -312,7 +312,7 @@ export const AISelector = memo(({ onOpenChange, inPlaceEditType }: AISelectorPro
                 </Button>
                 <Button
                   size="small"
-                  icon={<IconCopy />}
+                  icon={<CopyOutlined />}
                   onClick={() => {
                     copyToClipboard(resultContent);
                     message.success(t('components.markdown.copySuccess'));

--- a/packages/ai-workspace-common/src/components/editor/core/extensions/image-resizer.tsx
+++ b/packages/ai-workspace-common/src/components/editor/core/extensions/image-resizer.tsx
@@ -1,6 +1,6 @@
 import { useCurrentEditor } from '@tiptap/react';
 import type { FC } from 'react';
-import { Spin } from '@arco-design/web-react';
+import { Spin } from 'antd';
 import { lazy, Suspense } from 'react';
 
 // Dynamically import Moveable

--- a/packages/ai-workspace-common/src/components/markdown/index.tsx
+++ b/packages/ai-workspace-common/src/components/markdown/index.tsx
@@ -1,4 +1,4 @@
-import { IconLoading } from '@arco-design/web-react/icon';
+import { LoadingOutlined } from '@ant-design/icons';
 import { memo, useEffect, useRef, useState, Suspense, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 
@@ -119,7 +119,7 @@ export const Markdown = memo(
     return (
       <div className={markdownClassName} ref={mdRef}>
         {props.loading ? (
-          <IconLoading />
+          <LoadingOutlined />
         ) : (
           <Suspense fallback={<div>{t('common.loading')}</div>}>
             {isKatexLoaded &&

--- a/packages/ai-workspace-common/src/components/markdown/plugins/code/render.tsx
+++ b/packages/ai-workspace-common/src/components/markdown/plugins/code/render.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useMemo, useState } from 'react';
-import { Message as message, Space } from '@arco-design/web-react';
+import { message, Space } from 'antd';
 import { Button, Tooltip } from 'antd';
 import copyToClipboard from 'copy-to-clipboard';
 import { useTranslation } from 'react-i18next';
 import React from 'react';
 import { CodeArtifactType } from '@refly/openapi-schema';
-import { IconCopy, IconCode, IconEye } from '@arco-design/web-react/icon';
+import { CopyOutlined, CodeOutlined, EyeOutlined } from '@ant-design/icons';
 import { cn } from '@refly/utils';
 import MermaidComponent from '../mermaid/render';
 import Renderer from '@refly-packages/ai-workspace-common/modules/artifacts/code-runner/render';
@@ -151,7 +151,7 @@ const PreCode = React.memo(
                   type="default"
                   size="small"
                   className="flex items-center justify-center bg-white/80 hover:bg-white border border-gray-200 dark:bg-gray-900 dark:border-gray-700"
-                  icon={<IconCopy />}
+                  icon={<CopyOutlined />}
                   onClick={handleCopy}
                 />
               </Tooltip>
@@ -160,7 +160,7 @@ const PreCode = React.memo(
                   type="default"
                   size="small"
                   className="flex items-center justify-center bg-white/80 hover:bg-white border border-gray-200 dark:bg-gray-900 dark:border-gray-700"
-                  icon={<IconCode />}
+                  icon={<CodeOutlined />}
                   onClick={toggleViewMode}
                 />
               </Tooltip>
@@ -199,7 +199,7 @@ const PreCode = React.memo(
                 type="text"
                 size="small"
                 className="flex items-center justify-center hover:bg-gray-100"
-                icon={<IconCopy />}
+                icon={<CopyOutlined />}
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
@@ -213,7 +213,7 @@ const PreCode = React.memo(
                   type="text"
                   size="small"
                   className="flex items-center justify-center hover:bg-gray-100"
-                  icon={<IconEye />}
+                  icon={<EyeOutlined />}
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();

--- a/packages/ai-workspace-common/src/components/markdown/plugins/mermaid/render.tsx
+++ b/packages/ai-workspace-common/src/components/markdown/plugins/mermaid/render.tsx
@@ -9,7 +9,7 @@ import { ImagePreview } from '@refly-packages/ai-workspace-common/components/com
 import { domToPng } from 'modern-screenshot';
 import copyToClipboard from 'copy-to-clipboard';
 import { IconCodeArtifact } from '@refly-packages/ai-workspace-common/components/common/icon';
-import { IconCode, IconEye, IconCopy } from '@arco-design/web-react/icon';
+import { CopyOutlined, CodeOutlined, EyeOutlined } from '@ant-design/icons';
 import { MarkdownMode } from '../../types';
 import { PiMagnifyingGlassPlusBold } from 'react-icons/pi';
 import { useCreateCodeArtifact } from '@refly-packages/ai-workspace-common/hooks/use-create-code-artifact';
@@ -401,7 +401,7 @@ const MermaidComponent = memo(
                   type="text"
                   size="small"
                   className="flex items-center justify-center hover:bg-gray-100"
-                  icon={<IconCopy className="w-4 h-4 flex items-center justify-center" />}
+                  icon={<CopyOutlined className="w-4 h-4 flex items-center justify-center" />}
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
@@ -422,9 +422,9 @@ const MermaidComponent = memo(
                   className="flex items-center justify-center hover:bg-gray-100"
                   icon={
                     viewMode === 'code' ? (
-                      <IconEye className="w-4 h-4 flex items-center justify-center" />
+                      <EyeOutlined className="w-4 h-4 flex items-center justify-center" />
                     ) : (
-                      <IconCode className="w-4 h-4 flex items-center justify-center" />
+                      <CodeOutlined className="w-4 h-4 flex items-center justify-center" />
                     )
                   }
                   onClick={(e) => {

--- a/packages/ai-workspace-common/src/components/output-locale-list/index.tsx
+++ b/packages/ai-workspace-common/src/components/output-locale-list/index.tsx
@@ -11,7 +11,7 @@ import {
   localeToLanguageName,
 } from '@refly-packages/ai-workspace-common/utils/i18n';
 import { getPopupContainer } from '@refly-packages/ai-workspace-common/utils/ui';
-import { IconDown, IconTranslate } from '@arco-design/web-react/icon';
+import { DownOutlined, TranslationOutlined } from '@ant-design/icons';
 import classNames from 'classnames';
 
 export const OutputLocaleList = (props: {
@@ -73,8 +73,8 @@ export const OutputLocaleList = (props: {
     >
       {props.children || (
         <span className={classNames('output-locale-list-btn', 'chat-action-item')}>
-          <IconDown /> {displayLocale}{' '}
-          {outputLocale === 'auto' && <IconTranslate style={{ marginLeft: 4 }} />}
+          <DownOutlined /> {displayLocale}{' '}
+          {outputLocale === 'auto' && <TranslationOutlined style={{ marginLeft: 4 }} />}
         </span>
       )}
     </Dropdown>

--- a/packages/ai-workspace-common/src/components/project/project-settings/index.tsx
+++ b/packages/ai-workspace-common/src/components/project/project-settings/index.tsx
@@ -10,7 +10,7 @@ import { AiOutlineMenuFold } from 'react-icons/ai';
 import { CreateProjectModal } from '@refly-packages/ai-workspace-common/components/project/project-create';
 import { ActionDropdown } from '@refly-packages/ai-workspace-common/components/workspace/project-list';
 import { SlPicture } from 'react-icons/sl';
-import { IconDown } from '@arco-design/web-react/icon';
+import { DownOutlined } from '@ant-design/icons';
 import { useSiderStoreShallow } from '@refly-packages/ai-workspace-common/stores/sider';
 
 const { Paragraph, Text } = Typography;
@@ -92,7 +92,7 @@ export const ProjectSettings = ({
               className="flex-shrink-0"
               type="text"
               size="small"
-              icon={<IconDown className={cn(iconClassName, 'text-gray-500')} />}
+              icon={<DownOutlined className={cn(iconClassName, 'text-gray-500')} />}
               onClick={(e) => {
                 e.stopPropagation();
                 setShowLibraryModal(true);

--- a/packages/ai-workspace-common/src/components/request-access/index.tsx
+++ b/packages/ai-workspace-common/src/components/request-access/index.tsx
@@ -1,4 +1,4 @@
-import { Result, Button, Modal, Typography } from '@arco-design/web-react';
+import { Result, Button, Modal, Typography } from 'antd';
 import { useUserStoreShallow } from '@refly-packages/ai-workspace-common/stores/user';
 import { useTranslation } from 'react-i18next';
 import { useLogout } from '@refly-packages/ai-workspace-common/hooks/use-logout';
@@ -12,16 +12,15 @@ const RequestAccess = () => {
   const { t } = useTranslation();
   const { handleLogout, contextHolder } = useLogout();
 
-  const visible = true;
+  const _visible = true;
 
   return (
     <Modal
       className="request-access-modal"
-      visible={visible}
+      open={true}
       closable={false}
       footer={null}
-      autoFocus={false}
-      maskStyle={{ background: '#FFFFFF' }}
+      styles={{ mask: { background: '#FFFFFF' } }}
     >
       <div className="flex justify-center items-center h-full request-access">
         <Result

--- a/packages/ai-workspace-common/src/components/resource-view/index.tsx
+++ b/packages/ai-workspace-common/src/components/resource-view/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import getClient from '@refly-packages/ai-workspace-common/requests/proxiedRequest';
 import { Markdown } from '@refly-packages/ai-workspace-common/components/markdown';
-import { IconLoading, IconRefresh } from '@arco-design/web-react/icon';
+import { LoadingOutlined, ReloadOutlined } from '@ant-design/icons';
 import { IconSubscription } from '@refly-packages/ai-workspace-common/components/common/icon';
 import { ResourceIcon } from '@refly-packages/ai-workspace-common/components/common/resourceIcon';
 import { genUniqueId } from '@refly/utils/id';
@@ -57,7 +57,7 @@ const ResourceMeta = memo(
             showIcon
             icon={
               ['wait_index', 'wait_parse'].includes(resourceDetail?.indexStatus) ? (
-                <IconLoading />
+                <LoadingOutlined />
               ) : null
             }
             description={
@@ -71,7 +71,7 @@ const ResourceMeta = memo(
                 <Button
                   size="small"
                   loading={isReindexing}
-                  icon={<IconRefresh />}
+                  icon={<ReloadOutlined />}
                   className="retry-btn"
                   onClick={() => onReindex(resourceDetail.resourceId)}
                 >
@@ -286,7 +286,7 @@ export const ResourceView = memo(
                       !readonly && (
                         <div className="flex justify-center items-center gap-2">
                           <Button
-                            icon={<IconRefresh />}
+                            icon={<ReloadOutlined />}
                             onClick={() => handleReindexResource(resourceId)}
                           >
                             {t('common.retry')}

--- a/packages/ai-workspace-common/src/components/search/data-list.tsx
+++ b/packages/ai-workspace-common/src/components/search/data-list.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Command } from 'cmdk';
 import { useSearchStore } from '@refly-packages/ai-workspace-common/stores/search';
-import { IconFolderAdd } from '@arco-design/web-react/icon';
+import { FolderAddOutlined } from '@ant-design/icons';
 
 import './index.scss';
-import { Button } from '@arco-design/web-react';
+import { Button } from 'antd';
 import { Item } from './item';
 
 // request
@@ -139,7 +139,7 @@ export function DataList({
           onSelect={() => onCreateClick?.()}
           activeValue={activeValue}
         >
-          <IconFolderAdd style={{ fontSize: 12 }} />
+          <FolderAddOutlined style={{ fontSize: 12 }} />
           {t('knowledgeBase.quickSearch.new', { domain })}
         </Item>
       </Command.Group>

--- a/packages/ai-workspace-common/src/components/search/home.tsx
+++ b/packages/ai-workspace-common/src/components/search/home.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { Command } from 'cmdk';
-import { IconApps, IconFolderAdd } from '@arco-design/web-react/icon';
+import { AppstoreAddOutlined, FolderAddOutlined } from '@ant-design/icons';
 
 import './index.scss';
 import { Item } from './item';
@@ -76,7 +76,7 @@ export function Home({
                 }}
                 activeValue={activeValue}
               >
-                <IconApps style={{ fontSize: 12 }} />
+                <AppstoreAddOutlined style={{ fontSize: 12 }} />
                 {t('loggedHomePage.quickSearch.home.showAll', { heading: renderItem?.heading })}
               </Item>
             ) : null}
@@ -89,7 +89,7 @@ export function Home({
                 }}
                 activeValue={activeValue}
               >
-                <IconFolderAdd style={{ fontSize: 12 }} />
+                <FolderAddOutlined style={{ fontSize: 12 }} />
                 {renderItem?.actionHeading?.create}
               </Item>
             ) : null}

--- a/packages/ai-workspace-common/src/components/search/modal.tsx
+++ b/packages/ai-workspace-common/src/components/search/modal.tsx
@@ -1,4 +1,4 @@
-import { Modal } from '@arco-design/web-react';
+import { Modal } from 'antd';
 import { Search } from './index';
 import { useSearchStoreShallow } from '@refly-packages/ai-workspace-common/stores/search';
 import { useEffect } from 'react';
@@ -29,13 +29,14 @@ export const BigSearchModal = () => {
 
   return (
     <Modal
-      visible={isSearchOpen}
+      open={isSearchOpen}
       onCancel={() => setIsSearchOpen(false)}
-      maskStyle={{ background: 'transparent' }}
       footer={null}
       closeIcon={null}
-      alignCenter={false}
-      style={{ background: 'transparent', top: '10%', width: 750 }}
+      styles={{
+        mask: { background: 'transparent' },
+        content: { background: 'transparent', top: '10%', width: 750 },
+      }}
     >
       {isSearchOpen ? <Search showList /> : null}
     </Modal>

--- a/packages/ai-workspace-common/src/components/settings-guide/index.tsx
+++ b/packages/ai-workspace-common/src/components/settings-guide/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useUserStoreShallow } from '@refly-packages/ai-workspace-common/stores/user';
 import { UILocaleList } from '../ui-locale-list';
 import { OutputLocaleList } from '../output-locale-list';
-import { IconDown } from '@arco-design/web-react/icon';
+import { DownOutlined } from '@ant-design/icons';
 import { localeToLanguageName } from '@refly-packages/ai-workspace-common/utils/i18n';
 import {
   IconMouse,
@@ -134,7 +134,7 @@ export const SettingsGuideModal = React.memo(() => {
           </Typography.Paragraph>
           <UILocaleList width={200} onChange={() => setStepTo(1)}>
             <Button>
-              {t('language')} <IconDown />
+              {t('language')} <DownOutlined />
             </Button>
           </UILocaleList>
         </div>
@@ -149,7 +149,7 @@ export const SettingsGuideModal = React.memo(() => {
           </Typography.Paragraph>
           <OutputLocaleList width={200} onChange={() => setStepTo(2)}>
             <Button>
-              {localeToLanguageName?.[uiLocale]?.[outputLocale]} <IconDown />
+              {localeToLanguageName?.[uiLocale]?.[outputLocale]} <DownOutlined />
             </Button>
           </OutputLocaleList>
         </div>

--- a/packages/ai-workspace-common/src/components/settings/language-setting/index.tsx
+++ b/packages/ai-workspace-common/src/components/settings/language-setting/index.tsx
@@ -5,7 +5,7 @@ import './index.scss';
 import { useUserStoreShallow } from '@refly-packages/ai-workspace-common/stores/user';
 // components
 import { UILocaleList } from '@refly-packages/ai-workspace-common/components/ui-locale-list';
-import { IconDown } from '@arco-design/web-react/icon';
+import { DownOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { OutputLocaleList } from '../../output-locale-list';
 import { LOCALE } from '@refly/common-types';
@@ -35,7 +35,7 @@ export const LanguageSetting = () => {
             </Typography.Paragraph>
             <UILocaleList width={200}>
               <Button>
-                {t('language')} <IconDown />
+                {t('language')} <DownOutlined />
               </Button>
             </UILocaleList>
           </div>
@@ -49,7 +49,7 @@ export const LanguageSetting = () => {
             </Typography.Paragraph>
             <OutputLocaleList width={200} position="bl">
               <Button>
-                {localeToLanguageName?.[uiLocale]?.[outputLocale]} <IconDown />
+                {localeToLanguageName?.[uiLocale]?.[outputLocale]} <DownOutlined />
               </Button>
             </OutputLocaleList>
           </div>

--- a/packages/ai-workspace-common/src/components/settings/subscribe-modal/priceContent.tsx
+++ b/packages/ai-workspace-common/src/components/settings/subscribe-modal/priceContent.tsx
@@ -7,7 +7,7 @@ import './index.scss';
 import { useTranslation } from 'react-i18next';
 import { FaLightbulb } from 'react-icons/fa';
 import getClient from '@refly-packages/ai-workspace-common/requests/proxiedRequest';
-import { IconCheck, IconQuestionCircle } from '@arco-design/web-react/icon';
+import { CheckOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import { useSubscriptionStoreShallow } from '@refly-packages/ai-workspace-common/stores/subscription';
 import { useUserStoreShallow } from '@refly-packages/ai-workspace-common/stores/user';
 import { useNavigate } from '@refly-packages/ai-workspace-common/utils/router';
@@ -208,10 +208,10 @@ const PlanItem = (props: {
           {(features || [])?.map((feature, index) => (
             <div className="plane-features-item" key={index}>
               <div className="text-gray-500">
-                <IconCheck style={{ color: 'green', strokeWidth: 6 }} /> {feature.name}
+                <CheckOutlined style={{ color: 'green', strokeWidth: 6 }} /> {feature.name}
                 {feature.tooltip && (
                   <Tooltip title={<div>{feature.tooltip}</div>}>
-                    <IconQuestionCircle className="ml-1" />
+                    <QuestionCircleOutlined className="ml-1" />
                   </Tooltip>
                 )}
               </div>

--- a/packages/ai-workspace-common/src/components/sider/sider-logged-out.tsx
+++ b/packages/ai-workspace-common/src/components/sider/sider-logged-out.tsx
@@ -17,7 +17,7 @@ import {
   IconLanguage,
 } from '@refly-packages/ai-workspace-common/components/common/icon';
 import { UILocaleList } from '@refly-packages/ai-workspace-common/components/ui-locale-list';
-import { IconDown } from '@arco-design/web-react/icon';
+import { DownOutlined } from '@ant-design/icons';
 
 export const SiderLoggedOut = (props: { source: 'sider' | 'popover' }) => {
   const { t } = useTranslation();
@@ -81,7 +81,7 @@ export const SiderLoggedOut = (props: { source: 'sider' | 'popover' }) => {
             >
               <IconLanguage className="h-4 w-4" />
               {t('language')}{' '}
-              <IconDown className="ml-1 transition-transform duration-200 group-hover:rotate-180" />
+              <DownOutlined className="ml-1 transition-transform duration-200 group-hover:rotate-180" />
             </Button>
           </UILocaleList>
         </div>

--- a/packages/ai-workspace-common/src/components/skill/basic-info-form-items/index.tsx
+++ b/packages/ai-workspace-common/src/components/skill/basic-info-form-items/index.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 // components
 import { useTranslation } from 'react-i18next';
 
-import { Form, Input } from '@arco-design/web-react';
+import { Form, Input } from 'antd';
 import { FormHeader } from '@refly-packages/ai-workspace-common/components/skill/form-header';
 
 const FormItem = Form.Item;
@@ -27,27 +27,27 @@ export const BasicInfoFormItems = () => {
             label={t('skill.newSkillModal.name')}
             required
             layout="vertical"
-            field="displayName"
+            name="displayName"
             rules={[{ required: true, message: t('skill.newSkillModal.namePlaceholder') }]}
           >
             <Input
               placeholder={t('skill.newSkillModal.namePlaceholder')}
               maxLength={50}
-              showWordLimit
+              showCount
             />
           </FormItem>
           <FormItem
             label={t('skill.newSkillModal.description')}
             required
             layout="vertical"
-            field="description"
+            name="displayName"
             rules={[{ required: true, message: t('skill.newSkillModal.descriptionPlaceholder') }]}
           >
             <TextArea
               placeholder={t('skill.newSkillModal.descriptionPlaceholder')}
               autoSize
               maxLength={500}
-              showWordLimit
+              showCount
               style={{ minHeight: 84 }}
             />
           </FormItem>

--- a/packages/ai-workspace-common/src/components/skill/form-header/index.tsx
+++ b/packages/ai-workspace-common/src/components/skill/form-header/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { Typography, Select, Tooltip } from '@arco-design/web-react';
-import { IconDown, IconUp } from '@arco-design/web-react/icon';
+import { Typography, Select, Tooltip } from 'antd';
+import { DownOutlined, UpOutlined } from '@ant-design/icons';
 
 // styles
 import './index.scss';
@@ -63,11 +63,11 @@ export const FormHeader: React.FC<FormHeaderProps> = ({
       <div className="form-header-left" onClick={handleCollapseChange}>
         {enableCollapse && (
           <Typography.Text style={{ color: 'rgba(0, 0, 0, .5)' }}>
-            {collapsed ? <IconDown /> : <IconUp />}
+            {collapsed ? <DownOutlined /> : <UpOutlined />}
           </Typography.Text>
         )}
         {icon && <div className="form-header-icon">{icon}</div>}
-        <Typography.Title heading={6} style={{ margin: 0, marginLeft: 8 }}>
+        <Typography.Title level={5} style={{ margin: 0, marginLeft: 8 }}>
           {title}
         </Typography.Title>
       </div>
@@ -81,15 +81,15 @@ export const FormHeader: React.FC<FormHeaderProps> = ({
         {enableSelect && (
           <>
             {!isMultiSelect && (
-              <Tooltip content={selectTooltipTitle} getPopupContainer={getPopupContainer}>
+              <Tooltip title={selectTooltipTitle} getPopupContainer={getPopupContainer}>
                 <Select
-                  size="mini"
+                  size="small"
                   getPopupContainer={getPopupContainer}
                   className="context-selector"
                   defaultValue={options?.[0]?.value}
                   options={options}
                   onChange={handleSelectChange}
-                  autoWidth={{ minWidth: 100, maxWidth: 200 }}
+                  style={{ minWidth: 100, maxWidth: 200 }}
                 />
               </Tooltip>
             )}

--- a/packages/ai-workspace-common/src/components/skill/instance-dropdown-menu/index.tsx
+++ b/packages/ai-workspace-common/src/components/skill/instance-dropdown-menu/index.tsx
@@ -1,7 +1,7 @@
 import { RiDeleteBinLine, RiMoreFill } from 'react-icons/ri';
 import { TbEdit } from 'react-icons/tb';
 
-import { Dropdown, Menu, Button, Popconfirm, Message } from '@arco-design/web-react';
+import { Dropdown, Menu, Button, Popconfirm, message } from 'antd';
 import { useState } from 'react';
 import { useLocation, useSearchParams } from '@refly-packages/ai-workspace-common/utils/router';
 import { useSkillStore } from '@refly-packages/ai-workspace-common/stores/skill';
@@ -30,7 +30,7 @@ const DropList = (props: DropListProps) => {
   const { t } = useTranslation();
 
   return (
-    <Menu onClick={(e) => e.stopPropagation()}>
+    <Menu onClick={(e) => e.domEvent.stopPropagation()}>
       <Menu.Item key="edit">
         <div onClick={(e) => handlUpdateInstance(e)}>
           <TbEdit style={iconStyle} />
@@ -39,13 +39,12 @@ const DropList = (props: DropListProps) => {
       </Menu.Item>
       <Menu.Item key="delete">
         <Popconfirm
-          focusLock
           title={t('common.deleteConfirmMessage')}
-          position="br"
+          placement="bottomRight"
           okText={t('common.confirm')}
           cancelText={t('common.cancel')}
           getPopupContainer={getPopupContainer}
-          onOk={(e) => {
+          onConfirm={(e) => {
             handleDeleteInstance(e);
           }}
           onCancel={(e) => {
@@ -93,7 +92,7 @@ export const InstanceDropdownMenu = (props: InstanceDropdownMenuProps) => {
       console.error(error);
       return;
     }
-    Message.success({ content: t('common.putSuccess') });
+    message.success(t('common.putSuccess'));
 
     if (postDeleteList) {
       postDeleteList(data);
@@ -125,10 +124,10 @@ export const InstanceDropdownMenu = (props: InstanceDropdownMenuProps) => {
 
   return (
     <Dropdown
-      position="br"
-      popupVisible={popupVisible}
-      droplist={droplist}
-      triggerProps={{ onClickOutside: () => setPopupVisible(false) }}
+      placement="bottomRight"
+      open={popupVisible}
+      dropdownRender={() => droplist}
+      onOpenChange={(visible) => setPopupVisible(visible)}
       getPopupContainer={getPopupContainer}
     >
       <Button

--- a/packages/ai-workspace-common/src/components/skill/skill-avatar/index.tsx
+++ b/packages/ai-workspace-common/src/components/skill/skill-avatar/index.tsx
@@ -1,4 +1,4 @@
-import { Avatar } from '@arco-design/web-react';
+import { Avatar } from 'antd';
 import { Icon } from '@refly/openapi-schema';
 interface SkillAvatarProps {
   icon: Icon;

--- a/packages/ai-workspace-common/src/components/skill/skill-management-modal/index.tsx
+++ b/packages/ai-workspace-common/src/components/skill/skill-management-modal/index.tsx
@@ -1,5 +1,5 @@
 import { useSkillStore } from '@refly-packages/ai-workspace-common/stores/skill';
-import { Modal } from '@arco-design/web-react';
+import { Modal } from 'antd';
 
 // 组件
 import { SkillInstanceList } from '@refly-packages/ai-workspace-common/components/skill/skill-intance-list';
@@ -19,9 +19,9 @@ export const SkillManagementModal = (_props: any) => {
 
   return (
     <Modal
-      visible={skillStore.skillManagerModalVisible}
+      open={skillStore.skillManagerModalVisible}
       title={t('copilot.skillDisplay.skillManager')}
-      getPopupContainer={() => {
+      getContainer={() => {
         const elem = getPopupContainer();
 
         return elem;
@@ -30,7 +30,7 @@ export const SkillManagementModal = (_props: any) => {
       className="skill-management-modal-wrap"
       footer={null}
       onCancel={onCancel}
-      escToExit
+      keyboard={true}
     >
       <div className="skill-management-modal-content">
         <SkillInstanceList source="skill-management-modal" />

--- a/packages/ai-workspace-common/src/components/skill/skill-triggers/index.tsx
+++ b/packages/ai-workspace-common/src/components/skill/skill-triggers/index.tsx
@@ -14,11 +14,17 @@ import './index.scss';
 import { SkillTrigger } from '@refly/openapi-schema';
 
 import { ScrollLoading } from '@refly-packages/ai-workspace-common/components/workspace/scroll-loading';
-import { List, Empty, Grid, Divider, Switch, Popconfirm } from '@arco-design/web-react';
-import { IconDelete, IconSchedule, IconThunderbolt, IconTool } from '@arco-design/web-react/icon';
+import { List, Empty, Row, Col, Divider, Switch, Popconfirm } from 'antd';
+import {
+  DeleteOutlined,
+  ScheduleOutlined,
+  ThunderboltOutlined,
+  ToolOutlined,
+} from '@ant-design/icons';
 
-const Row = Grid.Row;
-const Col = Grid.Col;
+// 不再需要这些行，因为我们直接从antd导入Row和Col
+// const Row = Grid.Row;
+// const Col = Grid.Col;
 
 export const SkillTriggers = () => {
   const { t } = useTranslation();
@@ -67,7 +73,7 @@ export const SkillTriggers = () => {
 
     return (
       <div className="skill-triggers__card">
-        <Row align="center" justify="center">
+        <Row align="middle" justify="center">
           <Col span={4} className="skill-triggers__card-col ellipsis">
             {trigger.displayName}
           </Col>
@@ -79,13 +85,13 @@ export const SkillTriggers = () => {
           <Col span={4} className="skill-triggers__card-col">
             {eventType === 'timer' && (
               <div>
-                <IconSchedule style={{ marginRight: 8 }} />
+                <ScheduleOutlined style={{ marginRight: 8 }} />
                 {t('skill.newTriggerModal.timer')}
               </div>
             )}
             {eventType === 'simpleEvent' && (
               <div>
-                <IconThunderbolt style={{ marginRight: 8 }} />
+                <ThunderboltOutlined style={{ marginRight: 8 }} />
                 {t('skill.newTriggerModal.simpleEvent')}
               </div>
             )}
@@ -100,25 +106,23 @@ export const SkillTriggers = () => {
             <div className="actions">
               <Switch
                 className="actions-item"
-                type="round"
                 size="small"
                 checked={trigger.enabled}
                 onChange={(val) => updateTriggerStatus(val)}
               />
-              <IconTool
+              <ToolOutlined
                 className="actions-item"
                 style={{ fontSize: 16, margin: '0 20px' }}
                 onClick={handleUpdateTrigger}
               />
               <Popconfirm
-                focusLock
                 title={t('common.deleteConfirmMessage')}
-                position="br"
+                placement="bottomRight"
                 okText={t('common.confirm')}
                 cancelText={t('common.cancel')}
-                onOk={deleteTrigger}
+                onConfirm={deleteTrigger}
               >
-                <IconDelete className="actions-item" style={{ fontSize: 16 }} />
+                <DeleteOutlined className="actions-item" style={{ fontSize: 16 }} />
               </Popconfirm>
             </div>
           </Col>
@@ -145,16 +149,11 @@ export const SkillTriggers = () => {
   return (
     <List
       className="skill-triggers"
-      wrapperStyle={{ width: '100%' }}
+      style={{ width: '100%' }}
       bordered={false}
-      split={false}
-      pagination={false}
       dataSource={dataList}
       loading={isRequesting}
-      scrollLoading={
-        <ScrollLoading isRequesting={isRequesting} hasMore={hasMore} loadMore={loadMore} />
-      }
-      render={(item: SkillTrigger, key) => (
+      renderItem={(item: SkillTrigger, key) => (
         <List.Item
           key={item?.triggerId + key}
           style={{
@@ -162,12 +161,15 @@ export const SkillTriggers = () => {
             width: '100%',
           }}
           className="skill-triggers__list-item"
-          actionLayout="vertical"
           onClick={() => {}}
         >
           <TriggerCard trigger={item} />
         </List.Item>
       )}
-    />
+    >
+      {hasMore && (
+        <ScrollLoading isRequesting={isRequesting} hasMore={hasMore} loadMore={loadMore} />
+      )}
+    </List>
   );
 };

--- a/packages/ai-workspace-common/src/components/skill/template-config-form-items/index.tsx
+++ b/packages/ai-workspace-common/src/components/skill/template-config-form-items/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Input, Form, FormInstance, InputNumber, Select } from '@arco-design/web-react';
+import { Input, Form, FormInstance, InputNumber, Select } from 'antd';
 import {
   DynamicConfigItem,
   DynamicConfigValue,
@@ -52,11 +52,11 @@ const ConfigItem = (props: {
         placeholder={placeholder}
         type={(item.inputProps?.passwordType ? 'password' : 'text') as 'text' | 'password'}
         defaultValue={(item?.defaultValue as string) || String(configValue?.value || '') || ''}
-        onChange={(val) =>
+        onChange={(e) =>
           form.setFieldValue(field, {
-            value: val,
+            value: e.target.value,
             label,
-            displayValue: String(val),
+            displayValue: String(e.target.value),
           } as DynamicConfigValue)
         }
       />
@@ -78,11 +78,11 @@ const ConfigItem = (props: {
           minRows: 4,
           maxRows: 10,
         }}
-        onChange={(val) =>
+        onChange={(e) =>
           form.setFieldValue(field, {
-            value: val,
+            value: e.target.value,
             label,
-            displayValue: String(val),
+            displayValue: String(e.target.value),
           } as DynamicConfigValue)
         }
       />
@@ -92,7 +92,6 @@ const ConfigItem = (props: {
   if (item.inputMode === 'inputNumber') {
     return (
       <InputNumber
-        mode="button"
         defaultValue={(item?.defaultValue as number) || Number(configValue?.value) || 1}
         onChange={(val) =>
           form.setFieldValue(field, {
@@ -189,20 +188,19 @@ export const TemplateConfigFormItems = (props: {
                 layout="vertical"
                 label={item.labelDict[locale]}
                 key={item.key}
-                field={field}
+                name={field}
                 required={item.required?.value}
                 rules={[
                   {
-                    validator(value, cb) {
+                    validator(_, value) {
                       if (
                         !value?.value &&
                         item?.required?.value &&
                         item?.required?.configScope.includes(configScope)
                       ) {
-                        return cb(t('common.emptyInput'));
+                        return Promise.reject(t('common.emptyInput'));
                       }
-
-                      return cb();
+                      return Promise.resolve();
                     },
                   },
                 ]}

--- a/packages/ai-workspace-common/src/components/skill/trigger-config-form-items/index.tsx
+++ b/packages/ai-workspace-common/src/components/skill/trigger-config-form-items/index.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
+import dayjs from 'dayjs';
 
 // components
 import { useTranslation } from 'react-i18next';
 
-import { Form, Input, Select, DatePicker } from '@arco-design/web-react';
+import { Form, Input, Select, DatePicker } from 'antd';
 import { FormHeader } from '@refly-packages/ai-workspace-common/components/skill/form-header';
 
 const FormItem = Form.Item;
@@ -35,13 +36,13 @@ export const TriggerConfigFormItems = (props: {
             layout="vertical"
             label={t('skill.newTriggerModal.name')}
             required
-            field="displayName"
+            name="displayName"
             rules={[{ required: true, message: t('skill.newTriggerModal.namePlaceholder') }]}
           >
             <Input
               placeholder={t('skill.newTriggerModal.namePlaceholder')}
               maxLength={50}
-              showWordLimit
+              showCount
             />
           </FormItem>
 
@@ -49,7 +50,7 @@ export const TriggerConfigFormItems = (props: {
             layout="vertical"
             label={t('skill.newTriggerModal.triggerType')}
             required
-            field="triggerType"
+            name="triggerType"
             rules={[{ required: true, message: t('skill.newTriggerModal.triggerTypePlaceholder') }]}
           >
             <Select
@@ -75,14 +76,14 @@ export const TriggerConfigFormItems = (props: {
                 layout="vertical"
                 label={t('skill.newTriggerModal.timerConfig')}
                 required
-                field="timerConfig.datetime"
+                name="timerConfig.datetime"
                 rules={[
                   { required: true, message: t('skill.newTriggerModal.timerConfigPlaceholder') },
                 ]}
               >
                 <DatePicker
                   showTime={{
-                    defaultValue: '00:00:00',
+                    defaultValue: dayjs('00:00:00', 'HH:mm:ss'),
                   }}
                   format="YYYY-MM-DD HH:mm:ss"
                   placeholder={t('skill.newTriggerModal.timerConfigPlaceholder')}
@@ -92,7 +93,7 @@ export const TriggerConfigFormItems = (props: {
               <FormItem
                 layout="vertical"
                 label={t('skill.newTriggerModal.repeatInterval')}
-                field="timerConfig.repeatInterval"
+                name="timerConfig.repeatInterval"
               >
                 <Select
                   allowClear
@@ -116,7 +117,7 @@ export const TriggerConfigFormItems = (props: {
               layout="vertical"
               label={t('skill.newTriggerModal.event')}
               required
-              field="simpleEventName"
+              name="simpleEventName"
               rules={[{ required: true, message: t('skill.newTriggerModal.eventPlaceholder') }]}
             >
               <Select size="large" placeholder={t('skill.newTriggerModal.eventPlaceholder')}>

--- a/packages/ai-workspace-common/src/components/source-list/index.tsx
+++ b/packages/ai-workspace-common/src/components/source-list/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 // 样式
 import './index.scss';
-import { IconRight } from '@arco-design/web-react/icon';
+import { RightOutlined } from '@ant-design/icons';
 import { useKnowledgeBaseStoreShallow } from '@refly-packages/ai-workspace-common/stores/knowledge-base';
 import { getRuntime } from '@refly/utils/env';
 
@@ -156,7 +156,7 @@ const ViewMoreItem = ({
         className="w-full overflow-hidden font-medium whitespace-nowrap text-ellipsis text-zinc-500 dark:text-zinc-400"
         title={t('copilot.sourceListModal.moreSources', { count: extraCnt })}
       >
-        {t('copilot.sourceListModal.moreSources', { count: extraCnt })} <IconRight />
+        {t('copilot.sourceListModal.moreSources', { count: extraCnt })} <RightOutlined />
       </div>
       <div className="flex flex-wrap gap-1 max-w-full overflow-hidden">
         {extraSources.map((item, index) => {

--- a/packages/ai-workspace-common/src/components/source-list/source-detail-list/index.tsx
+++ b/packages/ai-workspace-common/src/components/source-list/source-detail-list/index.tsx
@@ -1,7 +1,7 @@
 // styles
 import './index.scss';
 import { HiOutlineSearch, HiOutlinePlus } from 'react-icons/hi';
-import { Divider, Input, Skeleton } from '@arco-design/web-react';
+import { Divider, Input, Skeleton } from 'antd';
 import { useState } from 'react';
 import { Source } from '@refly/openapi-schema';
 
@@ -63,9 +63,9 @@ export const SourceDetailList = (props: SourceDetailListProps) => {
       <div className="source-detail-inner-list" style={small ? { minWidth: 72, width: 72 } : {}}>
         {props?.isFetching ? (
           <div style={{ margin: '8px auto' }}>
-            <Skeleton animation style={{ marginTop: 24 }} />
-            <Skeleton animation style={{ marginTop: 24 }} />
-            <Skeleton animation style={{ marginTop: 24 }} />
+            <Skeleton active style={{ marginTop: 24 }} />
+            <Skeleton active style={{ marginTop: 24 }} />
+            <Skeleton active style={{ marginTop: 24 }} />
           </div>
         ) : (
           (props?.sources || []).map((item, index) => (

--- a/packages/ai-workspace-common/src/components/source-list/source-detail-list/source-detail-item.tsx
+++ b/packages/ai-workspace-common/src/components/source-list/source-detail-list/source-detail-item.tsx
@@ -1,5 +1,5 @@
 import './index.scss';
-import { Tooltip } from '@arco-design/web-react';
+import { Tooltip } from 'antd';
 import { Popover } from 'antd';
 
 import { Source } from '@refly/openapi-schema';
@@ -46,9 +46,9 @@ export const SourceDetailItem = memo((props: SourceDetailItemProps) => {
     >
       <div className="knowledge-base-directory-site-intro">
         <Tooltip
-          position="right"
+          placement="right"
           color="white"
-          content={small ? <div style={{ color: '#000' }}>{item?.title}</div> : null}
+          title={small ? <div style={{ color: '#000' }}>{item?.title}</div> : null}
         >
           <div className="site-intro-icon">
             <img

--- a/packages/ai-workspace-common/src/components/source-list/source-list-modal/index.tsx
+++ b/packages/ai-workspace-common/src/components/source-list/source-list-modal/index.tsx
@@ -6,7 +6,7 @@ import { Source } from '@refly/openapi-schema';
 import { getPopupContainer } from '@refly-packages/ai-workspace-common/utils/ui';
 import { getRuntime } from '@refly/utils/env';
 import './index.scss';
-import { IconLink } from '@arco-design/web-react/icon';
+import { LinkOutlined } from '@ant-design/icons';
 import { SearchResults } from '@refly-packages/ai-workspace-common/modules/multilingual-search/components/search-results';
 import {
   ActionMenu,
@@ -122,7 +122,7 @@ export const SourceListModal = (props: SourceListModalProps) => {
         <div className="source-list-modal-header flex items-center justify-between">
           <div>
             <div className="header-content">
-              <IconLink className="header-icon" />
+              <LinkOutlined className="header-icon" />
               <div className="header-text">
                 <div>
                   <span style={{ fontWeight: 'bold' }}>

--- a/packages/ai-workspace-common/src/components/translation-wrapper/index.tsx
+++ b/packages/ai-workspace-common/src/components/translation-wrapper/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { Spin } from 'antd';
 import cn from 'classnames';
 import './index.scss';
-import { IconLoading } from '@arco-design/web-react/icon';
+import { LoadingOutlined } from '@ant-design/icons';
 
 // Enhance cache with pending promises to prevent duplicate requests
 const translationCache: Record<string, string | Promise<string>> = {};
@@ -130,7 +130,7 @@ export const TranslationWrapper: React.FC<TranslationWrapperProps> = ({
         {isLoading ? (
           <>
             <span className="original-text">{content}</span>
-            <Spin indicator={<IconLoading style={{ fontSize: 12, marginLeft: 4 }} spin />} />
+            <Spin indicator={<LoadingOutlined style={{ fontSize: 12, marginLeft: 4 }} spin />} />
           </>
         ) : (
           <span>{translatedContent ?? content}</span>

--- a/packages/ai-workspace-common/src/components/workspace/content-panel/index.tsx
+++ b/packages/ai-workspace-common/src/components/workspace/content-panel/index.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect } from 'react';
-import { Radio } from '@arco-design/web-react';
+import { Radio } from 'antd';
 import { Affix } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -42,12 +42,13 @@ const ContentHeader = (props: { setVal: (val: string) => void; hitTop: boolean; 
     >
       <div className="flex items-center">
         <RadioGroup
-          type="button"
+          optionType="button"
+          buttonStyle="solid"
           size="large"
           className="content-panel-radio-group"
           defaultValue="resource"
           value={props.val}
-          onChange={(val) => handleTabChange(val)}
+          onChange={(e) => handleTabChange(e.target.value)}
           style={{ borderRadius: 8 }}
         >
           <Radio value="canvas">{t('workspace.contentPanel.tabPanel.canvas')}</Radio>

--- a/packages/ai-workspace-common/src/hooks/use-create-trigger.ts
+++ b/packages/ai-workspace-common/src/hooks/use-create-trigger.ts
@@ -1,5 +1,5 @@
 // components
-import { Message } from '@arco-design/web-react';
+import { message } from 'antd';
 import { useTranslation } from 'react-i18next';
 
 // requests
@@ -15,7 +15,7 @@ export const useCreateTrigger = () => {
     if (error) {
       return error;
     }
-    Message.success({ content: t('common.putSuccess') });
+    message.success({ content: t('common.putSuccess') });
   };
 
   const updateTrigger = async (trigger: SkillTrigger) => {
@@ -41,7 +41,7 @@ export const useCreateTrigger = () => {
       },
     });
     if (!error && data?.success) {
-      Message.success({ content: t('common.putSuccess') });
+      message.success({ content: t('common.putSuccess') });
       return;
     }
     return error;

--- a/packages/ai-workspace-common/src/hooks/use-save-resouce-notify.tsx
+++ b/packages/ai-workspace-common/src/hooks/use-save-resouce-notify.tsx
@@ -1,4 +1,4 @@
-import { Message, Link } from '@arco-design/web-react';
+import { message } from 'antd';
 import { showErrorNotification } from '@refly-packages/ai-workspace-common/utils/notification';
 import type { LOCALE } from '@refly/common-types';
 import type { BaseResponse } from '@refly/openapi-schema';
@@ -13,42 +13,36 @@ export const useSaveResourceNotify = () => {
   const handleSaveResourceAndNotify = async (
     saveResource: () => Promise<{ res: BaseResponse; url: string }>,
   ) => {
-    const close = Message.loading({
+    const messageKey = 'saveResource';
+    message.loading({
       content: t('resource.import.isSaving'),
+      key: messageKey,
       duration: 0,
-      style: {
-        borderRadius: 8,
-        background: '#FFFFFF',
-      },
     });
+
     const { res, url } = await saveResource();
 
     await delay(2000);
-    close();
+    message.destroy(messageKey);
     await delay(200);
 
     if (res?.success) {
-      Message.success({
+      message.success({
         content: (
           <span>
             {t('resource.import.saveResourceSuccess.prefix')}{' '}
-            <Link
+            <a
               href={`${url}?openLibrary=true`}
               target="_blank"
+              rel="noopener noreferrer"
               style={{ borderRadius: 4 }}
-              hoverable
             >
               {t('resource.import.saveResourceSuccess.link')}
-            </Link>{' '}
+            </a>{' '}
             {t('resource.import.saveResourceSuccess.suffix')}
           </span>
         ),
         duration: 5000,
-        style: {
-          borderRadius: 8,
-          background: '#fff',
-        },
-        closable: true,
       });
     } else {
       showErrorNotification(res, locale as LOCALE);

--- a/packages/ai-workspace-common/src/modules/artifacts/code-runner/render/react.tsx
+++ b/packages/ai-workspace-common/src/modules/artifacts/code-runner/render/react.tsx
@@ -7,7 +7,7 @@ import * as shadcnComponents from './shadcn';
 import { CheckIcon, CopyIcon } from 'lucide-react';
 import { useState, useCallback, memo, useMemo } from 'react';
 import { Button, message } from 'antd';
-import { IconClose } from '@arco-design/web-react/icon';
+import { CloseOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 
 const ReactCodeRunner = memo(
@@ -135,7 +135,7 @@ const ErrorMessage = memo(
               className="rounded-full p-1 text-white hover:bg-red-700 hover:text-white"
               aria-label={t('codeArtifact.fix.closeErrorMessage')}
             >
-              <IconClose className="hover:text-white text-white" />
+              <CloseOutlined className="hover:text-white text-white" />
             </Button>
           </div>
 

--- a/packages/ai-workspace-common/src/modules/entity-selector/components/search-list/index.tsx
+++ b/packages/ai-workspace-common/src/modules/entity-selector/components/search-list/index.tsx
@@ -7,7 +7,7 @@ import { useFetchOrSearchList } from '@refly-packages/ai-workspace-common/module
 import { AiOutlineLoading3Quarters } from 'react-icons/ai';
 import { ContextItem } from '@refly-packages/ai-workspace-common/types/context';
 import throttle from 'lodash.throttle';
-import { IconCheck } from '@arco-design/web-react/icon';
+import { CheckOutlined } from '@ant-design/icons';
 import { FileText, Link2 } from 'lucide-react';
 
 interface SearchListProps {
@@ -176,7 +176,7 @@ export const SearchList = (props: SearchListProps) => {
                 <span className="flex-grow truncate">{option.title || t('common.untitled')}</span>
                 {mode === 'multiple' && option.isSelected && (
                   <div className="flex-shrink-0">
-                    <IconCheck className="text-[#00968F] w-4 h-4" />
+                    <CheckOutlined className="text-[#00968F] w-4 h-4" />
                   </div>
                 )}
               </div>

--- a/packages/ai-workspace-common/src/modules/multilingual-search/components/search-box.tsx
+++ b/packages/ai-workspace-common/src/modules/multilingual-search/components/search-box.tsx
@@ -7,7 +7,7 @@ import { SearchOptions } from './search-options';
 
 import './search-box.scss';
 import getClient from '@refly-packages/ai-workspace-common/requests/proxiedRequest';
-import { IconSearch } from '@arco-design/web-react/icon';
+import { SearchOutlined } from '@ant-design/icons';
 
 const { Search: AntSearch } = Input;
 
@@ -78,7 +78,7 @@ export const SearchBox: React.FC = () => {
             className="search-input"
             onChange={(e) => multilingualSearchStore.setQuery(e.target.value)}
             onSearch={handleMultilingualSearch}
-            enterButton={<IconSearch />}
+            enterButton={<SearchOutlined />}
           />
           <SearchOptions />
         </Space>

--- a/packages/ai-workspace-common/src/modules/multilingual-search/components/search-progress.tsx
+++ b/packages/ai-workspace-common/src/modules/multilingual-search/components/search-progress.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Timeline, Spin, Collapse } from 'antd';
-import { IconLoading } from '@arco-design/web-react/icon';
+import { LoadingOutlined } from '@ant-design/icons';
 import { useMultilingualSearchStore } from '../stores/multilingual-search';
 import './search-progress.scss';
 import { useTranslation } from 'react-i18next';
@@ -143,7 +143,9 @@ export const SearchProgress: React.FC = () => {
                   dot:
                     step.step === 'Processing...' ? (
                       <Spin
-                        indicator={<IconLoading style={{ fontSize: 12, color: '#00968f' }} spin />}
+                        indicator={
+                          <LoadingOutlined style={{ fontSize: 12, color: '#00968f' }} spin />
+                        }
                       />
                     ) : undefined,
                   children: (

--- a/packages/ai-workspace-common/src/modules/multilingual-search/index.tsx
+++ b/packages/ai-workspace-common/src/modules/multilingual-search/index.tsx
@@ -6,7 +6,7 @@ import { ActionMenu, ImportActionMode } from './components/action-menu';
 import { SearchHome } from './components/search-home';
 import { useMultilingualSearchStoreShallow } from './stores/multilingual-search';
 import './index.scss';
-import { IconSearch } from '@arco-design/web-react/icon';
+import { SearchOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { TbWorldSearch } from 'react-icons/tb';
 
@@ -42,7 +42,7 @@ function MultilingualSearch() {
             <>
               <div className="breadcrumb-item clickable" onClick={handleHomeClick}>
                 <span className="menu-item-icon">
-                  <IconSearch />
+                  <SearchOutlined />
                 </span>
                 <span className="intergration-header-title">
                   {t('resource.import.fromWebSearch')}


### PR DESCRIPTION
# Summary

Migration from Arco Design to Ant Design ＆ Support darkmode for scrollbar.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [x] Free-form Canvas Interface
- [ ] Other

# Checklist


- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
