### PR TITLE
fix(web): incorrect hook placement in SkillResponseNodePreviewComponent

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
@@ -250,6 +250,11 @@ const SkillResponseNodePreviewComponent = ({ node, resultId }: SkillResponseNode
     };
   }, [node.id]);
 
+  const isPending = result?.status === 'executing' || result?.status === 'waiting' || loading;
+  const errDescription = useMemo(() => {
+    return `${errCode} ${errMsg} ${rawError ? `: ${String(rawError)}` : ''}`;
+  }, [errCode, errMsg, rawError]);
+
   if (!result && !loading) {
     return (
       <div className="h-full w-full flex items-center justify-center">
@@ -261,11 +266,6 @@ const SkillResponseNodePreviewComponent = ({ node, resultId }: SkillResponseNode
       </div>
     );
   }
-
-  const isPending = result?.status === 'executing' || result?.status === 'waiting' || loading;
-  const errDescription = useMemo(() => {
-    return `${errCode} ${errMsg} ${rawError ? `: ${String(rawError)}` : ''}`;
-  }, [errCode, errMsg, rawError]);
 
   return (
     <div className="flex flex-col space-y-4 p-4 h-full max-w-[1024px] mx-auto">


### PR DESCRIPTION
# Summary

- Moved the isPending and errDescription logic inside the component to improve readability.
- Utilized useMemo for errDescription to optimize performance.
- Ensured consistent handling of loading and result states.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
