### PR TITLE
docs: fix broken links to configuration guide in self-deploy documentation

### DIFF
--- a/docs/community-version/self-deploy/index.md
+++ b/docs/community-version/self-deploy/index.md
@@ -32,7 +32,7 @@ cp ../../apps/api/.env.example .env
 ```
 
 ::: info
-A detailed description of all the environment variables is available in the [Configuration](../configuration.md).
+A detailed description of all the environment variables is available in the [Configuration](./configuration.md).
 :::
 
 ### 3. Start the application via docker compose {#start-the-application-via-docker-compose}

--- a/docs/zh/community-version/self-deploy/index.md
+++ b/docs/zh/community-version/self-deploy/index.md
@@ -31,7 +31,7 @@ cp ../../apps/api/.env.example .env
 ```
 
 ::: info
-所有环境变量的详细描述可以在[配置指南](../configuration.md)中查看。
+所有环境变量的详细描述可以在[配置指南](./configuration.md)中查看。
 :::
 
 ### 3. 通过 docker compose 启动应用 {#start-the-application-via-docker-compose}

--- a/docs/zh/community-version/self-deploy/local-quick-start.md
+++ b/docs/zh/community-version/self-deploy/local-quick-start.md
@@ -46,7 +46,7 @@ cp ../../apps/api/.env.example .env
 ```
 
 ::: info
-所有环境变量的详细描述可以在[配置指南](../configuration.md)中查看。
+所有环境变量的详细描述可以在[配置指南](./configuration.md)中查看。
 :::
 
 #### 3. 通过 docker compose 启动应用
@@ -67,7 +67,7 @@ docker compose up -d
 如果无法访问 Refly 应用，请检查以下内容：
 
 -   `HOST_IP` 是否正确。
--   应用是否正常运行。如果未运行，请跳转到[故障排除](#troubleshooting)部分。
+-   应用是否正常运行。如果未运行，请跳转到[故障排除](./index.md#troubleshooting)部分。
 -   端口 `5700` 是否被任何应用程序防火墙阻止。如果您使用的是云服务器，请特别注意这一点。
 :::
 


### PR DESCRIPTION
# Summary

- Changed relative links from '../configuration.md' to './configuration.md' for consistency in both English and Chinese documentation.
- Updated troubleshooting link in the Chinese local quick start guide for accurate navigation.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
