### PR TITLE
fix(api): TypeError when provider item is null

### DIFF
--- a/apps/api/src/modules/skill/skill.service.ts
+++ b/apps/api/src/modules/skill/skill.service.ts
@@ -274,7 +274,7 @@ export class SkillService {
 
     const tiers = [];
     for (const providerItem of Object.values(modelProviderMap)) {
-      if (providerItem.tier) {
+      if (providerItem?.tier) {
         tiers.push(providerItem.tier);
       }
     }
@@ -389,7 +389,7 @@ export class SkillService {
               uid,
               version: (existingResult.version ?? 0) + 1,
               type: 'skill',
-              tier: providerItem.tier ?? '',
+              tier: providerItem?.tier ?? '',
               status: 'executing',
               title: param.input.query,
               targetId: param.target?.entityId,
@@ -424,7 +424,7 @@ export class SkillService {
           resultId,
           uid,
           version: 0,
-          tier: providerItem.tier,
+          tier: providerItem?.tier ?? '',
           targetId: param.target?.entityId,
           targetType: param.target?.entityType,
           title: param.input?.query,


### PR DESCRIPTION
# Summary

- Updated SkillService to use optional chaining when accessing the tier property of provider items, ensuring safer property access.
- Applied nullish coalescing to provide default values for potentially undefined tier properties, enhancing code robustness.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when handling missing or undefined provider information during skill operations, preventing potential errors and ensuring smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->