### PR TITLE
Remove tool output processing logic from Agent class

### DIFF
--- a/packages/skill-template/src/skills/agent.ts
+++ b/packages/skill-template/src/skills/agent.ts
@@ -42,15 +42,8 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 // Removed duplicate imports for MCPTool, MCPToolInputSchema, and zodToJsonSchema as they are already imported above
 
 import type { AIMessage, BaseMessage } from '@langchain/core/messages';
-import type { Runnable, RunnableConfig } from '@langchain/core/runnables';
+import type { Runnable } from '@langchain/core/runnables';
 import type { StructuredToolInterface } from '@langchain/core/tools'; // For MCP Tools
-
-// Constants for tool output processing
-const DEFAULT_MAX_STRING_OUTPUT_LENGTH = 2000;
-const DEFAULT_MAX_ARRAY_OUTPUT_LENGTH = 5;
-const DEFAULT_MAX_OBJECT_PROPERTY_STRING_LENGTH = 500;
-const TRUNCATION_SUFFIX = '... [Truncated]';
-// const ARRAY_TRUNCATION_SUFFIX_TEMPLATE = (omittedCount: number) => `... [${omittedCount} more items truncated]`; // Example if needed
 
 /**
  * Converts LangChain StructuredToolInterface array to MCPTool array.
@@ -242,107 +235,6 @@ export class Agent extends BaseSkill {
     return { requestMessages, sources };
   };
 
-  // Method to process/truncate tool output values recursively
-  private processToolOutputValue(value: any, toolName: string, depth = 0): any {
-    // Max recursion depth to prevent infinite loops in complex objects
-    if (depth > 5) {
-      this.engine.logger.warn(
-        `[ToolWrapper] Max recursion depth reached for tool ${toolName}. Returning raw value.`,
-      );
-      return value;
-    }
-
-    if (value === null || value === undefined) {
-      return value;
-    }
-
-    if (typeof value === 'string') {
-      if (value.length > DEFAULT_MAX_STRING_OUTPUT_LENGTH) {
-        this.engine.logger.log(
-          `[ToolWrapper] Truncating string output for tool: ${toolName}, original length: ${value.length}`,
-        );
-        return value.substring(0, DEFAULT_MAX_STRING_OUTPUT_LENGTH) + TRUNCATION_SUFFIX;
-      }
-      return value;
-    }
-
-    if (Array.isArray(value)) {
-      const originalLength = value.length;
-      let processedArray = value;
-      if (originalLength > DEFAULT_MAX_ARRAY_OUTPUT_LENGTH) {
-        this.engine.logger.log(
-          `[ToolWrapper] Truncating array output for tool: ${toolName}, from ${originalLength} to ${DEFAULT_MAX_ARRAY_OUTPUT_LENGTH} items.`,
-        );
-        processedArray = value.slice(0, DEFAULT_MAX_ARRAY_OUTPUT_LENGTH);
-      }
-      // Recursively process items in the (potentially truncated) array
-      const finalArray = processedArray.map((item) =>
-        this.processToolOutputValue(item, toolName, depth + 1),
-      );
-      // Optionally, if the array was truncated, one could append a string or marker if the schema allows for mixed types
-      // For example: if (originalLength > DEFAULT_MAX_ARRAY_OUTPUT_LENGTH) finalArray.push(ARRAY_TRUNCATION_SUFFIX_TEMPLATE(originalLength - DEFAULT_MAX_ARRAY_OUTPUT_LENGTH));
-      // However, this changes the array's content type. Logging the truncation is safer for now.
-      return finalArray;
-    }
-
-    if (typeof value === 'object') {
-      const processedObject: { [key: string]: any } = {};
-      for (const key in value) {
-        if (Object.prototype.hasOwnProperty.call(value, key)) {
-          const propertyValue = value[key];
-          if (typeof propertyValue === 'string') {
-            if (propertyValue.length > DEFAULT_MAX_OBJECT_PROPERTY_STRING_LENGTH) {
-              this.engine.logger.log(
-                `[ToolWrapper] Truncating object property string '${key}' for tool: ${toolName}, original length: ${propertyValue.length}`,
-              );
-              processedObject[key] =
-                propertyValue.substring(0, DEFAULT_MAX_OBJECT_PROPERTY_STRING_LENGTH) +
-                TRUNCATION_SUFFIX;
-            } else {
-              processedObject[key] = propertyValue;
-            }
-          } else {
-            // Recursively process non-string properties (like nested objects or arrays)
-            processedObject[key] = this.processToolOutputValue(propertyValue, toolName, depth + 1);
-          }
-        }
-      }
-      return processedObject;
-    }
-
-    // For numbers, booleans, etc., return as is
-    return value;
-  }
-
-  // Method to wrap an MCP tool for output processing
-  private wrapMcpTool(originalTool: StructuredToolInterface): StructuredToolInterface {
-    const toolName = originalTool.name;
-    const originalInvoke = originalTool.invoke.bind(originalTool);
-
-    const wrappedTool: StructuredToolInterface = {
-      ...originalTool, // Spread to copy name, description, schema, etc.
-      invoke: async (
-        input: z.input<typeof originalTool.schema>,
-        config?: RunnableConfig,
-      ): Promise<z.output<typeof originalTool.schema>> => {
-        // 1. Optional: Input processing can be added here if needed
-        // this.engine.logger.log(`[ToolWrapper] Input for tool ${toolName}: ${safeStringifyJSON(input)}`);
-
-        const rawResult = await originalInvoke(input, config);
-
-        // 2. Output processing
-        // this.engine.logger.log(`[ToolWrapper] Original output for tool ${toolName}: ${safeStringifyJSON(rawResult)}`); // Can be very verbose
-        const processedResult = this.processToolOutputValue(rawResult, toolName);
-        this.engine.logger.log(
-          `[ToolWrapper] Output processed for tool ${toolName}. Raw type: ${typeof rawResult}, Processed type: ${typeof processedResult}`,
-        );
-
-        return processedResult as z.output<typeof originalTool.schema>; // Cast as Zod output type, assuming processing maintains schema compatibility or is acceptable
-      },
-    };
-    return wrappedTool;
-  }
-
   private async getOrInitializeAgentComponents(
     user: User,
     selectedMcpServers: string[] = [],
@@ -417,16 +309,13 @@ export class Agent extends BaseSkill {
               );
           } else {
             this.engine.logger.log(
-              `Loaded ${toolsFromMcp.length} MCP tools for new components: ${toolsFromMcp
+              `Loaded ${toolsFromMcp.length} MCP tools: ${toolsFromMcp
                 .map((tool) => tool.name)
                 .join(', ')}`,
             );
-            // Wrap each MCP tool to process its output for token optimization
-            actualMcpTools = toolsFromMcp.map((tool) => this.wrapMcpTool(tool));
+            // Use tools directly without wrapping
+            actualMcpTools = toolsFromMcp;
 
-            this.engine.logger.log(
-              `Wrapped ${actualMcpTools.length} MCP tools for token optimization.`,
-            );
             mcpClientToCache = tempMcpClient;
             mcpSuccessfullyInitializedAndToolsAvailable = true;
           }


### PR DESCRIPTION
Simplifies the Agent class by removing unused code for processing and truncating tool outputs, including constants and helper methods. Also removes an unused RunnableConfig import.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
