### PR TITLE
fix: enhance MediaModelSelector and ModelConfig for media model manag…

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/media/media-model-selector.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/media/media-model-selector.tsx
@@ -270,7 +270,8 @@ export const MediaModelSelector = memo(
       prevProps.readonly === nextProps.readonly &&
       prevProps.model === nextProps.model &&
       prevProps.defaultModel === nextProps.defaultModel &&
-      JSON.stringify(prevProps.trigger) === JSON.stringify(nextProps.trigger)
+      JSON.stringify(prevProps.trigger) === JSON.stringify(nextProps.trigger) &&
+      JSON.stringify(prevProps.mediaModelList) === JSON.stringify(nextProps.mediaModelList)
     );
   },
 );

--- a/packages/ai-workspace-common/src/components/settings/model-config/index.tsx
+++ b/packages/ai-workspace-common/src/components/settings/model-config/index.tsx
@@ -9,7 +9,6 @@ import {
   Tooltip,
   Dropdown,
   Popconfirm,
-  Typography,
   message,
   MenuProps,
   Divider,
@@ -31,8 +30,7 @@ import { modelEmitter } from '@refly-packages/ai-workspace-common/utils/event-em
 import { useGroupModels } from '@refly-packages/ai-workspace-common/hooks/use-group-models';
 import { ModelFormModal } from './model-form';
 import { useUserStoreShallow } from '@refly-packages/ai-workspace-common/stores/user';
-
-const { Title } = Typography;
+import { useChatStoreShallow } from '@refly-packages/ai-workspace-common/stores/chat';
 
 const MODEL_TIER_TO_COLOR = {
   free: 'green',
@@ -210,6 +208,15 @@ export const ModelConfig = ({ visible }: { visible: boolean }) => {
     userProfile: state.userProfile,
     setUserProfile: state.setUserProfile,
   }));
+
+  const { setMediaModelList } = useChatStoreShallow((state) => ({
+    setMediaModelList: state.setMediaModelList,
+  }));
+
+  useEffect(() => {
+    setMediaModelList(mediaGenerationModels.filter((item) => item.enabled));
+  }, [mediaGenerationModels, setMediaModelList]);
+
   const defaultPreferences = userProfile?.preferences || {};
   const defaultModel = defaultPreferences.defaultModel || {};
   const chatModel = defaultModel.chat;
@@ -478,26 +485,22 @@ export const ModelConfig = ({ visible }: { visible: boolean }) => {
     {
       key: 'conversation',
       label: t('settings.modelConfig.conversationModels'),
-      icon: <LuMessageCircle className="h-4 w-4" />,
+      icon: <LuMessageCircle className="h-4 w-4 flex items-center" />,
     },
     {
       key: 'media',
       label: t('settings.modelConfig.mediaGeneration'),
-      icon: <LuImage className="h-4 w-4" />,
+      icon: <LuImage className="h-4 w-4 flex items-center" />,
     },
     {
       key: 'other',
       label: t('settings.modelConfig.otherModels'),
-      icon: <LuSettings className="h-4 w-4" />,
+      icon: <LuSettings className="h-4 w-4 flex items-center" />,
     },
   ];
 
   const renderConversationModels = () => (
     <>
-      <Title level={4} className="pb-4">
-        {t('settings.modelConfig.chatModels')}
-      </Title>
-
       {/* Search and Add Bar */}
       <div className="flex items-center justify-between mb-6">
         <div className="relative flex-1 max-w-xs">
@@ -591,10 +594,6 @@ export const ModelConfig = ({ visible }: { visible: boolean }) => {
 
   const renderMediaGenerationModels = () => (
     <>
-      <Title level={4} className="pb-4">
-        {t('settings.modelConfig.mediaGeneration')}
-      </Title>
-
       <div className="flex items-center justify-between mb-4">
         <Input
           placeholder={t('settings.modelConfig.searchPlaceholder')}
@@ -647,10 +646,6 @@ export const ModelConfig = ({ visible }: { visible: boolean }) => {
 
   const renderOtherModels = () => (
     <>
-      <Title level={4} className="pb-4">
-        {t('settings.modelConfig.otherModels')}
-      </Title>
-
       <div className="flex flex-col gap-4 pb-8">
         <div className="flex items-center justify-between">
           <div>
@@ -726,15 +721,15 @@ export const ModelConfig = ({ visible }: { visible: boolean }) => {
               cursor-pointer relative px-4 py-2.5 flex items-center justify-center gap-1.5 text-sm font-medium transition-all duration-200 ease-in-out 
               ${
                 activeTab === tab.key
-                  ? 'text-blue-600 dark:text-blue-400'
+                  ? 'text-green-600 dark:text-green-400'
                   : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
               }
             `}
           >
-            <span className="text-sm">{tab.icon}</span>
-            <span>{tab.label}</span>
+            <div className="text-sm">{tab.icon}</div>
+            <div>{tab.label}</div>
             {activeTab === tab.key && (
-              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-blue-600 dark:bg-blue-400 rounded-t-sm" />
+              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-green-600 dark:bg-green-400 rounded-t-sm" />
             )}
           </div>
         ))}

--- a/packages/ai-workspace-common/src/components/settings/model-providers/index.tsx
+++ b/packages/ai-workspace-common/src/components/settings/model-providers/index.tsx
@@ -356,6 +356,7 @@ interface ModelProvidersProps {
 }
 
 export const ModelProviders = ({ visible }: ModelProvidersProps) => {
+  const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState('my-providers');
 
   // Get installed providers for Provider Store
@@ -379,13 +380,13 @@ export const ModelProviders = ({ visible }: ModelProvidersProps) => {
   const tabItems = [
     {
       key: 'my-providers',
-      label: 'My Providers',
-      icon: <LuList className="h-4 w-4" />,
+      label: t('settings.modelProviders.myProviders'),
+      icon: <LuList className="h-4 w-4 flex items-center" />,
     },
     {
       key: 'provider-store',
-      label: 'Provider Store',
-      icon: <LuStore className="h-4 w-4" />,
+      label: t('settings.modelProviders.providerStore'),
+      icon: <LuStore className="h-4 w-4 flex items-center" />,
     },
   ];
 
@@ -423,15 +424,15 @@ export const ModelProviders = ({ visible }: ModelProvidersProps) => {
               cursor-pointer relative px-4 py-2.5 flex items-center justify-center gap-1.5 text-sm font-medium transition-all duration-200 ease-in-out 
               ${
                 activeTab === tab.key
-                  ? 'text-blue-600 dark:text-blue-400'
+                  ? 'text-green-600 dark:text-green-400'
                   : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
               }
             `}
           >
-            <span className="text-sm">{tab.icon}</span>
-            <span>{tab.label}</span>
+            <div className="text-sm">{tab.icon}</div>
+            <div>{tab.label}</div>
             {activeTab === tab.key && (
-              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-blue-600 dark:bg-blue-400 rounded-t-sm" />
+              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-green-600 dark:bg-green-400 rounded-t-sm" />
             )}
           </div>
         ))}


### PR DESCRIPTION
…ement

- Updated MediaModelSelector to include mediaModelList in the memoization check, improving performance by preventing unnecessary re-renders.
- Refactored ModelConfig to utilize useChatStoreShallow for setting media model list based on enabled media generation models, ensuring proper state management.
- Removed unused Typography import and adjusted icon styling for better alignment in tabs.
- Enhanced rendering logic by removing unnecessary Title components, streamlining the UI.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
