### PR TITLE
fix: remove sessionId requirement for MCP server fetching

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/launchpad/mcp-selector-panel/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/mcp-selector-panel/index.tsx
@@ -6,7 +6,6 @@ import { ReloadOutlined, ToolOutlined } from '@ant-design/icons';
 import { cn } from '@refly-packages/ai-workspace-common/utils/cn';
 import { useListMcpServers } from '@refly-packages/ai-workspace-common/queries';
 import { useLaunchpadStoreShallow } from '@refly-packages/ai-workspace-common/stores/launchpad';
-import { useAuthStoreShallow } from '@refly-packages/ai-workspace-common/stores/auth';
 import { usePublicAccessPage } from '@refly-packages/ai-workspace-common/hooks/use-is-share-page';
 // McpServerDTO is used implicitly through the API response
 
@@ -24,17 +23,10 @@ export const McpSelectorPanel: React.FC<McpSelectorPanelProps> = ({ isOpen, onCl
   const { t } = useTranslation();
 
   // Get selected MCP servers from store
-  const { sessionId } = useAuthStoreShallow((state) => ({
-    sessionId: state.sessionId,
-  }));
-
-  // Get selected MCP servers from store
   const { selectedMcpServers, setSelectedMcpServers } = useLaunchpadStoreShallow((state) => ({
     selectedMcpServers: state.selectedMcpServers,
     setSelectedMcpServers: state.setSelectedMcpServers,
   }));
-
-  console.log('selectedMcpServers', { sessionId, isPublicAccessPage, isOpen });
 
   // Fetch MCP servers from API
   const { data, refetch, isLoading, isRefetching } = useListMcpServers(

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/mcp-selector-panel/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/mcp-selector-panel/index.tsx
@@ -6,7 +6,7 @@ import { ReloadOutlined, ToolOutlined } from '@ant-design/icons';
 import { cn } from '@refly-packages/ai-workspace-common/utils/cn';
 import { useListMcpServers } from '@refly-packages/ai-workspace-common/queries';
 import { useLaunchpadStoreShallow } from '@refly-packages/ai-workspace-common/stores/launchpad';
-import { usePublicAccessPage } from '@refly-packages/ai-workspace-common/hooks/use-is-share-page';
+import { useUserStoreShallow } from '@refly-packages/ai-workspace-common/stores/user';
 // McpServerDTO is used implicitly through the API response
 
 interface McpSelectorPanelProps {
@@ -19,7 +19,6 @@ interface McpSelectorPanelProps {
  * Displays a list of available MCP servers for selection
  */
 export const McpSelectorPanel: React.FC<McpSelectorPanelProps> = ({ isOpen, onClose }) => {
-  const isPublicAccessPage = usePublicAccessPage();
   const { t } = useTranslation();
 
   // Get selected MCP servers from store
@@ -28,12 +27,14 @@ export const McpSelectorPanel: React.FC<McpSelectorPanelProps> = ({ isOpen, onCl
     setSelectedMcpServers: state.setSelectedMcpServers,
   }));
 
+  const isLogin = useUserStoreShallow((state) => state.isLogin);
+
   // Fetch MCP servers from API
   const { data, refetch, isLoading, isRefetching } = useListMcpServers(
     { query: { enabled: true } },
     [],
     {
-      enabled: isOpen && !isPublicAccessPage,
+      enabled: isOpen && isLogin,
       refetchOnWindowFocus: false,
     },
   );

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/mcp-selector-panel/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/mcp-selector-panel/index.tsx
@@ -34,12 +34,14 @@ export const McpSelectorPanel: React.FC<McpSelectorPanelProps> = ({ isOpen, onCl
     setSelectedMcpServers: state.setSelectedMcpServers,
   }));
 
+  console.log('selectedMcpServers', { sessionId, isPublicAccessPage, isOpen });
+
   // Fetch MCP servers from API
   const { data, refetch, isLoading, isRefetching } = useListMcpServers(
     { query: { enabled: true } },
     [],
     {
-      enabled: isOpen && !!sessionId && !isPublicAccessPage,
+      enabled: isOpen && !isPublicAccessPage,
       refetchOnWindowFocus: false,
     },
   );

--- a/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerList.tsx
+++ b/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerList.tsx
@@ -32,7 +32,6 @@ import {
   useValidateMcpServer,
 } from '@refly-packages/ai-workspace-common/queries';
 import { useListMcpServers } from '@refly-packages/ai-workspace-common/queries';
-import { useAuthStoreShallow } from '@refly-packages/ai-workspace-common/stores/auth';
 import { usePublicAccessPage } from '@refly-packages/ai-workspace-common/hooks/use-is-share-page';
 import { McpServerForm } from '@refly-packages/ai-workspace-common/components/settings/mcp-server/McpServerForm';
 import { McpServerBatchImport } from '@refly-packages/ai-workspace-common/components/settings/mcp-server/McpServerBatchImport';
@@ -44,7 +43,6 @@ interface McpServerListProps {
 
 export const McpServerList: React.FC<McpServerListProps> = ({ visible }) => {
   const isPublicAccessPage = usePublicAccessPage();
-  const { sessionId } = useAuthStoreShallow((state) => ({ sessionId: state.sessionId }));
   const { token } = theme.useToken();
   const { t } = useTranslation();
   const [editingServer, setEditingServer] = useState<McpServerDTO | null>(null);
@@ -64,8 +62,6 @@ export const McpServerList: React.FC<McpServerListProps> = ({ visible }) => {
   });
 
   const mcpServers = useMemo(() => data?.data || [], [data]);
-
-  console.log('mcpServers', { sessionId, isPublicAccessPage, visible });
 
   // Load tool data from localStorage
   useEffect(() => {

--- a/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerList.tsx
+++ b/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerList.tsx
@@ -59,11 +59,13 @@ export const McpServerList: React.FC<McpServerListProps> = ({ visible }) => {
 
   // Fetch MCP servers
   const { data, refetch, isLoading, isRefetching } = useListMcpServers({}, [], {
-    enabled: visible && !!sessionId && !isPublicAccessPage,
+    enabled: visible && !isPublicAccessPage,
     refetchOnWindowFocus: false,
   });
 
   const mcpServers = useMemo(() => data?.data || [], [data]);
+
+  console.log('mcpServers', { sessionId, isPublicAccessPage, visible });
 
   // Load tool data from localStorage
   useEffect(() => {

--- a/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerList.tsx
+++ b/packages/ai-workspace-common/src/components/settings/mcp-server/McpServerList.tsx
@@ -32,17 +32,17 @@ import {
   useValidateMcpServer,
 } from '@refly-packages/ai-workspace-common/queries';
 import { useListMcpServers } from '@refly-packages/ai-workspace-common/queries';
-import { usePublicAccessPage } from '@refly-packages/ai-workspace-common/hooks/use-is-share-page';
 import { McpServerForm } from '@refly-packages/ai-workspace-common/components/settings/mcp-server/McpServerForm';
 import { McpServerBatchImport } from '@refly-packages/ai-workspace-common/components/settings/mcp-server/McpServerBatchImport';
 import { preloadMonacoEditor } from '@refly-packages/ai-workspace-common/modules/artifacts/code-runner/monaco-editor/monacoPreloader';
+import { useUserStoreShallow } from '@refly-packages/ai-workspace-common/stores/user';
 
 interface McpServerListProps {
   visible: boolean;
 }
 
 export const McpServerList: React.FC<McpServerListProps> = ({ visible }) => {
-  const isPublicAccessPage = usePublicAccessPage();
+  const isLogin = useUserStoreShallow((state) => state.isLogin);
   const { token } = theme.useToken();
   const { t } = useTranslation();
   const [editingServer, setEditingServer] = useState<McpServerDTO | null>(null);
@@ -57,7 +57,7 @@ export const McpServerList: React.FC<McpServerListProps> = ({ visible }) => {
 
   // Fetch MCP servers
   const { data, refetch, isLoading, isRefetching } = useListMcpServers({}, [], {
-    enabled: visible && !isPublicAccessPage,
+    enabled: visible && isLogin,
     refetchOnWindowFocus: false,
   });
 


### PR DESCRIPTION
Remove dependency on sessionId for fetching MCP servers in both the selector panel and server list components. Added debug logging to help troubleshoot server fetching behavior.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
