### PR TITLE
style: enhance scrollbar styles and improve dark mode support

### DIFF
--- a/apps/web/src/styles/style.css
+++ b/apps/web/src/styles/style.css
@@ -63,34 +63,64 @@ select:focus {
   content: none !important;
 }
 
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
+/* Scrollbar Styles - Only show during scrolling */
+@media (hover: hover) {
+  * {
+    scrollbar-width: auto;
+    scrollbar-color: transparent transparent;
+  }
 
-::-webkit-scrollbar-track {
-  background: #f1f1f1;
-}
+  *:hover,
+  *:focus,
+  *:focus-within {
+    scrollbar-color: #c1c1c1 #f1f1f1;
+  }
 
-::-webkit-scrollbar-thumb {
-  background: #c1c1c1;
-  border-radius: 4px;
-}
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
 
-::-webkit-scrollbar-thumb:hover {
-  background: #a8a8a8;
-}
-
-.dark {
   ::-webkit-scrollbar-track {
-    background: #2d2d2d;
+    background: #f1f1f1;
   }
 
   ::-webkit-scrollbar-thumb {
-    background: #555;
+    background-color: transparent;
+    border-radius: 4px;
   }
 
-  ::-webkit-scrollbar-thumb:hover {
-    background: #777;
+  *:hover::-webkit-scrollbar-thumb,
+  *:focus::-webkit-scrollbar-thumb,
+  *:focus-within::-webkit-scrollbar-thumb,
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: #c1c1c1;
+    transition: background-color 0.3s ease;
+  }
+
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: #a8a8a8;
+  }
+
+  .dark *:hover,
+  .dark *:focus,
+  .dark *:focus-within {
+    scrollbar-color: #555 #2d2d2d;
+  }
+
+  .dark ::-webkit-scrollbar-track {
+    background: #2d2d2d;
+  }
+
+  .dark *:hover::-webkit-scrollbar-thumb,
+  .dark *:focus::-webkit-scrollbar-thumb,
+  .dark *:focus-within::-webkit-scrollbar-thumb,
+  .dark *::-webkit-scrollbar-thumb:hover {
+    background-color: #555;
+    transition: background-color 0.3s ease;
+  }
+
+  .dark *::-webkit-scrollbar-thumb:hover {
+    background-color: #777;
   }
 }

--- a/packages/ai-workspace-common/src/modules/artifacts/code-runner/monaco-editor/SimpleTextEditor.tsx
+++ b/packages/ai-workspace-common/src/modules/artifacts/code-runner/monaco-editor/SimpleTextEditor.tsx
@@ -43,7 +43,7 @@ const SimpleTextEditor = React.memo(
         </div>
 
         {isContentTruncated && (
-          <div className="bg-yellow-50 text-yellow-800 px-4 py-2 text-sm dark:bg-yellow-850 dark:text-yellow-100">
+          <div className="bg-yellow-50 text-yellow-800 px-4 py-2 text-sm dark:bg-yellow-50 dark:text-yellow-600">
             {t('codeArtifact.editor.contentTruncated', {
               chars: DEFAULT_MAX_GENERATION_DISPLAY,
               total: content.length,


### PR DESCRIPTION
- Updated scrollbar styles to only show during scrolling for better user experience.
- Improved dark mode scrollbar visibility and consistency across components.
- Adjusted text color in SimpleTextEditor for better readability in dark mode.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
