### PR TITLE
fix: update changelog links to version 0.8.0

### DIFF
--- a/packages/ai-workspace-common/src/components/sider/layout.tsx
+++ b/packages/ai-workspace-common/src/components/sider/layout.tsx
@@ -576,9 +576,7 @@ const SiderLoggedIn = (props: { source: 'sider' | 'popover' }) => {
           )}
 
           <div
-            onClick={() =>
-              window.open('https://github.com/refly-ai/refly/releases/tag/v0.7.0', '_blank')
-            }
+            onClick={() => window.open('https://docs.refly.ai/changelog/v0.8.0', '_blank')}
             className="mb-2 flex items-start text-[#00968F] hover:bg-gray-50 rounded-md whitespace-normal h-auto cursor-pointer dark:text-gray-300"
           >
             <span className="flex items-start gap-2 leading-6 w-full ">

--- a/packages/web-core/src/components/landing-page-partials/HeroHome.tsx
+++ b/packages/web-core/src/components/landing-page-partials/HeroHome.tsx
@@ -70,10 +70,7 @@ function HeroHome() {
                 <div className="z-10 flex items-center justify-center">
                   <div
                     onClick={() => {
-                      window.open(
-                        'https://github.com/refly-ai/refly/releases/tag/v0.7.0',
-                        '_blank',
-                      );
+                      window.open('https://docs.refly.ai/changelog/v0.8.0', '_blank');
                     }}
                     className={cn(
                       'group inline-flex items-center justify-center rounded-lg border border-black/5 bg-white text-base hover:cursor-pointer hover:bg-neutral-50',


### PR DESCRIPTION
# Summary

- Changed the changelog link in SiderLoggedIn and HeroHome components to point to the new version 0.8.0 documentation.
- Ensured consistency in the link updates across components for better user navigation.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
