### PR TITLE
fix: dark mode for messages and notifications

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -154,13 +154,39 @@ export const App = () => {
   useEffect(() => {
     preloadMonacoEditor();
   }, []);
+  // Use light theme when forced, otherwise use the user's preference
+  const shouldUseDarkTheme = isDarkMode && !isForcedLightMode;
+
+  useEffect(() => {
+    ConfigProvider.config({
+      holderRender: (children) => (
+        <ConfigProvider
+          theme={{
+            token: {
+              colorPrimary: '#00968F',
+              borderRadius: 6,
+              ...(shouldUseDarkTheme
+                ? {
+                    controlItemBgActive: 'rgba(255, 255, 255, 0.08)',
+                    controlItemBgActiveHover: 'rgba(255, 255, 255, 0.12)',
+                  }
+                : {
+                    controlItemBgActive: '#f1f1f0',
+                    controlItemBgActiveHover: '#e0e0e0',
+                  }),
+            },
+            algorithm: shouldUseDarkTheme ? theme.darkAlgorithm : theme.defaultAlgorithm,
+          }}
+        >
+          {children}
+        </ConfigProvider>
+      ),
+    });
+  }, [shouldUseDarkTheme]);
 
   if (isInitialLoading) {
     return <SuspenseLoading />;
   }
-
-  // Use light theme when forced, otherwise use the user's preference
-  const shouldUseDarkTheme = isDarkMode && !isForcedLightMode;
 
   return (
     <ConfigProvider


### PR DESCRIPTION
# Summary

Add dark mode style for messages and notifications, resolves #971 

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [x] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/4cf202a2-a24f-4315-9a7e-11c31aab9c66)   | ![image](https://github.com/user-attachments/assets/631a8928-8d2f-4a3f-af13-2eee4a5f8fa2) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
