### PR TITLE
feat(canvas): improve skill response handling and polling logic

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
@@ -58,7 +58,10 @@ import { BorderBeam } from '@refly-packages/ai-workspace-common/components/magic
 import { NodeActionButtons } from './shared/node-action-buttons';
 import { useGetNodeConnectFromDragCreateInfo } from '@refly-packages/ai-workspace-common/hooks/canvas/use-get-node-connect';
 import { NodeDragCreateInfo } from '@refly-packages/ai-workspace-common/events/nodeOperations';
-import { useActionResultStoreShallow } from '@refly-packages/ai-workspace-common/stores/action-result';
+import {
+  useActionResultStoreShallow,
+  useActionResultStore,
+} from '@refly-packages/ai-workspace-common/stores/action-result';
 
 export const NodeHeader = memo(
   ({
@@ -275,13 +278,27 @@ export const SkillResponseNode = memo(
     }));
 
     useEffect(() => {
-      if (!isStreaming && (status === 'executing' || status === 'waiting')) {
-        startPolling(entityId, version);
+      if (!isStreaming) {
+        if (['executing', 'waiting'].includes(status)) {
+          startPolling(entityId, version);
+        }
+      } else {
+        // Only remove stream result if the status has been 'failed' or 'finish'
+        // for a reasonable time to avoid race conditions during rerun
+        if (['failed', 'finish'].includes(status)) {
+          // Add a small delay to handle race conditions during rerun
+          const timeoutId = setTimeout(() => {
+            // Double check the status before removing
+            const currentStream = useActionResultStore.getState().streamResults[entityId];
+            if (currentStream && ['failed', 'finish'].includes(status)) {
+              removeStreamResult(entityId);
+            }
+          }, 100);
+
+          return () => clearTimeout(timeoutId);
+        }
       }
-      if (isStreaming && status !== 'executing' && status !== 'waiting') {
-        removeStreamResult(entityId);
-      }
-    }, [isStreaming, status, startPolling, entityId, version]);
+    }, [isStreaming, status, startPolling, entityId, version, removeStreamResult]);
 
     const sources = Array.isArray(structuredData?.sources) ? structuredData?.sources : [];
 

--- a/packages/ai-workspace-common/src/hooks/canvas/use-action-polling.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-action-polling.ts
@@ -100,6 +100,11 @@ export const useActionPolling = () => {
             failedResultIds.add(resultId);
             return;
           }
+
+          // Update with executing status
+          if (status === 'executing') {
+            onUpdateResult(resultId, result.data);
+          }
         }
 
         updateLastPollTime(resultId);
@@ -126,6 +131,11 @@ export const useActionPolling = () => {
 
       // Don't restart polling for results that are already marked as failed
       if (failedResultIds.has(resultId) || currentResult?.status === 'failed') {
+        return;
+      }
+
+      // Don't restart polling for finished results
+      if (currentResult?.status === 'finish') {
         return;
       }
 

--- a/packages/ai-workspace-common/src/hooks/canvas/use-action-polling.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-action-polling.ts
@@ -100,11 +100,6 @@ export const useActionPolling = () => {
             failedResultIds.add(resultId);
             return;
           }
-
-          // Update with executing status
-          if (status === 'executing') {
-            onUpdateResult(resultId, result.data);
-          }
         }
 
         updateLastPollTime(resultId);
@@ -131,11 +126,6 @@ export const useActionPolling = () => {
 
       // Don't restart polling for results that are already marked as failed
       if (failedResultIds.has(resultId) || currentResult?.status === 'failed') {
-        return;
-      }
-
-      // Don't restart polling for finished results
-      if (currentResult?.status === 'finish') {
         return;
       }
 


### PR DESCRIPTION
- Enhanced polling logic to prevent unnecessary updates for finished or failed results.
- Added timeout handling to manage race conditions during reruns.
- Updated action result store to prevent overriding final states with intermediate states.
- Improved cleanup of pending updates in the invoke action hook.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
