### PR TITLE
feat: support full skill execution on server

### DIFF
--- a/apps/api/src/modules/skill/skill-invoker.service.ts
+++ b/apps/api/src/modules/skill/skill-invoker.service.ts
@@ -262,13 +262,7 @@ export class SkillInvokerService {
       // In desktop mode, we could handle usage tracking differently if needed
     }
 
-    let aborted = false;
-
-    if (res) {
-      res.on('close', () => {
-        aborted = true;
-      });
-    }
+    const aborted = false;
 
     // const job = await this.timeoutCheckQueue.add(
     //   `idle_timeout_check:${resultId}`,

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo, memo, useCallback } from 'react';
-import { Button, Divider, Result, Skeleton } from 'antd';
+import { Button, Divider, message, Result, Skeleton, Spin } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { useActionResultStoreShallow } from '@refly-packages/ai-workspace-common/stores/action-result';
 import getClient from '@refly-packages/ai-workspace-common/requests/proxiedRequest';
@@ -25,7 +25,11 @@ import { cn } from '@refly/utils/cn';
 import { useReactFlow } from '@xyflow/react';
 import { useInvokeAction } from '@refly-packages/ai-workspace-common/hooks/canvas/use-invoke-action';
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
-import { IconRerun } from '@refly-packages/ai-workspace-common/components/common/icon';
+import {
+  IconError,
+  IconLoading,
+  IconRerun,
+} from '@refly-packages/ai-workspace-common/components/common/icon';
 import { locateToNodePreviewEmitter } from '@refly-packages/ai-workspace-common/events/locateToNodePreview';
 import { useFetchShareData } from '@refly-packages/ai-workspace-common/hooks/use-fetch-share-data';
 import { processContentPreview } from '@refly-packages/ai-workspace-common/utils/content';
@@ -71,8 +75,9 @@ const StepsList = memo(
 );
 
 const SkillResponseNodePreviewComponent = ({ node, resultId }: SkillResponseNodePreviewProps) => {
-  const { result, updateActionResult } = useActionResultStoreShallow((state) => ({
+  const { result, isStreaming, updateActionResult } = useActionResultStoreShallow((state) => ({
     result: state.resultMap[resultId],
+    isStreaming: !!state.streamResults[resultId],
     updateActionResult: state.updateActionResult,
   }));
   const knowledgeBaseStore = useKnowledgeBaseStoreShallow((state) => ({
@@ -177,7 +182,7 @@ const SkillResponseNodePreviewComponent = ({ node, resultId }: SkillResponseNode
   const tplConfig = result?.tplConfig ?? data?.metadata?.tplConfig;
   const runtimeConfig = result?.runtimeConfig ?? data?.metadata?.runtimeConfig;
 
-  const { errCode, errMsg } = useSkillError(result?.errors?.[0]);
+  const { errCode, errMsg, rawError } = useSkillError(result?.errors?.[0]);
 
   const { steps = [], context, history = [] } = result ?? {};
   const contextItems = useMemo(() => {
@@ -283,41 +288,73 @@ const SkillResponseNodePreviewComponent = ({ node, resultId }: SkillResponseNode
         </>
       )}
 
-      <div
-        className={cn('flex-grow transition-opacity duration-500', { 'opacity-30': editMode })}
-        onClick={() => {
-          if (editMode) {
-            setEditMode(false);
-          }
-        }}
+      <Spin
+        spinning={!isStreaming && result?.status === 'executing'}
+        indicator={<IconLoading className="animate-spin" />}
+        size="large"
+        tip={t('canvas.skillResponse.generating')}
       >
-        {result?.status === 'failed' ? (
-          <div className="h-full w-full flex items-center justify-center">
-            <Result
-              status="500"
-              subTitle={
-                errCode ? `[${errCode}] ${errMsg}` : t('canvas.skillResponse.executionFailed')
-              }
-              extra={
+        <div
+          className={cn('flex-grow transition-opacity duration-500', { 'opacity-30': editMode })}
+          onClick={() => {
+            if (editMode) {
+              setEditMode(false);
+            }
+          }}
+        >
+          {steps.length === 0 && isPending && (
+            <Skeleton className="mt-1" active paragraph={{ rows: 5 }} />
+          )}
+          <StepsList steps={steps} result={result} title={title} nodeId={node.id} />
+
+          {result?.status === 'failed' && (
+            <div className="mt-2 flex flex-col gap-2 border border-solid border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 px-3 py-2 rounded-md">
+              <div className="flex items-center justify-between">
+                <div className="space-y-2">
+                  <div className="font-medium text-base flex items-center gap-2">
+                    <IconError className="text-sm flex items-center justify-center text-yellow-500" />
+                    {t('canvas.skillResponse.error.defaultTitle')}
+                  </div>
+                  {errCode && (
+                    <div className="space-y-2">
+                      <p className="text-gray-700 dark:text-gray-200 text-sm">
+                        [{errCode}] {errMsg} {rawError ? `: ${String(rawError)}` : ''}
+                      </p>
+                      <p className="text-gray-500 dark:text-gray-400 text-xs">
+                        Request ID: ea79eee8bb0710bd86f4a5af663088b7
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center justify-end gap-2">
                 <Button
-                  disabled={readonly}
-                  icon={<IconRerun className="text-sm flex items-center justify-center" />}
+                  type="text"
+                  size="small"
+                  className="text-xs"
+                  onClick={() => {
+                    if (errCode) {
+                      navigator.clipboard.writeText(errCode);
+                      message.success(t('components.markdown.copySuccess'));
+                    }
+                  }}
+                >
+                  {t('common.copyRequestInfo')}
+                </Button>
+                <Button
+                  type="primary"
+                  size="small"
+                  className="text-xs"
+                  icon={<IconRerun className="text-xs flex items-center justify-center" />}
                   onClick={handleRetry}
                 >
                   {t('canvas.nodeActions.rerun')}
                 </Button>
-              }
-            />
-          </div>
-        ) : (
-          <>
-            {steps.length === 0 && isPending && (
-              <Skeleton className="mt-1" active paragraph={{ rows: 5 }} />
-            )}
-            <StepsList steps={steps} result={result} title={title} nodeId={node.id} />
-          </>
-        )}
-      </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </Spin>
 
       {knowledgeBaseStore?.sourceListDrawerVisible ? (
         <SourceListModal classNames="source-list-modal" />

--- a/packages/ai-workspace-common/src/components/canvas/nodes/index.ts
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/index.ts
@@ -189,7 +189,7 @@ export const getNodeCommonStyles = ({
   border-[1px]
   border-solid
   overflow-hidden
-  ${selected ? 'border-[#00968F] dark:border-gray-700' : 'border-transparent'}
+  ${selected ? 'border-[#00968F] border-solid border-2' : 'border-transparent'}
   ${
     isHovered
       ? 'shadow-[0px_12px_16px_-4px_rgba(16,24,40,0.08),0px_4px_6px_-2px_rgba(16,24,40,0.03)]'

--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
@@ -274,7 +274,7 @@ export const SkillResponseNode = memo(
     }));
 
     useEffect(() => {
-      if (!isStreaming && status === 'executing') {
+      if (!isStreaming && (status === 'executing' || status === 'waiting')) {
         startPolling(entityId, version);
       }
       if (isStreaming && status !== 'executing' && status !== 'waiting') {

--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
@@ -114,7 +114,7 @@ export const NodeHeader = memo(
           <div className="flex items-center gap-2">
             {showIcon && (
               <div className="w-6 h-6 rounded bg-[#F79009] shadow-lg flex items-center justify-center flex-shrink-0">
-                <IconResponse className="w-4 h-4 text-white dark:text-gray-900" />
+                <IconResponse className="w-4 h-4 text-white" />
               </div>
             )}
             {isEditing ? (
@@ -268,13 +268,17 @@ export const SkillResponseNode = memo(
     const currentSkill = actionMeta || selectedSkill;
 
     const { startPolling, resetFailedState } = useActionPolling();
-    const { isStreaming } = useActionResultStoreShallow((state) => ({
+    const { isStreaming, removeStreamResult } = useActionResultStoreShallow((state) => ({
       isStreaming: !!state.streamResults[entityId],
+      removeStreamResult: state.removeStreamResult,
     }));
 
     useEffect(() => {
       if (!isStreaming && status === 'executing') {
         startPolling(entityId, version);
+      }
+      if (isStreaming && status !== 'executing' && status !== 'waiting') {
+        removeStreamResult(entityId);
       }
     }, [isStreaming, status, startPolling, entityId, version]);
 

--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
@@ -57,8 +57,7 @@ import { BorderBeam } from '@refly-packages/ai-workspace-common/components/magic
 import { NodeActionButtons } from './shared/node-action-buttons';
 import { useGetNodeConnectFromDragCreateInfo } from '@refly-packages/ai-workspace-common/hooks/canvas/use-get-node-connect';
 import { NodeDragCreateInfo } from '@refly-packages/ai-workspace-common/events/nodeOperations';
-
-const POLLING_WAIT_TIME = 15000;
+import { useActionResultStoreShallow } from '@refly-packages/ai-workspace-common/stores/action-result';
 
 export const NodeHeader = memo(
   ({
@@ -269,16 +268,15 @@ export const SkillResponseNode = memo(
     const currentSkill = actionMeta || selectedSkill;
 
     const { startPolling, resetFailedState } = useActionPolling();
+    const { isStreaming } = useActionResultStoreShallow((state) => ({
+      isStreaming: !!state.streamResults[entityId],
+    }));
 
     useEffect(() => {
-      if (
-        createdAt &&
-        Date.now() - new Date(createdAt).getTime() >= POLLING_WAIT_TIME &&
-        status === 'executing'
-      ) {
+      if (!isStreaming && status === 'executing') {
         startPolling(entityId, version);
       }
-    }, [createdAt, status, startPolling, entityId, version]);
+    }, [isStreaming, status, startPolling, entityId, version]);
 
     const sources = Array.isArray(structuredData?.sources) ? structuredData?.sources : [];
 

--- a/packages/ai-workspace-common/src/components/markdown/styles/markdown.scss
+++ b/packages/ai-workspace-common/src/components/markdown/styles/markdown.scss
@@ -46,48 +46,48 @@
 
 @mixin dark {
   color-scheme: dark;
-  //   --color-prettylights-syntax-comment: #8b949e;
-  //   --color-prettylights-syntax-constant: #79c0ff;
-  //   --color-prettylights-syntax-entity: #d2a8ff;
-  //   --color-prettylights-syntax-storage-modifier-import: #c9d1d9;
-  //   --color-prettylights-syntax-entity-tag: #7ee787;
-  //   --color-prettylights-syntax-keyword: #ff7b72;
-  //   --color-prettylights-syntax-string: #a5d6ff;
-  //   --color-prettylights-syntax-variable: #ffa657;
-  //   --color-prettylights-syntax-brackethighlighter-unmatched: #f85149;
-  //   --color-prettylights-syntax-invalid-illegal-text: #f0f6fc;
-  //   --color-prettylights-syntax-invalid-illegal-bg: #8e1519;
-  //   --color-prettylights-syntax-carriage-return-text: #f0f6fc;
-  //   --color-prettylights-syntax-carriage-return-bg: #b62324;
-  //   --color-prettylights-syntax-string-regexp: #7ee787;
-  //   --color-prettylights-syntax-markup-list: #f2cc60;
-  //   --color-prettylights-syntax-markup-heading: #1f6feb;
-  //   --color-prettylights-syntax-markup-italic: #c9d1d9;
-  //   --color-prettylights-syntax-markup-bold: #c9d1d9;
-  //   --color-prettylights-syntax-markup-deleted-text: #ffdcd7;
-  //   --color-prettylights-syntax-markup-deleted-bg: #67060c;
-  //   --color-prettylights-syntax-markup-inserted-text: #aff5b4;
-  //   --color-prettylights-syntax-markup-inserted-bg: #033a16;
-  //   --color-prettylights-syntax-markup-changed-text: #ffdfb6;
-  //   --color-prettylights-syntax-markup-changed-bg: #5a1e02;
-  //   --color-prettylights-syntax-markup-ignored-text: #c9d1d9;
-  //   --color-prettylights-syntax-markup-ignored-bg: #1158c7;
-  //   --color-prettylights-syntax-meta-diff-range: #d2a8ff;
-  //   --color-prettylights-syntax-brackethighlighter-angle: #8b949e;
-  //   --color-prettylights-syntax-sublimelinter-gutter-mark: #484f58;
-  //   --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
-  //   --color-fg-default: #c9d1d9;
-  //   --color-fg-muted: #8b949e;
-  //   --color-fg-subtle: #6e7681;
-  //   --color-canvas-default: transparent;
-  //   --color-canvas-subtle: #161b22;
-  //   --color-border-default: #30363d;
-  //   --color-border-muted: #21262d;
-  //   --color-neutral-muted: rgba(110, 118, 129, 0.4);
+  --color-prettylights-syntax-comment: #8b949e;
+  --color-prettylights-syntax-constant: #79c0ff;
+  --color-prettylights-syntax-entity: #d2a8ff;
+  --color-prettylights-syntax-storage-modifier-import: #c9d1d9;
+  --color-prettylights-syntax-entity-tag: #7ee787;
+  --color-prettylights-syntax-keyword: #ff7b72;
+  --color-prettylights-syntax-string: #a5d6ff;
+  --color-prettylights-syntax-variable: #ffa657;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #f85149;
+  --color-prettylights-syntax-invalid-illegal-text: #f0f6fc;
+  --color-prettylights-syntax-invalid-illegal-bg: #8e1519;
+  --color-prettylights-syntax-carriage-return-text: #f0f6fc;
+  --color-prettylights-syntax-carriage-return-bg: #b62324;
+  --color-prettylights-syntax-string-regexp: #7ee787;
+  --color-prettylights-syntax-markup-list: #f2cc60;
+  --color-prettylights-syntax-markup-heading: #1f6feb;
+  --color-prettylights-syntax-markup-italic: #c9d1d9;
+  --color-prettylights-syntax-markup-bold: #c9d1d9;
+  --color-prettylights-syntax-markup-deleted-text: #ffdcd7;
+  --color-prettylights-syntax-markup-deleted-bg: #67060c;
+  --color-prettylights-syntax-markup-inserted-text: #aff5b4;
+  --color-prettylights-syntax-markup-inserted-bg: #033a16;
+  --color-prettylights-syntax-markup-changed-text: #ffdfb6;
+  --color-prettylights-syntax-markup-changed-bg: #5a1e02;
+  --color-prettylights-syntax-markup-ignored-text: #c9d1d9;
+  --color-prettylights-syntax-markup-ignored-bg: #1158c7;
+  --color-prettylights-syntax-meta-diff-range: #d2a8ff;
+  --color-prettylights-syntax-brackethighlighter-angle: #8b949e;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #484f58;
+  --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
+  --color-fg-default: #c9d1d9;
+  --color-fg-muted: #8b949e;
+  --color-fg-subtle: #6e7681;
+  --color-canvas-default: transparent;
+  --color-canvas-subtle: #161b22;
+  --color-border-default: #30363d;
+  --color-border-muted: #21262d;
+  --color-neutral-muted: rgba(110, 118, 129, 0.4);
   --color-accent-fg: #58a6ff;
-  //   --color-accent-emphasis: #1f6feb;
-  //   --color-attention-subtle: rgba(187, 128, 9, 0.15);
-  //   --color-danger-fg: #f85149;
+  --color-accent-emphasis: #1f6feb;
+  --color-attention-subtle: rgba(187, 128, 9, 0.15);
+  --color-danger-fg: #f85149;
 }
 
 .markdown-body {
@@ -116,22 +116,12 @@
   @include light;
 }
 
-// .dark {
-//   @include dark;
-// }
-
-// :root {
-//   @include light;
-// }
-
-// @media (prefers-color-scheme: dark) {
-//   :root {
-//     @include dark;
-//   }
-// }
-
 :root {
   @include light;
+}
+
+.dark {
+  @include dark;
 }
 
 .markdown-body .octicon {

--- a/packages/ai-workspace-common/src/hooks/canvas/use-action-polling.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-action-polling.ts
@@ -8,7 +8,7 @@ import getClient from '@refly-packages/ai-workspace-common/requests/proxiedReque
 import { useUpdateActionResult } from './use-update-action-result';
 
 const POLLING_INTERVAL = 3000;
-const TIMEOUT_DURATION = 10000;
+const TIMEOUT_DURATION = 5000;
 const MAX_NOT_FOUND_RETRIES = 3;
 
 // Track globally failed result IDs to prevent auto-restarting polling for failed actions
@@ -54,11 +54,14 @@ export const useActionPolling = () => {
       const { pollingStateMap, resultMap } = useActionResultStore.getState();
       const pollingState = pollingStateMap[resultId];
 
+      console.log('pollActionResult', resultId, version, pollingState);
+
       if (!pollingState?.isPolling) {
         return;
       }
 
       try {
+        console.log('getActionResult', resultId, version);
         const { data: result } = await getClient().getActionResult({
           query: { resultId, version },
         });
@@ -173,7 +176,6 @@ export const useActionPolling = () => {
           }
 
           if (result?.status !== 'finish') {
-            console.log('start polling', resultId, result);
             startPolling(resultId, version);
           }
         }, TIMEOUT_DURATION);

--- a/packages/ai-workspace-common/src/hooks/canvas/use-action-polling.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-action-polling.ts
@@ -54,14 +54,11 @@ export const useActionPolling = () => {
       const { pollingStateMap, resultMap } = useActionResultStore.getState();
       const pollingState = pollingStateMap[resultId];
 
-      console.log('pollActionResult', resultId, version, pollingState);
-
       if (!pollingState?.isPolling) {
         return;
       }
 
       try {
-        console.log('getActionResult', resultId, version);
         const { data: result } = await getClient().getActionResult({
           query: { resultId, version },
         });

--- a/packages/ai-workspace-common/src/hooks/canvas/use-invoke-action.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-invoke-action.ts
@@ -518,11 +518,18 @@ export const useInvokeAction = () => {
     const runtime = getRuntime();
     const { originError, resultId } = skillEvent;
 
-    const { resultMap } = useActionResultStore.getState();
+    const { resultMap, setTraceId } = useActionResultStore.getState();
     const result = resultMap[resultId];
 
     if (!result) {
       return;
+    }
+
+    // Set traceId if available (check for traceId in different possible locations)
+    const traceId = skillEvent?.error?.traceId;
+
+    if (traceId) {
+      setTraceId(resultId, traceId);
     }
 
     const updatedResult = {

--- a/packages/ai-workspace-common/src/hooks/canvas/use-invoke-action.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-invoke-action.ts
@@ -61,10 +61,13 @@ export const useInvokeAction = () => {
     };
   }, []);
 
-  const { createTimeoutHandler } = useActionPolling();
+  const { createTimeoutHandler, stopPolling } = useActionPolling();
   const onUpdateResult = useUpdateActionResult();
 
-  const onSkillStart = (_skillEvent: SkillEvent) => {};
+  const onSkillStart = (skillEvent: SkillEvent) => {
+    const { resultId } = skillEvent;
+    stopPolling(resultId);
+  };
 
   const onSkillLog = (skillEvent: SkillEvent) => {
     const { resultId, step, log } = skillEvent;
@@ -681,21 +684,14 @@ export const useInvokeAction = () => {
         onSkillArtifact: wrapEventHandler(onSkillArtifact),
         onSkillStructedData: wrapEventHandler(onSkillStructedData),
         onSkillCreateNode: wrapEventHandler(onSkillCreateNode),
-        onSkillEnd: wrapEventHandler((event) => {
-          onSkillEnd(event);
-          useActionResultStore.getState().removeStreamResult(resultId);
-        }),
+        onSkillEnd: wrapEventHandler(onSkillEnd),
         onCompleted: wrapEventHandler(onCompleted),
-        onSkillError: wrapEventHandler((event) => {
-          onSkillError(event);
-          useActionResultStore.getState().removeStreamResult(resultId);
-        }),
+        onSkillError: wrapEventHandler(onSkillError),
         onSkillTokenUsage: wrapEventHandler(onSkillTokenUsage),
       });
 
       return () => {
         timeoutCleanup();
-        useActionResultStore.getState().removeStreamResult(resultId);
       };
     },
     [addNode, setNodeDataByEntity, onUpdateResult, createTimeoutHandler, selectedMcpServers],

--- a/packages/ai-workspace-common/src/hooks/use-skill-error.ts
+++ b/packages/ai-workspace-common/src/hooks/use-skill-error.ts
@@ -15,6 +15,7 @@ export const useSkillError = (error: string | Error) => {
     return {
       errCode: guessedErr.code,
       errMsg,
+      rawError: error,
     };
   }, [error]);
 };

--- a/packages/ai-workspace-common/src/modules/entity-selector/components/search-list/index.tsx
+++ b/packages/ai-workspace-common/src/modules/entity-selector/components/search-list/index.tsx
@@ -204,7 +204,7 @@ export const SearchList = (props: SearchListProps) => {
           </div>
 
           {mode === 'multiple' && (
-            <div className="pt-2 flex justify-end items-center gap-2 border-solid border-t-1 border-x-0 border-b-0 border-[#E5E5E5]">
+            <div className="pt-2 flex justify-end items-center gap-2 border-solid border-t-1 border-x-0 border-b-0 border-gray-100 dark:border-gray-700">
               <Button size="small" className="text-xs" onClick={cancel}>
                 {t('common.cancel')}
               </Button>

--- a/packages/ai-workspace-common/src/stores/action-result.ts
+++ b/packages/ai-workspace-common/src/stores/action-result.ts
@@ -18,6 +18,11 @@ interface ActionResultState {
   pollingStateMap: Record<string, PollingState & CacheInfo>;
   batchUpdateQueue: Array<{ resultId: string; result: ActionResult }>;
   isBatchUpdateScheduled: boolean;
+  streamResults: Record<string, ActionResult>;
+
+  // Stream result actions
+  addStreamResult: (resultId: string, result: ActionResult) => void;
+  removeStreamResult: (resultId: string) => void;
 
   // Individual update actions
   updateActionResult: (resultId: string, result: ActionResult) => void;
@@ -47,6 +52,7 @@ export const defaultState = {
   pollingStateMap: {},
   batchUpdateQueue: [],
   isBatchUpdateScheduled: false,
+  streamResults: {},
 };
 
 const POLLING_STATE_INITIAL: PollingState = {
@@ -410,13 +416,34 @@ export const useActionResultStore = create<ActionResultState>()(
         // Clean up old results after batch updates
         get().cleanupOldResults();
       },
+
+      // Stream result methods
+      addStreamResult: (resultId: string, result: ActionResult) => {
+        set((state) => ({
+          ...state,
+          streamResults: {
+            ...state.streamResults,
+            [resultId]: result,
+          },
+        }));
+      },
+
+      removeStreamResult: (resultId: string) => {
+        set((state) => {
+          const newStreamResults = { ...state.streamResults };
+          delete newStreamResults[resultId];
+          return {
+            ...state,
+            streamResults: newStreamResults,
+          };
+        });
+      },
     }),
     {
       name: 'action-result-storage',
       storage: createJSONStorage(() => actionResultStorage),
       partialize: (state) => ({
         resultMap: state.resultMap,
-        pollingStateMap: state.pollingStateMap,
       }),
     },
   ),

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -60,6 +60,9 @@ const translations = {
     project: 'Project',
     upgrade: 'Upgrade',
     upgradeSubscription: 'Upgrade Subscription',
+    dismiss: 'Dismiss',
+    copyRequestInfo: 'Copy Request Info',
+    tryAgain: 'Try again',
     copy: {
       title: 'Copy',
       success: 'Content has been copied to the clipboard!',
@@ -1287,6 +1290,11 @@ const translations = {
       shareLoading: 'Loading shared skill response...',
       notFound: 'Skill Response Not Found',
       notFoundDesc: 'The skill response you are looking for does not exist or has been removed.',
+      generating: 'Generating content...',
+      error: {
+        defaultTitle: 'Skill execution failed',
+        networkError: 'If the problem persists, please check your internet connection or VPN',
+      },
     },
     chatHistory: {
       alreadyAdded: 'Already added to chat history',

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -68,6 +68,9 @@ const translations = {
     project: '知识库',
     upgrade: '升级',
     upgradeSubscription: '升级订阅',
+    dismiss: '关闭',
+    copyRequestInfo: '复制请求信息',
+    tryAgain: '重试',
     copy: {
       title: '复制',
       success: '内容已复制到剪切板！',
@@ -1100,6 +1103,11 @@ const translations = {
       shareLoading: '正在加载共享技能响应...',
       notFound: '技能响应未找到',
       notFoundDesc: '您查找的技能响应不存在或已被删除。',
+      generating: '正在生成内容...',
+      error: {
+        defaultTitle: '技能执行失败',
+        networkError: '如果问题持续存在，请检查您的网络连接或 VPN',
+      },
     },
     chatHistory: {
       alreadyAdded: '已添加到对话历史',

--- a/packages/openapi-schema/package.json
+++ b/packages/openapi-schema/package.json
@@ -12,7 +12,8 @@
     "dev": "nodemon",
     "codegen": "openapi-ts && tsc --build --verbose",
     "clean": "rimraf dist && rimraf tsconfig.tsbuildinfo",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "tsc --build --verbose"
   },
   "devDependencies": {
     "@hey-api/client-fetch": "0.4.0",

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -5529,7 +5529,6 @@ components:
         error:
           description: Error data. Only present when `event` is `error`.
           $ref: '#/components/schemas/BaseResponse'
-          deprecated: true
         originError:
           type: string
           description: Original error message. Only present when `event` is `error`.

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -3800,7 +3800,6 @@ export const SkillEventSchema = {
     error: {
       description: 'Error data. Only present when `event` is `error`.',
       $ref: '#/components/schemas/BaseResponse',
-      deprecated: true,
     },
     originError: {
       type: 'string',

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -2722,7 +2722,6 @@ export type SkillEvent = {
   node?: CanvasNode;
   /**
    * Error data. Only present when `event` is `error`.
-   * @deprecated
    */
   error?: BaseResponse;
   /**


### PR DESCRIPTION
# Summary

Skills are now executed on server, loosely decoupled with SSE connection. When the browser is refreshed or closed during the process, the skill response can still be generated and retrieved.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
