### PR TITLE
style: update line-height for html and body elements in CSS files

### DIFF
--- a/apps/web/src/styles/style.css
+++ b/apps/web/src/styles/style.css
@@ -124,6 +124,7 @@ select:focus {
     background-color: #777;
   }
 }
-html,body {
+html,
+body {
   line-height: 1.5;
 }

--- a/apps/web/src/styles/style.css
+++ b/apps/web/src/styles/style.css
@@ -124,3 +124,6 @@ select:focus {
     background-color: #777;
   }
 }
+html,body {
+  line-height: 1.5;
+}

--- a/packages/ai-workspace-common/src/components/settings/subscribe-modal/index.scss
+++ b/packages/ai-workspace-common/src/components/settings/subscribe-modal/index.scss
@@ -97,7 +97,6 @@
         font-size: 18px;
         line-height: 32px;
         color: #000;
-        font-weight: 600;
       }
 
       &.item-free {
@@ -137,11 +136,7 @@
         font-weight: 800;
         height: 48px;
         margin-top: 12px;
-        .period {
-          color: #2c2929;
-          font-size: 14px;
-          line-height: 24px;
-        }
+
       }
 
       .description {

--- a/packages/ai-workspace-common/src/components/settings/subscribe-modal/priceContent.tsx
+++ b/packages/ai-workspace-common/src/components/settings/subscribe-modal/priceContent.tsx
@@ -136,7 +136,7 @@ const PlanItem = (props: {
                 t('settings.subscription.subscribe.forFree')
               )}
             </span>
-            <span className="period !text-xs dark:text-gray-200">
+            <span className="text-xs text-[#2c2929] dark:text-gray-200">
               {' '}
               /{' '}
               {title === 'free' ? (
@@ -152,7 +152,7 @@ const PlanItem = (props: {
           {interval === 'yearly' && title !== 'free' && (
             <div>
               <span className="price text-base">${getPrice(title)}</span>
-              <span className="period !text-xs">
+              <span className="!text-xs !text-[#2c2929] dark:!text-gray-200">
                 {' '}
                 /{' '}
                 <span className="whitespace-nowrap">

--- a/packages/ai-workspace-common/src/styles/style.css
+++ b/packages/ai-workspace-common/src/styles/style.css
@@ -20,6 +20,7 @@
   display: none;
 }
 
-html,body {
+html,
+body {
   line-height: 1.5;
 }

--- a/packages/ai-workspace-common/src/styles/style.css
+++ b/packages/ai-workspace-common/src/styles/style.css
@@ -19,3 +19,7 @@
 [x-cloak=''] {
   display: none;
 }
+
+html,body {
+  line-height: 1.5;
+}


### PR DESCRIPTION
- Added line-height of 1.5 to html and body elements in both web and common stylesheets for improved readability.
- Removed unnecessary font-weight and period styles from the subscribe modal's SCSS for cleaner code.
- Adjusted text color in priceContent component for better consistency with design.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
