### PR TITLE
Enhance media generation support in model configuration

### DIFF
--- a/config/provider-catalog.json
+++ b/config/provider-catalog.json
@@ -323,6 +323,30 @@
       "categories": ["llm"],
       "documentation": "https://platform.stepfun.com/docs",
       "icon": "https://static.refly.ai/icons/providers/stepfun-ai.png"
+    },
+    {
+      "name": "Replicate (Media Generation)",
+      "providerKey": "replicate",
+      "baseUrl": "https://api.replicate.com/v1",
+      "description": {
+        "en": "Replicate provides a platform to run thousands of open-source AI models for media generation, including audio, image, and video generation with a cloud API.",
+        "zh-CN": "Replicate 提供一个平台，让您可以通过云 API 运行数以千计的开源 AI 模型进行媒体生成，包括音频、图像和视频生成。"
+      },
+      "categories": ["mediaGeneration"],
+      "documentation": "https://replicate.com/docs",
+      "icon": "https://static.refly.ai/icons/providers/replicate.png"
+    },
+    {
+      "name": "FAL",
+      "providerKey": "fal",
+      "baseUrl": "https://fal.run/fal-ai",
+      "description": {
+        "en": "FAL provides fast and scalable AI inference for media generation, including audio, image, and video generation models with optimized performance.",
+        "zh-CN": "FAL 提供快速且可扩展的 AI 推理服务，用于媒体生成，包括音频、图像和视频生成模型，具有优化的性能。"
+      },
+      "categories": ["mediaGeneration"],
+      "documentation": "https://fal.ai/docs",
+      "icon": "https://static.refly.ai/icons/providers/fal.png"
     }
   ]
 }

--- a/packages/ai-workspace-common/src/components/settings/model-config/index.tsx
+++ b/packages/ai-workspace-common/src/components/settings/model-config/index.tsx
@@ -18,7 +18,7 @@ import {
   Collapse,
 } from 'antd';
 import { Spin } from '@refly-packages/ai-workspace-common/components/common/spin';
-import { LuPlus, LuSearch } from 'react-icons/lu';
+import { LuPlus, LuSearch, LuMessageCircle, LuImage, LuSettings } from 'react-icons/lu';
 import { cn } from '@refly-packages/ai-workspace-common/utils/cn';
 import {
   IconDelete,
@@ -195,6 +195,7 @@ export const ModelConfig = ({ visible }: { visible: boolean }) => {
   const [modelItems, setModelItems] = useState<ProviderItem[]>([]);
   const [embedding, setEmbedding] = useState<ProviderItem | null>(null);
   const [reranker, setReranker] = useState<ProviderItem | null>(null);
+  const [mediaGenerationModels, setMediaGenerationModels] = useState<ProviderItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
 
@@ -203,6 +204,7 @@ export const ModelConfig = ({ visible }: { visible: boolean }) => {
   const [editingModel, setEditingModel] = useState<ProviderItem | null>(null);
   const [activeCollapseKeys, setActiveCollapseKeys] = useState<string[]>([]);
   const [userHasInteracted, setUserHasInteracted] = useState(false);
+  const [activeTab, setActiveTab] = useState('conversation');
 
   const { userProfile, setUserProfile } = useUserStoreShallow((state) => ({
     userProfile: state.userProfile,
@@ -269,75 +271,60 @@ export const ModelConfig = ({ visible }: { visible: boolean }) => {
       setModelItems(list.filter((item) => item.category === 'llm'));
       setEmbedding(list.filter((item) => item.category === 'embedding')?.[0]);
       setReranker(list.filter((item) => item.category === 'reranker')?.[0]);
+      setMediaGenerationModels(list.filter((item) => item.category === 'mediaGeneration'));
     }
   }, []);
 
-  const updateModelMutation = useCallback(
-    async (enabled: boolean, model: ProviderItem) => {
-      setIsUpdating(true);
-      const res = await getClient().updateProviderItem({
-        body: {
-          ...model,
-          enabled,
-        },
-        query: {
-          providerId: model.providerId,
-        },
-      });
-      setIsUpdating(false);
-      if (res.data.success) {
-        const updatedModel = {
-          ...model,
-          enabled,
-        };
-        setModelItems(
-          modelItems.map((item) => (item.itemId === updatedModel.itemId ? updatedModel : item)),
+  const updateModelMutation = async (enabled: boolean, model: ProviderItem) => {
+    setIsUpdating(true);
+    const res = await getClient().updateProviderItem({
+      body: {
+        itemId: model.itemId,
+        enabled,
+      },
+    });
+    if (res.data.success) {
+      const updatedModel = { ...model, enabled };
+      if (model.category === 'llm') {
+        setModelItems((prev) =>
+          prev.map((item) => (item.itemId === model.itemId ? updatedModel : item)),
         );
-        message.success(t('common.saveSuccess'));
-
-        // Emit event to refresh model list in other components
-        modelEmitter.emit('model:list:refetch', null);
+      } else if (model.category === 'embedding') {
+        setEmbedding(updatedModel);
+      } else if (model.category === 'reranker') {
+        setReranker(updatedModel);
+      } else if (model.category === 'mediaGeneration') {
+        setMediaGenerationModels((prev) =>
+          prev.map((item) => (item.itemId === model.itemId ? updatedModel : item)),
+        );
       }
-    },
-    [modelItems, t],
-  );
+
+      // Emit event to refresh model list in other components
+      modelEmitter.emit('model:list:refetch', null);
+    }
+    setIsUpdating(false);
+  };
 
   const beforeDeleteProviderItem = async (model: ProviderItem) => {
-    const type = getDefaultModelTypes(model.itemId);
-    if (type.length) {
-      Modal.confirm({
-        title: t('settings.modelConfig.deleteSyncConfirm', {
-          name: model.name || t('common.untitled'),
-        }),
-        onOk: () => deleteProviderItem(model.itemId),
-        okText: t('common.confirm'),
-        cancelText: t('common.cancel'),
-        okButtonProps: {
-          danger: true,
-        },
-        cancelButtonProps: {
-          className: 'hover:!text-green-600 hover:!border-green-600',
-        },
-      });
-    } else {
-      deleteProviderItem(model.itemId);
-    }
+    Modal.confirm({
+      title: t('settings.modelConfig.deleteConfirm', {
+        name: model.name || t('common.untitled'),
+      }),
+      content: t('settings.modelConfig.deleteWarning'),
+      okText: t('common.confirm'),
+      cancelText: t('common.cancel'),
+      okType: 'danger',
+      onOk: () => deleteProviderItem(model.itemId),
+    });
   };
 
   const disableDefaultModelConfirm = async (modelName: string, handleOk: () => void) => {
     Modal.confirm({
-      title: t('settings.modelConfig.disableSyncConfirm', {
-        name: modelName || t('common.untitled'),
-      }),
-      onOk: () => handleOk(),
+      title: t('settings.modelConfig.disableDefaultModelTitle'),
+      content: t('settings.modelConfig.disableDefaultModelContent', { modelName }),
       okText: t('common.confirm'),
       cancelText: t('common.cancel'),
-      okButtonProps: {
-        danger: true,
-      },
-      cancelButtonProps: {
-        className: 'hover:!text-green-600 hover:!border-green-600',
-      },
+      onOk: handleOk,
     });
   };
 
@@ -407,42 +394,30 @@ export const ModelConfig = ({ visible }: { visible: boolean }) => {
     type?: 'create' | 'update',
     model?: ProviderItem,
   ) => {
-    if (categoryType === 'llm') {
-      let updatedItems = [...modelItems];
-      if (type === 'create') {
-        updatedItems = [...modelItems, model];
-        setModelItems(updatedItems);
-      } else if (type === 'update') {
-        updatedItems = [
-          ...modelItems.map((item) => (item.itemId === model.itemId ? { ...model } : item)),
-        ];
-        setModelItems(updatedItems);
-
-        const types = getDefaultModelTypes(model.itemId);
-        if (types.length) {
-          updateDefaultModel(types, model?.enabled ? model : null);
-        }
+    if (type === 'create') {
+      if (categoryType === 'llm') {
+        setModelItems((prev) => [...prev, model!]);
+      } else if (categoryType === 'embedding') {
+        setEmbedding(model!);
+      } else if (categoryType === 'reranker') {
+        setReranker(model!);
+      } else if (categoryType === 'mediaGeneration') {
+        setMediaGenerationModels((prev) => [...prev, model!]);
       }
-
-      if (model) {
-        setTimeout(() => {
-          const groups = handleGroupModelList(updatedItems);
-          const groupWithModel = groups.find((group) =>
-            group.models.some((m) => m.itemId === model.itemId),
-          );
-
-          if (groupWithModel) {
-            // Open the group containing the model
-            setActiveCollapseKeys((prev) =>
-              prev.includes(groupWithModel.key) ? prev : [...prev, groupWithModel.key],
-            );
-          }
-        }, 0);
+    } else if (type === 'update') {
+      if (categoryType === 'llm') {
+        setModelItems((prev) =>
+          prev.map((item) => (item.itemId === model!.itemId ? model! : item)),
+        );
+      } else if (categoryType === 'embedding') {
+        setEmbedding(model!);
+      } else if (categoryType === 'reranker') {
+        setReranker(model!);
+      } else if (categoryType === 'mediaGeneration') {
+        setMediaGenerationModels((prev) =>
+          prev.map((item) => (item.itemId === model!.itemId ? model! : item)),
+        );
       }
-    } else if (categoryType === 'embedding') {
-      setEmbedding(model);
-    } else if (categoryType === 'reranker') {
-      setReranker(model);
     }
     setIsModalOpen(false);
     setEditingModel(null);
@@ -490,7 +465,7 @@ export const ModelConfig = ({ visible }: { visible: boolean }) => {
     if (visible) {
       getProviderItems();
     }
-  }, [visible]);
+  }, [visible, getProviderItems]);
 
   // Handle collapse panel change
   const handleCollapseChange = (keys: string | string[]) => {
@@ -498,8 +473,27 @@ export const ModelConfig = ({ visible }: { visible: boolean }) => {
     setActiveCollapseKeys(typeof keys === 'string' ? [keys] : keys);
   };
 
-  return (
-    <div className="p-4 pt-0 h-full overflow-hidden flex flex-col">
+  // Tab items for model categories
+  const tabItems = [
+    {
+      key: 'conversation',
+      label: t('settings.modelConfig.conversationModels'),
+      icon: <LuMessageCircle className="h-4 w-4" />,
+    },
+    {
+      key: 'media',
+      label: t('settings.modelConfig.mediaGeneration'),
+      icon: <LuImage className="h-4 w-4" />,
+    },
+    {
+      key: 'other',
+      label: t('settings.modelConfig.otherModels'),
+      icon: <LuSettings className="h-4 w-4" />,
+    },
+  ];
+
+  const renderConversationModels = () => (
+    <>
       <Title level={4} className="pb-4">
         {t('settings.modelConfig.chatModels')}
       </Title>
@@ -592,9 +586,67 @@ export const ModelConfig = ({ visible }: { visible: boolean }) => {
           </div>
         )}
       </div>
+    </>
+  );
 
-      <Divider />
+  const renderMediaGenerationModels = () => (
+    <>
+      <Title level={4} className="pb-4">
+        {t('settings.modelConfig.mediaGeneration')}
+      </Title>
 
+      <div className="flex items-center justify-between mb-4">
+        <Input
+          placeholder={t('settings.modelConfig.searchPlaceholder')}
+          prefix={<LuSearch className="h-4 w-4 text-gray-400" />}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="max-w-sm"
+        />
+        <Button
+          type="primary"
+          icon={<LuPlus className="h-4 w-4" />}
+          onClick={() => handleAddModel('mediaGeneration')}
+        >
+          {t('settings.modelConfig.addModel')}
+        </Button>
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        <Spin spinning={isLoading}>
+          {mediaGenerationModels.length === 0 ? (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description={t('settings.modelConfig.noMediaModels')}
+            >
+              <Button
+                onClick={() => handleAddModel('mediaGeneration')}
+                icon={<LuPlus className="flex items-center" />}
+              >
+                {t('settings.modelConfig.addFirstModel')}
+              </Button>
+            </Empty>
+          ) : (
+            <div className="space-y-2">
+              {mediaGenerationModels.map((model) => (
+                <ModelItem
+                  key={model.itemId}
+                  model={model}
+                  onEdit={handleEditModel}
+                  onDelete={handleDeleteModel}
+                  onToggleEnabled={handleToggleEnabled}
+                  isSubmitting={isUpdating}
+                />
+              ))}
+            </div>
+          )}
+        </Spin>
+      </div>
+    </>
+  );
+
+  const renderOtherModels = () => (
+    <>
       <Title level={4} className="pb-4">
         {t('settings.modelConfig.otherModels')}
       </Title>
@@ -646,6 +698,50 @@ export const ModelConfig = ({ visible }: { visible: boolean }) => {
           </div>
         </div>
       </div>
+    </>
+  );
+
+  const renderTabContent = () => {
+    switch (activeTab) {
+      case 'conversation':
+        return renderConversationModels();
+      case 'media':
+        return renderMediaGenerationModels();
+      case 'other':
+        return renderOtherModels();
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="p-4 pt-0 h-full overflow-hidden flex flex-col">
+      {/* Custom Tab Header */}
+      <div className="flex border-b border-gray-100 dark:border-gray-800 mb-4">
+        {tabItems.map((tab) => (
+          <div
+            key={tab.key}
+            onClick={() => setActiveTab(tab.key)}
+            className={`
+              cursor-pointer relative px-4 py-2.5 flex items-center justify-center gap-1.5 text-sm font-medium transition-all duration-200 ease-in-out 
+              ${
+                activeTab === tab.key
+                  ? 'text-blue-600 dark:text-blue-400'
+                  : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+              }
+            `}
+          >
+            <span className="text-sm">{tab.icon}</span>
+            <span>{tab.label}</span>
+            {activeTab === tab.key && (
+              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-blue-600 dark:bg-blue-400 rounded-t-sm" />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Tab Content */}
+      <div className="flex-1 overflow-auto">{renderTabContent()}</div>
 
       {/* Modal for Create and Edit */}
       <ModelFormModal
@@ -665,3 +761,5 @@ export const ModelConfig = ({ visible }: { visible: boolean }) => {
     </div>
   );
 };
+
+ModelItem.displayName = 'ModelItem';

--- a/packages/ai-workspace-common/src/requests/types.gen.ts
+++ b/packages/ai-workspace-common/src/requests/types.gen.ts
@@ -4258,7 +4258,8 @@ export type ProviderCategory =
   | 'reranker'
   | 'webSearch'
   | 'urlParsing'
-  | 'pdfParsing';
+  | 'pdfParsing'
+  | 'mediaGeneration';
 
 /**
  * General provider info
@@ -4578,7 +4579,11 @@ export type CanvasNodeType =
   | 'toolResponse'
   | 'memo'
   | 'group'
-  | 'image';
+  | 'image'
+  | 'video'
+  | 'audio'
+  | 'mediaSkill'
+  | 'mediaSkillResponse';
 
 export type CanvasNodeData = {
   /**

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -2275,6 +2275,7 @@ const translations = {
         pdfParsing: 'PDF Parsing',
         reranker: 'Reranker',
         embedding: 'Embedding',
+        mediaGeneration: 'Media Generation',
       },
       // Provider Store related translations
       community: {
@@ -2329,6 +2330,8 @@ const translations = {
       title: 'Model Config',
       chatModels: 'Chat Models',
       otherModels: 'Other Models',
+      conversationModels: 'Conversation Models',
+      mediaGeneration: 'Media Generation',
       addModel: 'Add Model',
       editModel: 'Edit Model',
       deleteSyncConfirm:
@@ -2336,6 +2339,11 @@ const translations = {
       disableSyncConfirm:
         '{{name}}​​ has been applied to the default model. Disabling it will reset your default settings. Proceed?',
       deleteConfirm: 'Are you sure you want to delete the model {{name}}?',
+      deleteWarning: 'This action cannot be undone. Please proceed with caution.',
+      disableDefaultModelTitle: 'Disable Default Model',
+      disableDefaultModelContent:
+        'Model {{modelName}} has been applied to the default model configuration. Disabling it will require reconfiguring the default model. Proceed?',
+      noMediaModels: 'No media generation models',
       provider: 'Provider',
       providerPlaceholder: 'Please select the provider',
       name: 'Model Name',

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -2063,6 +2063,7 @@ const translations = {
         pdfParsing: 'PDF 解析',
         reranker: '重排器',
         embedding: '嵌入',
+        mediaGeneration: '媒体生成',
       },
       // Provider Store 相关翻译
       community: {
@@ -2106,13 +2107,20 @@ const translations = {
       title: '模型配置',
       chatModels: '对话模型',
       otherModels: '其他模型',
+      conversationModels: '对话模型',
+      mediaGeneration: '媒体生成',
       addModel: '添加模型',
       editModel: '编辑模型',
       deleteConfirm: '确定删除模型 {{name}} 吗？',
+      deleteWarning: '删除后无法恢复，请谨慎操作',
+      disableDefaultModelTitle: '禁用默认模型',
+      disableDefaultModelContent:
+        '模型 {{modelName}} 已被应用到默认模型配置中，禁用后需要重新配置默认模型，确定禁用吗？',
       deleteSyncConfirm:
         '模型 {{name}} 已被应用到默认模型配置中，删除后需要重新配置默认模型，确定删除吗？',
       disableSyncConfirm:
         '模型 {{name}} 已被应用到默认模型配置中，禁用后需要重新配置默认模型，确定禁用吗？',
+      noMediaModels: '暂无媒体生成模型',
       provider: '供应商',
       providerPlaceholder: '请选择供应商',
       name: '模型名称',

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -7162,6 +7162,7 @@ components:
         - webSearch
         - urlParsing
         - pdfParsing
+        - mediaGeneration
     Provider:
       type: object
       description: General provider info

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -6109,7 +6109,15 @@ export const ListModelsResponseSchema = {
 
 export const ProviderCategorySchema = {
   type: 'string',
-  enum: ['llm', 'embedding', 'reranker', 'webSearch', 'urlParsing', 'pdfParsing'],
+  enum: [
+    'llm',
+    'embedding',
+    'reranker',
+    'webSearch',
+    'urlParsing',
+    'pdfParsing',
+    'mediaGeneration',
+  ],
 } as const;
 
 export const ProviderSchema = {

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -4258,7 +4258,8 @@ export type ProviderCategory =
   | 'reranker'
   | 'webSearch'
   | 'urlParsing'
-  | 'pdfParsing';
+  | 'pdfParsing'
+  | 'mediaGeneration';
 
 /**
  * General provider info

--- a/packages/utils/src/provider.ts
+++ b/packages/utils/src/provider.ts
@@ -87,4 +87,28 @@ export const providerInfoList: ProviderInfo[] = [
       },
     },
   },
+  {
+    key: 'replicate',
+    name: 'Replicate',
+    categories: ['llm', 'embedding', 'mediaGeneration'],
+    fieldConfig: {
+      apiKey: { presence: 'required' },
+      baseUrl: {
+        presence: 'optional',
+        defaultValue: 'https://api.replicate.com/v1',
+      },
+    },
+  },
+  {
+    key: 'fal',
+    name: 'FAL',
+    categories: ['mediaGeneration'],
+    fieldConfig: {
+      apiKey: { presence: 'required' },
+      baseUrl: {
+        presence: 'optional',
+        defaultValue: 'https://fal.run/fal-ai',
+      },
+    },
+  },
 ];


### PR DESCRIPTION
- Added new media generation providers: Replicate and FAL, with relevant details in the provider catalog.
- Updated ModelConfig component to manage media generation models, including state management and rendering.
- Introduced tabbed interface for model categories, including a dedicated tab for media generation.
- Enhanced UI with search functionality and add model button for media generation models.
- Added translations for media generation features in English and Chinese.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
