### PR TITLE
fix: support double write for compatibility with legacy Ydoc sync

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -65,6 +65,7 @@
     "@prisma/instrumentation": "5.16.1",
     "@qdrant/js-client-rest": "^1.9.0",
     "@refly/canvas-common": "workspace:*",
+    "@refly/common-types": "workspace:*",
     "@refly/errors": "workspace:*",
     "@refly/openapi-schema": "workspace:*",
     "@refly/providers": "workspace:*",

--- a/apps/api/src/modules/canvas/canvas.module.ts
+++ b/apps/api/src/modules/canvas/canvas.module.ts
@@ -61,6 +61,6 @@ import { CanvasSyncService } from './canvas-sync.service';
           VerifyNodeAdditionProcessor,
         ]),
   ],
-  exports: [CanvasService],
+  exports: [CanvasService, CanvasSyncService],
 })
 export class CanvasModule {}

--- a/apps/api/src/modules/collab/collab.module.ts
+++ b/apps/api/src/modules/collab/collab.module.ts
@@ -7,11 +7,13 @@ import { QUEUE_SYNC_CANVAS_ENTITY } from '../../utils/const';
 import { CollabService } from './collab.service';
 import { CollabController } from './collab.controller';
 import { isDesktop } from '../../utils/runtime';
+import { CanvasModule } from '../canvas/canvas.module';
 
 @Module({
   imports: [
     CommonModule,
     RAGModule,
+    CanvasModule,
     ...(isDesktop() ? [] : [BullModule.registerQueue({ name: QUEUE_SYNC_CANVAS_ENTITY })]),
   ],
   providers: [CollabGateway, CollabService],

--- a/apps/api/src/modules/collab/collab.service.ts
+++ b/apps/api/src/modules/collab/collab.service.ts
@@ -296,8 +296,11 @@ export class CollabService {
       updatedAt: new Date().toJSON(),
     });
 
-    // Double-write: sync ydoc to new state storage
-    await this.canvasSync.syncCanvasStateFromYDoc(user, canvas.canvasId, cleanedDocument);
+    // If this canvas already has version info (synchronization V2) but still goes for legacy sync,
+    // we have to double-write: sync ydoc to new state storage
+    if (canvas.version) {
+      await this.canvasSync.syncCanvasStateFromYDoc(user, canvas.canvasId, cleanedDocument);
+    }
 
     // Add sync canvas entity job with debouncing
     await this.canvasQueue?.add(

--- a/apps/api/src/modules/collab/collab.service.ts
+++ b/apps/api/src/modules/collab/collab.service.ts
@@ -299,7 +299,13 @@ export class CollabService {
     // If this canvas already has version info (synchronization V2) but still goes for legacy sync,
     // we have to double-write: sync ydoc to new state storage
     if (canvas.version) {
-      await this.canvasSync.syncCanvasStateFromYDoc(user, canvas.canvasId, cleanedDocument);
+      try {
+        await this.canvasSync.syncCanvasStateFromYDoc(user, canvas.canvasId, document);
+      } catch (err) {
+        this.logger.error(
+          `failed to sync canvas state from ydoc: ${canvas.canvasId}, err: ${err.stack}`,
+        );
+      }
     }
 
     // Add sync canvas entity job with debouncing

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       '@refly/canvas-common':
         specifier: workspace:*
         version: link:../../packages/canvas-common
+      '@refly/common-types':
+        specifier: workspace:*
+        version: link:../../packages/common-types
       '@refly/errors':
         specifier: workspace:*
         version: link:../../packages/errors
@@ -1079,10 +1082,10 @@ importers:
         version: 2.7.4(@tiptap/core@2.7.4(@tiptap/pm@2.7.4))(@tiptap/extension-code-block@2.12.0(@tiptap/core@2.7.4(@tiptap/pm@2.7.4))(@tiptap/pm@2.7.4))(@tiptap/pm@2.7.4)(highlight.js@11.10.0)(lowlight@3.1.0)
       '@tiptap/extension-collaboration':
         specifier: 2.7.4
-        version: 2.7.4(@tiptap/core@2.7.4(@tiptap/pm@2.7.4))(@tiptap/pm@2.7.4)(y-prosemirror@1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16))
+        version: 2.7.4(@tiptap/core@2.7.4(@tiptap/pm@2.7.4))(@tiptap/pm@2.7.4)(y-prosemirror@1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.34.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16))
       '@tiptap/extension-collaboration-cursor':
         specifier: 2.7.4
-        version: 2.7.4(@tiptap/core@2.7.4(@tiptap/pm@2.7.4))(y-prosemirror@1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16))
+        version: 2.7.4(@tiptap/core@2.7.4(@tiptap/pm@2.7.4))(y-prosemirror@1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.34.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16))
       '@tiptap/extension-color':
         specifier: 2.7.4
         version: 2.7.4(@tiptap/core@2.7.4(@tiptap/pm@2.7.4))(@tiptap/extension-text-style@2.7.4(@tiptap/core@2.7.4(@tiptap/pm@2.7.4)))
@@ -1403,7 +1406,7 @@ importers:
         version: 9.0.12(yjs@13.6.16)
       y-prosemirror:
         specifier: ^1.2.6
-        version: 1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16)
+        version: 1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.34.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16)
       y-protocols:
         specifier: ^1.0.6
         version: 1.0.6(yjs@13.6.16)
@@ -1846,7 +1849,7 @@ importers:
         version: 9.0.1
       y-prosemirror:
         specifier: ~1.2.6
-        version: 1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.34.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16)
+        version: 1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16)
       y-protocols:
         specifier: ~1.0.6
         version: 1.0.6(yjs@13.6.16)
@@ -3700,7 +3703,6 @@ packages:
   '@lancedb/lancedb@0.19.1':
     resolution: {integrity: sha512-EsEP5eGpVzmpryNS/V9IPZvtBmImsE8rAWjhLQuhD9bbF3upcICTovQBK7A3lhy81D2g1RWaJaSSAmLtGPPOyA==}
     engines: {node: '>= 18'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
@@ -21120,16 +21122,16 @@ snapshots:
     dependencies:
       '@tiptap/core': 2.7.4(@tiptap/pm@2.7.4)
 
-  '@tiptap/extension-collaboration-cursor@2.7.4(@tiptap/core@2.7.4(@tiptap/pm@2.7.4))(y-prosemirror@1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16))':
+  '@tiptap/extension-collaboration-cursor@2.7.4(@tiptap/core@2.7.4(@tiptap/pm@2.7.4))(y-prosemirror@1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.34.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16))':
     dependencies:
       '@tiptap/core': 2.7.4(@tiptap/pm@2.7.4)
-      y-prosemirror: 1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16)
+      y-prosemirror: 1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.34.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16)
 
-  '@tiptap/extension-collaboration@2.7.4(@tiptap/core@2.7.4(@tiptap/pm@2.7.4))(@tiptap/pm@2.7.4)(y-prosemirror@1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16))':
+  '@tiptap/extension-collaboration@2.7.4(@tiptap/core@2.7.4(@tiptap/pm@2.7.4))(@tiptap/pm@2.7.4)(y-prosemirror@1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.34.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16))':
     dependencies:
       '@tiptap/core': 2.7.4(@tiptap/pm@2.7.4)
       '@tiptap/pm': 2.7.4
-      y-prosemirror: 1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16)
+      y-prosemirror: 1.2.12(prosemirror-model@1.22.3)(prosemirror-state@1.4.3)(prosemirror-view@1.34.3)(y-protocols@1.0.6(yjs@13.6.16))(yjs@13.6.16)
 
   '@tiptap/extension-color@2.7.4(@tiptap/core@2.7.4(@tiptap/pm@2.7.4))(@tiptap/extension-text-style@2.7.4(@tiptap/core@2.7.4(@tiptap/pm@2.7.4)))':
     dependencies:


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved canvas synchronization by supporting state syncing from legacy YDoc data for better backward compatibility.
  * Enhanced collaboration performance with Redis-based synchronization (when not in desktop environments).

* **Bug Fixes**
  * Ensured consistent canvas state updates by double-writing Yjs document state to new storage for canvases using the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->