### PR TITLE
refactor: update module imports and nodemon configurations

### DIFF
--- a/apps/api/nodemon.json
+++ b/apps/api/nodemon.json
@@ -9,5 +9,5 @@
   ],
   "ext": "ts",
   "ignore": ["src/**/*.spec.ts"],
-  "exec": "prisma format && prisma generate && ts-node -r tsconfig-paths/register src/main.ts"
+  "exec": "pnpm build && node dist/main.js"
 }

--- a/apps/api/src/modules/internal-mcp/internal-mcp.module.ts
+++ b/apps/api/src/modules/internal-mcp/internal-mcp.module.ts
@@ -1,15 +1,15 @@
 import { Module } from '@nestjs/common';
 import { McpModule, McpTransportType } from '@rekog/mcp-nest';
-import { JwtAuthGuard } from '@/modules/auth/guard/jwt-auth.guard';
+import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
 import { McpServerService } from '../mcp-server/mcp-server.service';
-import { PrismaService } from '@/modules/common/prisma.service';
-import { EncryptionService } from '@/modules/common/encryption.service';
-import { InternalMcpService } from '@/modules/internal-mcp/internal-mcp.service';
-import { SearchTools } from '@/modules/internal-mcp/tools/search.tools';
-import { SearchService } from '@/modules/search/search.service';
-import { RAGModule } from '@/modules/rag/rag.module';
-import { ProviderModule } from '@/modules/provider/provider.module';
-import { CommonModule } from '@/modules/common/common.module';
+import { PrismaService } from '../common/prisma.service';
+import { EncryptionService } from '../common/encryption.service';
+import { InternalMcpService } from './internal-mcp.service';
+import { SearchTools } from './tools/search.tools';
+import { SearchService } from '../search/search.service';
+import { RAGModule } from '../rag/rag.module';
+import { ProviderModule } from '../provider/provider.module';
+import { CommonModule } from '../common/common.module';
 
 @Module({
   imports: [

--- a/apps/api/src/modules/internal-mcp/internal-mcp.service.ts
+++ b/apps/api/src/modules/internal-mcp/internal-mcp.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { McpServerService } from '../mcp-server/mcp-server.service';
-import { EncryptionService } from '@/modules/common/encryption.service';
+import { EncryptionService } from '../common/encryption.service';
 
 @Injectable()
 export class InternalMcpService {

--- a/apps/api/src/modules/internal-mcp/tools/mcp-server.tools.ts
+++ b/apps/api/src/modules/internal-mcp/tools/mcp-server.tools.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { Request } from 'express';
 import { McpServerService } from '../../mcp-server/mcp-server.service';
 import { InternalMcpService } from '../internal-mcp.service';
-import { User as UserModel } from '@/generated/client';
+import { User as UserModel } from '../../../generated/client';
 import { mcpServerPO2DTO } from '../../mcp-server/mcp-server.dto';
 import { UpsertMcpServerRequest } from '@refly/openapi-schema';
 

--- a/apps/api/src/modules/internal-mcp/tools/search.tools.ts
+++ b/apps/api/src/modules/internal-mcp/tools/search.tools.ts
@@ -3,8 +3,8 @@ import { Tool, Context } from '@rekog/mcp-nest';
 import { z } from 'zod';
 import { Request } from 'express';
 import { InternalMcpService } from '../internal-mcp.service';
-import { User as UserModel } from '@/generated/client';
-import { SearchService } from '@/modules/search/search.service';
+import { User as UserModel } from '../../../generated/client';
+import { SearchService } from '../../search/search.service';
 
 @Injectable()
 export class SearchTools {

--- a/apps/api/src/modules/pilot/pilot.dto.ts
+++ b/apps/api/src/modules/pilot/pilot.dto.ts
@@ -2,9 +2,9 @@ import {
   PilotSession as PilotSessionPO,
   PilotStep as PilotStepPO,
   ActionResult as ActionResultPO,
-} from '@/generated/client';
-import { actionResultPO2DTO } from '@/modules/action/action.dto';
-import { pick } from '@/utils';
+} from '../../generated/client';
+import { actionResultPO2DTO } from '../action/action.dto';
+import { pick } from '../../utils';
 import {
   PilotSession,
   PilotSessionStatus,

--- a/apps/api/src/modules/pilot/pilot.module.ts
+++ b/apps/api/src/modules/pilot/pilot.module.ts
@@ -2,14 +2,14 @@ import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { CommonModule } from '../common/common.module';
 import { CanvasModule } from '../canvas/canvas.module';
-import { SkillModule } from '@/modules/skill/skill.module';
+import { SkillModule } from '../skill/skill.module';
 import { KnowledgeModule } from '../knowledge/knowledge.module';
 import { ProviderModule } from '../provider/provider.module';
 import { CodeArtifactModule } from '../code-artifact/code-artifact.module';
 import { PilotService } from './pilot.service';
 import { PilotController } from './pilot.controller';
 import { RunPilotProcessor, SyncPilotStepProcessor } from './pilot.processor';
-import { QUEUE_RUN_PILOT } from '@/utils/const';
+import { QUEUE_RUN_PILOT } from '../../utils/const';
 
 @Module({
   imports: [

--- a/apps/api/src/modules/pilot/pilot.service.ts
+++ b/apps/api/src/modules/pilot/pilot.service.ts
@@ -15,19 +15,19 @@ import {
   convertResultContextToItems,
 } from '@refly/canvas-common';
 import { PilotEngine } from './pilot-engine';
-import { PilotSession } from '@/generated/client';
-import { SkillService } from '@/modules/skill/skill.service';
+import { PilotSession } from '../../generated/client';
+import { SkillService } from '../skill/skill.service';
 import { genActionResultID, genPilotSessionID, genPilotStepID } from '@refly/utils';
 import { CanvasContentItem } from '../canvas/canvas.dto';
-import { ProviderService } from '@/modules/provider/provider.service';
-import { CanvasService } from '@/modules/canvas/canvas.service';
+import { ProviderService } from '../provider/provider.service';
+import { CanvasService } from '../canvas/canvas.service';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
-import { QUEUE_RUN_PILOT } from '@/utils/const';
+import { QUEUE_RUN_PILOT } from '../../utils/const';
 import { RunPilotJobData } from './pilot.processor';
 import { ProviderItemNotFoundError } from '@refly/errors';
-import { pilotSessionPO2DTO, pilotStepPO2DTO } from '@/modules/pilot/pilot.dto';
-import { findBestMatch } from '@/utils/similarity';
+import { pilotSessionPO2DTO, pilotStepPO2DTO } from './pilot.dto';
+import { findBestMatch } from '../../utils/similarity';
 
 @Injectable()
 export class PilotService {

--- a/apps/api/src/modules/provider/provider.service.ts
+++ b/apps/api/src/modules/provider/provider.service.ts
@@ -48,7 +48,7 @@ import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { ConfigService } from '@nestjs/config';
 import { VectorSearchService } from '../common/vector-search';
 import { VECTOR_SEARCH } from '../common/vector-search/tokens';
-import { providerItemPO2DTO } from '@/modules/provider/provider.dto';
+import { providerItemPO2DTO } from './provider.dto';
 
 interface GlobalProviderConfig {
   providers: ProviderModel[];

--- a/apps/api/src/modules/skill/skill-engine.service.ts
+++ b/apps/api/src/modules/skill/skill-engine.service.ts
@@ -1,21 +1,21 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { ReflyService, SkillEngine, SkillEngineOptions } from '@refly/skill-template';
-import { CanvasService } from '@/modules/canvas/canvas.service';
-import { KnowledgeService } from '@/modules/knowledge/knowledge.service';
-import { LabelService } from '@/modules/label/label.service';
-import { McpServerService } from '@/modules/mcp-server/mcp-server.service';
-import { ProviderService } from '@/modules/provider/provider.service';
-import { RAGService } from '@/modules/rag/rag.service';
-import { SearchService } from '@/modules/search/search.service';
-import { buildSuccessResponse } from '@/utils';
-import { mcpServerPO2DTO } from '@/modules/mcp-server/mcp-server.dto';
-import { canvasPO2DTO } from '@/modules/canvas/canvas.dto';
-import { ParserFactory } from '@/modules/knowledge/parsers/factory';
-import { documentPO2DTO, referencePO2DTO, resourcePO2DTO } from '@/modules/knowledge/knowledge.dto';
-import { labelClassPO2DTO, labelPO2DTO } from '@/modules/label/label.dto';
+import { CanvasService } from '../canvas/canvas.service';
+import { KnowledgeService } from '../knowledge/knowledge.service';
+import { LabelService } from '../label/label.service';
+import { McpServerService } from '../mcp-server/mcp-server.service';
+import { ProviderService } from '../provider/provider.service';
+import { RAGService } from '../rag/rag.service';
+import { SearchService } from '../search/search.service';
+import { buildSuccessResponse } from '../../utils';
+import { mcpServerPO2DTO } from '../mcp-server/mcp-server.dto';
+import { canvasPO2DTO } from '../canvas/canvas.dto';
+import { ParserFactory } from '../knowledge/parsers/factory';
+import { documentPO2DTO, referencePO2DTO, resourcePO2DTO } from '../knowledge/knowledge.dto';
+import { labelClassPO2DTO, labelPO2DTO } from '../label/label.dto';
 import { ConfigService } from '@nestjs/config';
-import { AuthService } from '@/modules/auth/auth.service';
+import { AuthService } from '../auth/auth.service';
 
 @Injectable()
 export class SkillEngineService implements OnModuleInit {

--- a/apps/api/src/modules/skill/skill-invoker.service.ts
+++ b/apps/api/src/modules/skill/skill-invoker.service.ts
@@ -32,7 +32,7 @@ import {
 } from '@refly/skill-template';
 import { throttle } from 'lodash';
 import { MiscService } from '../misc/misc.service';
-import { ResultAggregator } from '@/utils/result';
+import { ResultAggregator } from '../../utils/result';
 import { DirectConnection } from '@hocuspocus/server';
 import { getWholeParsedContent } from '@refly/utils';
 import { ProjectNotFoundError } from '@refly/errors';
@@ -44,11 +44,11 @@ import {
   QUEUE_SYNC_PILOT_STEP,
   QUEUE_SYNC_REQUEST_USAGE,
   QUEUE_SYNC_TOKEN_USAGE,
-} from '@/utils/const';
+} from '../../utils/const';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
-import { writeSSEResponse } from '@/utils/response';
-import { genBaseRespDataFromError } from '@/utils/exception';
+import { writeSSEResponse } from '../../utils/response';
+import { genBaseRespDataFromError } from '../../utils/exception';
 import { SyncPilotStepJobData } from '../pilot/pilot.processor';
 import { AutoNameCanvasJobData } from '../canvas/canvas.dto';
 import { ProviderService } from '../provider/provider.service';

--- a/apps/api/src/modules/skill/skill.processor.ts
+++ b/apps/api/src/modules/skill/skill.processor.ts
@@ -5,7 +5,7 @@ import { Job } from 'bullmq';
 import { SkillService } from './skill.service';
 import { QUEUE_SKILL, QUEUE_SKILL_TIMEOUT_CHECK } from '../../utils/const';
 import { InvokeSkillJobData, SkillTimeoutCheckJobData } from './skill.dto';
-import { SkillInvokerService } from '@/modules/skill/skill-invoker.service';
+import { SkillInvokerService } from './skill-invoker.service';
 
 @Processor(QUEUE_SKILL)
 export class SkillProcessor extends WorkerHost {

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
+    "composite": true,
     "declaration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
@@ -20,9 +21,6 @@
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "types": ["jest", "node", "express", "multer"],
     "resolveJsonModule": true
   },

--- a/apps/desktop/nodemon.json
+++ b/apps/desktop/nodemon.json
@@ -2,5 +2,5 @@
   "watch": ["src"],
   "ext": "ts",
   "ignore": ["src/**/*.spec.ts"],
-  "exec": "tsc && electron ."
+  "exec": "tsc --build --verbose && tsc-alias --project tsconfig.json && electron ."
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "nodemon",
     "dev:electron": "nodemon",
-    "start": "tsc && electron .",
+    "start": "tsc && tsc-alias --project tsconfig.json && electron .",
     "copy-renderer": "ncp ../web/dist dist/renderer",
     "build:mac": "tsc && electron-builder --mac --dir",
     "build:mac:x64": "tsc && electron-builder --mac --x64 --dir",
@@ -18,9 +18,14 @@
   },
   "devDependencies": {
     "@electron/asar": "^4.0.0",
+    "@types/express": "^4.17.13",
+    "@types/multer": "~1.4.11",
     "electron": "36.2.1",
     "electron-builder": "26.0.15",
-    "electron-notarize": "^1.2.2"
+    "electron-notarize": "^1.2.2",
+    "tsconfig-paths": "~4.2.0",
+    "ts-node": "^10.9.2",
+    "tsc-alias": "^1.8.16"
   },
   "dependencies": {
     "@prisma/engines": "5.16.1",

--- a/apps/desktop/src/electron-env.d.ts
+++ b/apps/desktop/src/electron-env.d.ts
@@ -23,7 +23,7 @@ declare namespace NodeJS {
 
 // Used in Renderer process, expose in `preload.ts`
 interface Window {
-  ipcRenderer: import('electron').IpcRenderer;
+  // ipcRenderer: import('electron').IpcRenderer;
   versions: {
     node: () => string;
     chrome: () => string;

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -23,8 +23,17 @@
     "inlineSources": true,
     "sourceRoot": "/",
     "composite": true,
-    "types": ["electron"],
+    "types": ["electron", "express", "multer"],
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [{ "path": "../api" }],
+  "tsc-alias": {
+    "verbose": true,
+    "resolveFullPaths": true,
+    "fileExtensions": {
+      "inputGlob": "{js,jsx,mjs}",
+      "outputCheck": ["js", "json", "jsx", "mjs"]
+    }
+  }
 }

--- a/packages/utils/src/brand.ts
+++ b/packages/utils/src/brand.ts
@@ -1,1 +1,1 @@
-export const BRANDING_NAME = 'Refly';
+export const BRANDING_NAME = 'Refly2';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,6 +430,12 @@ importers:
       '@electron/asar':
         specifier: ^4.0.0
         version: 4.0.0
+      '@types/express':
+        specifier: ^4.17.13
+        version: 4.17.21
+      '@types/multer':
+        specifier: ~1.4.11
+        version: 1.4.12
       electron:
         specifier: 36.2.1
         version: 36.2.1
@@ -439,6 +445,15 @@ importers:
       electron-notarize:
         specifier: ^1.2.2
         version: 1.2.2
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@swc/core@1.11.24)(@types/node@24.0.4)(typescript@5.8.3)
+      tsc-alias:
+        specifier: ^1.8.16
+        version: 1.8.16
+      tsconfig-paths:
+        specifier: ~4.2.0
+        version: 4.2.0
 
   apps/extension:
     dependencies:
@@ -21765,7 +21780,6 @@ snapshots:
   '@types/node@24.0.4':
     dependencies:
       undici-types: 7.8.0
-    optional: true
 
   '@types/normalize-path@3.0.2': {}
 
@@ -32281,7 +32295,6 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.11.24
-    optional: true
 
   tsc-alias@1.8.16:
     dependencies:
@@ -32511,8 +32524,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.8.0:
-    optional: true
+  undici-types@7.8.0: {}
 
   undici@5.28.4:
     dependencies:


### PR DESCRIPTION
# Summary

- Changed import paths in multiple modules to relative paths for consistency.
- Updated nodemon configurations for both API and desktop applications to improve build and execution processes.
- Added composite option in tsconfig for better project structure.
- Updated package.json scripts to include tsc-alias for better path resolution.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
