### PR TITLE
fix(editor): improve error handling and validation in table grip selection utilities

### DIFF
--- a/packages/ai-workspace-common/src/components/editor/extensions/Table/menus/TableColumn/utils.ts
+++ b/packages/ai-workspace-common/src/components/editor/extensions/Table/menus/TableColumn/utils.ts
@@ -16,25 +16,33 @@ export const isColumnGripSelected = ({
   state: EditorState;
   from: number;
 }) => {
-  if (!view) return false;
+  if (!view || !editor?.isInitialized || !editor?.view) return false;
 
-  const domAtPos = view.domAtPos(from).node as HTMLElement;
-  const nodeDOM = view.nodeDOM(from) as HTMLElement;
-  const node = nodeDOM || domAtPos;
+  try {
+    const domAtPosResult = view.domAtPos(from);
+    if (!domAtPosResult) return false;
 
-  if (!editor?.isActive(Table.name) || !node || isTableSelected(state?.selection)) {
+    const domAtPos = domAtPosResult.node as HTMLElement;
+    const nodeDOM = view.nodeDOM(from) as HTMLElement;
+    const node = nodeDOM || domAtPos;
+
+    if (!editor?.isActive(Table.name) || !node || isTableSelected(state?.selection)) {
+      return false;
+    }
+
+    let container = node;
+
+    while (container && !['TD', 'TH'].includes(container.tagName)) {
+      container = container.parentElement!;
+    }
+
+    const gripColumn = container?.querySelector?.('a.grip-column.selected');
+
+    return !!gripColumn;
+  } catch (error) {
+    console.error(error);
     return false;
   }
-
-  let container = node;
-
-  while (container && !['TD', 'TH'].includes(container.tagName)) {
-    container = container.parentElement!;
-  }
-
-  const gripColumn = container?.querySelector?.('a.grip-column.selected');
-
-  return !!gripColumn;
 };
 
 export default isColumnGripSelected;

--- a/packages/ai-workspace-common/src/components/editor/extensions/Table/menus/TableRow/utils.ts
+++ b/packages/ai-workspace-common/src/components/editor/extensions/Table/menus/TableRow/utils.ts
@@ -16,25 +16,33 @@ export const isRowGripSelected = ({
   state: EditorState;
   from: number;
 }) => {
-  if (!view) return false;
+  if (!view || !editor?.isInitialized || !editor?.view) return false;
 
-  const domAtPos = view.domAtPos(from).node as HTMLElement;
-  const nodeDOM = view.nodeDOM(from) as HTMLElement;
-  const node = nodeDOM || domAtPos;
+  try {
+    const domAtPosResult = view.domAtPos(from);
+    if (!domAtPosResult) return false;
 
-  if (!editor?.isActive(Table.name) || !node || isTableSelected(state?.selection)) {
+    const domAtPos = domAtPosResult.node as HTMLElement;
+    const nodeDOM = view.nodeDOM(from) as HTMLElement;
+    const node = nodeDOM || domAtPos;
+
+    if (!editor?.isActive(Table.name) || !node || isTableSelected(state?.selection)) {
+      return false;
+    }
+
+    let container = node;
+
+    while (container && !['TD', 'TH'].includes(container.tagName)) {
+      container = container.parentElement!;
+    }
+
+    const gripRow = container?.querySelector('a.grip-row.selected');
+
+    return !!gripRow;
+  } catch (error) {
+    console.error(error);
     return false;
   }
-
-  let container = node;
-
-  while (container && !['TD', 'TH'].includes(container.tagName)) {
-    container = container.parentElement!;
-  }
-
-  const gripRow = container?.querySelector('a.grip-row.selected');
-
-  return !!gripRow;
 };
 
 export default isRowGripSelected;


### PR DESCRIPTION
# Summary

- Enhanced null checks for view, editor initialization, and node existence to prevent runtime errors.
- Wrapped logic in try-catch blocks to handle potential exceptions gracefully.
- Ensured proper querying of grip elements in both column and row utilities for better reliability.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
