### PR TITLE
refactor: move MCP selector panel state to local component level

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/launchpad/chat-actions/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/chat-actions/index.tsx
@@ -170,7 +170,8 @@ export const ChatActions = memo(
       prevProps.runtimeConfig === nextProps.runtimeConfig &&
       prevProps.setRuntimeConfig === nextProps.setRuntimeConfig &&
       prevProps.onUploadImage === nextProps.onUploadImage &&
-      prevProps.model === nextProps.model
+      prevProps.model === nextProps.model &&
+      prevProps.customActions === nextProps.customActions
     );
   },
 );

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/chat-panel.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/chat-panel.tsx
@@ -1,5 +1,5 @@
 import { notification, Button, Form, Badge } from 'antd';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   useContextPanelStore,
@@ -37,6 +37,7 @@ import { ActionStatus, SkillTemplateConfig } from '@refly/openapi-schema';
 import { ContextTarget } from '@refly-packages/ai-workspace-common/stores/context-panel';
 import { ProjectKnowledgeToggle } from '@refly-packages/ai-workspace-common/components/project/project-knowledge-toggle';
 import { useAskProject } from '@refly-packages/ai-workspace-common/hooks/canvas/use-ask-project';
+import { McpSelectorPanel } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/mcp-selector-panel';
 import { ToolOutlined } from '@ant-design/icons';
 
 const PremiumBanner = () => {
@@ -318,17 +319,18 @@ export const ChatPanel = ({
     abortAction();
   };
 
-  const { setRecommendQuestionsOpen, recommendQuestionsOpen, setMcpSelectorOpen, mcpSelectorOpen } =
-    useLaunchpadStoreShallow((state) => ({
+  const { setRecommendQuestionsOpen, recommendQuestionsOpen } = useLaunchpadStoreShallow(
+    (state) => ({
       setRecommendQuestionsOpen: state.setRecommendQuestionsOpen,
       recommendQuestionsOpen: state.recommendQuestionsOpen,
-      setMcpSelectorOpen: state.setMcpSelectorOpen,
-      mcpSelectorOpen: state.mcpSelectorOpen,
-    }));
+    }),
+  );
 
   const handleRecommendQuestionsToggle = useCallback(() => {
     setRecommendQuestionsOpen(!recommendQuestionsOpen);
   }, [recommendQuestionsOpen, setRecommendQuestionsOpen]);
+
+  const [mcpSelectorOpen, setMcpSelectorOpen] = useState<boolean>(false);
 
   // Toggle MCP selector panel
   const handleMcpSelectorToggle = useCallback(() => {
@@ -360,7 +362,13 @@ export const ChatPanel = ({
         },
       },
     ],
-    [handleRecommendQuestionsToggle, handleMcpSelectorToggle, t, selectedMcpServers],
+    [
+      handleRecommendQuestionsToggle,
+      handleMcpSelectorToggle,
+      t,
+      selectedMcpServers,
+      handleMcpSelectorToggle,
+    ],
   );
 
   const handleImageUpload = async (file: File) => {
@@ -404,6 +412,8 @@ export const ChatPanel = ({
             embeddedMode && 'embedded-chat-panel border !border-gray-100 dark:!border-gray-700',
           )}
         >
+          <McpSelectorPanel isOpen={mcpSelectorOpen} onClose={() => setMcpSelectorOpen(false)} />
+
           <SelectedSkillHeader
             skill={selectedSkill}
             setSelectedSkill={setSelectedSkill}

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/index.tsx
@@ -13,7 +13,6 @@ import { useSkillStoreShallow } from '@refly-packages/ai-workspace-common/stores
 // types
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 import { RecommendQuestionsPanel } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/recommend-questions-panel';
-import { McpSelectorPanel } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/mcp-selector-panel';
 import { SkillTemplateConfig } from '@refly/openapi-schema';
 
 interface LaunchPadProps {
@@ -57,17 +56,12 @@ export const LaunchPad = memo(
 
     const { canvasId } = useCanvasContext();
 
-    const {
-      recommendQuestionsOpen,
-      setRecommendQuestionsOpen,
-      mcpSelectorOpen,
-      setMcpSelectorOpen,
-    } = useLaunchpadStoreShallow((state) => ({
-      recommendQuestionsOpen: state.recommendQuestionsOpen,
-      setRecommendQuestionsOpen: state.setRecommendQuestionsOpen,
-      mcpSelectorOpen: state.mcpSelectorOpen,
-      setMcpSelectorOpen: state.setMcpSelectorOpen,
-    }));
+    const { recommendQuestionsOpen, setRecommendQuestionsOpen } = useLaunchpadStoreShallow(
+      (state) => ({
+        recommendQuestionsOpen: state.recommendQuestionsOpen,
+        setRecommendQuestionsOpen: state.setRecommendQuestionsOpen,
+      }),
+    );
 
     // Add new method to clear state
     const clearLaunchpadState = useCallback(() => {
@@ -115,7 +109,6 @@ export const LaunchPad = memo(
             isOpen={recommendQuestionsOpen}
             onClose={() => setRecommendQuestionsOpen(false)}
           />
-          <McpSelectorPanel isOpen={mcpSelectorOpen} onClose={() => setMcpSelectorOpen(false)} />
           {chatPanelComponent}
         </div>
       </div>

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/mcp-selector-panel/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/mcp-selector-panel/index.tsx
@@ -129,7 +129,7 @@ export const McpSelectorPanel: React.FC<McpSelectorPanelProps> = ({ isOpen, onCl
   };
 
   return (
-    <div className="w-full border border-solid border-black/10 dark:border-gray-700 shadow-[0px_2px_6px_0px_rgba(0,0,0,0.1)] max-w-7xl mx-auto p-3 pb-1 space-y-1 rounded-lg bg-white dark:bg-gray-900 mb-1">
+    <div className="w-full border border-solid border-black/10 dark:border-gray-700 shadow-[0px_2px_6px_0px_rgba(0,0,0,0.1)] max-w-7xl mx-auto p-3 pb-1 space-y-1 rounded-t-lg bg-white dark:bg-gray-900">
       <div className="text-gray-800 font-bold flex items-center justify-between">
         <div className="flex items-center space-x-1 pl-1 dark:text-gray-200">
           <span>{t('copilot.mcpSelector.title')}</span>

--- a/packages/ai-workspace-common/src/components/canvas/node-chat-panel/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-chat-panel/index.tsx
@@ -1,11 +1,14 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Button, Tooltip, Select, Form } from 'antd';
-import { SwapOutlined } from '@ant-design/icons';
+import { Button, Tooltip, Select, Form, Badge } from 'antd';
+import { SwapOutlined, ToolOutlined } from '@ant-design/icons';
 
 import { ChatInput } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/chat-input';
 import { getSkillIcon } from '@refly-packages/ai-workspace-common/components/common/icon';
 import { ModelInfo, Skill, SkillRuntimeConfig, SkillTemplateConfig } from '@refly/openapi-schema';
-import { ChatActions } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/chat-actions';
+import {
+  ChatActions,
+  CustomAction,
+} from '@refly-packages/ai-workspace-common/components/canvas/launchpad/chat-actions';
 import { ContextManager } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/context-manager';
 import { ConfigManager } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/config-manager';
 import {
@@ -28,6 +31,8 @@ import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/ca
 import { useListSkills } from '@refly-packages/ai-workspace-common/hooks/use-find-skill';
 
 import './index.scss';
+import { McpSelectorPanel } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/mcp-selector-panel';
+import { t } from 'i18next';
 
 // Memoized Premium Banner Component
 export const PremiumBanner = memo(() => {
@@ -375,6 +380,39 @@ export const ChatPanel = memo(
       handleSendMessage();
     }, [handleSendMessage, resultId, setActiveResultId]);
 
+    const [mcpSelectorOpen, setMcpSelectorOpen] = useState<boolean>(false);
+
+    // Toggle MCP selector panel
+    const handleMcpSelectorToggle = useCallback(() => {
+      setMcpSelectorOpen(!mcpSelectorOpen);
+    }, [mcpSelectorOpen, setMcpSelectorOpen]);
+
+    // 获取选择的 MCP 服务器
+    const { selectedMcpServers } = useLaunchpadStoreShallow((state) => ({
+      selectedMcpServers: state.selectedMcpServers,
+    }));
+
+    const customActions: CustomAction[] = useMemo(
+      () => [
+        {
+          icon: (
+            <Badge
+              count={selectedMcpServers.length > 0 ? selectedMcpServers.length : 0}
+              size="small"
+              offset={[2, -2]}
+            >
+              <ToolOutlined className="flex items-center" />
+            </Badge>
+          ),
+          title: t('copilot.chatActions.chooseMcp'),
+          onClick: () => {
+            handleMcpSelectorToggle();
+          },
+        },
+      ],
+      [handleMcpSelectorToggle, t, selectedMcpServers],
+    );
+
     const renderContent = () => (
       <>
         <ContextManager
@@ -442,6 +480,7 @@ export const ChatPanel = memo(
         ) : null}
 
         <ChatActions
+          customActions={customActions}
           className={classNames({
             'py-2': isList,
           })}
@@ -467,6 +506,8 @@ export const ChatPanel = memo(
               'border border-gray-100 border-solid dark:border-gray-700',
             )}
           >
+            <McpSelectorPanel isOpen={mcpSelectorOpen} onClose={() => setMcpSelectorOpen(false)} />
+
             <SelectedSkillHeader
               skill={selectedSkill}
               setSelectedSkill={setSelectedSkill}
@@ -488,6 +529,8 @@ export const ChatPanel = memo(
       <div
         className={`flex flex-col gap-3 h-full p-3 box-border ${className} max-w-[1024px] mx-auto`}
       >
+        <McpSelectorPanel isOpen={mcpSelectorOpen} onClose={() => setMcpSelectorOpen(false)} />
+
         <NodeHeader
           readonly={readonly}
           selectedSkillName={selectedSkill?.name}


### PR DESCRIPTION
Move MCP selector panel state management from global launchpad store to local useState in ChatPanel component for better encapsulation

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
