### PR TITLE
fix: ensure safe access to media configuration in ModelFormModal

### DIFF
--- a/packages/ai-workspace-common/src/components/settings/model-config/model-form.tsx
+++ b/packages/ai-workspace-common/src/components/settings/model-config/model-form.tsx
@@ -337,7 +337,7 @@ export const ModelFormModal = memo(
         const provider = providerOptions.find((p) => p.value === selectedProviderId);
         const providerKey = provider?.providerKey || selectedProviderId;
         return (
-          (mediaConfig as MediaConfig)[providerKey].map((item) => ({
+          (mediaConfig as MediaConfig)[providerKey]?.map((item) => ({
             label: item.config?.modelId || '',
             value: item.config?.modelId || '',
             ...item,

--- a/packages/ai-workspace-common/src/components/settings/model-config/model-form.tsx
+++ b/packages/ai-workspace-common/src/components/settings/model-config/model-form.tsx
@@ -135,7 +135,7 @@ export const ModelFormModal = memo(
           modelName: values.name,
         };
 
-        if (filterProviderCategory === 'llm') {
+        if (filterProviderCategory === 'llm' || filterProviderCategory === 'mediaGeneration') {
           const capabilitiesObject = {};
           if (Array.isArray(values.capabilities)) {
             for (const capability of values.capabilities) {


### PR DESCRIPTION
- Updated the ModelFormModal component to use optional chaining when accessing the media configuration array, preventing potential runtime errors when the providerKey is not found.
- This change enhances the robustness of the component by ensuring it handles undefined values gracefully.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
