### PR TITLE
chore: use ts-node for api dev script

### DIFF
--- a/apps/api/nodemon.json
+++ b/apps/api/nodemon.json
@@ -7,8 +7,7 @@
     "../../packages/skill-template",
     "../../packages/utils"
   ],
-  "delay": "1000",
   "ext": "ts",
   "ignore": ["src/**/*.spec.ts"],
-  "exec": "pnpm build && node dist/main.js"
+  "exec": "ts-node -r tsconfig-paths/register src/main.ts"
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,8 @@
     "type": "git",
     "url": "git+https://github.com/refly-ai/refly.git"
   },
-  "main": "dist/index.js",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "scripts": {
     "copy-env": "ncp .env.example .env",
     "copy-env:develop": "ncp .env.development .env",
@@ -21,7 +22,7 @@
     "gen-sqlite-schema": "ts-node src/scripts/gen-sqlite-schema.ts",
     "format-schema": "prisma format && prisma format --schema=prisma/sqlite-schema.prisma",
     "sync-db-schema": "prisma format && prisma generate && node -r ts-node/register --env-file=.env src/scripts/sync-db-schema.ts && prisma format --schema=prisma/sqlite-schema.prisma",
-    "dev": "nodemon",
+    "dev": "prisma format && prisma generate && nodemon",
     "dev:debug": "nodemon --inspect",
     "start": "node --env-file=.env dist/scripts/sync-db-schema.js && node --env-file=.env dist/main.js",
     "test": "jest",

--- a/packages/canvas-common/package.json
+++ b/packages/canvas-common/package.json
@@ -2,17 +2,8 @@
   "name": "@refly/canvas-common",
   "version": "0.7.0",
   "description": "Common canvas utilitized shared by UI and server",
-  "main": "dist/index.js",
-  "module": "src/index.ts",
+  "main": "src/index.ts",
   "types": "src/index.ts",
-  "exports": {
-    ".": {
-      "development": "./src/index.ts",
-      "import": "./src/index.ts",
-      "require": "./dist/index.js",
-      "default": "./src/index.ts"
-    }
-  },
   "scripts": {
     "clean": "rimraf dist",
     "test": "vitest"

--- a/packages/common-types/package.json
+++ b/packages/common-types/package.json
@@ -2,17 +2,8 @@
   "name": "@refly/common-types",
   "version": "0.8.0",
   "description": "Refly Common Types",
-  "main": "dist/index.js",
-  "module": "src/index.ts",
+  "main": "src/index.ts",
   "types": "src/index.ts",
-  "exports": {
-    ".": {
-      "development": "./src/index.ts",
-      "import": "./src/index.ts",
-      "require": "./dist/index.js",
-      "default": "./src/index.ts"
-    }
-  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -2,17 +2,8 @@
   "name": "@refly/errors",
   "version": "0.8.0",
   "description": "Refly Predefined Errors",
-  "main": "dist/index.js",
-  "module": "src/index.ts",
+  "main": "src/index.ts",
   "types": "src/index.ts",
-  "exports": {
-    ".": {
-      "development": "./src/index.ts",
-      "import": "./src/index.ts",
-      "require": "./dist/index.js",
-      "default": "./src/index.ts"
-    }
-  },
   "scripts": {
     "clean": "rimraf dist",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -2,8 +2,8 @@
   "name": "@refly/observability",
   "version": "0.1.0",
   "description": "Observability package for Refly with Langfuse integration",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",

--- a/packages/openapi-schema/package.json
+++ b/packages/openapi-schema/package.json
@@ -2,12 +2,8 @@
   "name": "@refly/openapi-schema",
   "version": "0.8.0",
   "description": "Refly OpenAPI Schema",
-  "main": "dist/index.js",
-  "exports": {
-    ".": "./src/index.ts",
-    "./queries": "./src/queries/index.ts",
-    "./requests": "./src/requests/index.ts"
-  },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "scripts": {
     "dev": "nodemon",
     "codegen": "openapi-ts && tsc --build --verbose",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -2,17 +2,8 @@
   "name": "@refly/providers",
   "version": "0.8.0",
   "description": "Implementation of Refly providers",
-  "main": "dist/index.js",
-  "module": "src/index.ts",
+  "main": "src/index.ts",
   "types": "src/index.ts",
-  "exports": {
-    ".": {
-      "development": "./src/index.ts",
-      "import": "./src/index.ts",
-      "require": "./dist/index.js",
-      "default": "./src/index.ts"
-    }
-  },
   "scripts": {
     "clean": "rimraf dist && rimraf tsconfig.tsbuildinfo",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/skill-template/package.json
+++ b/packages/skill-template/package.json
@@ -2,7 +2,8 @@
   "name": "@refly/skill-template",
   "version": "0.8.0",
   "description": "Refly Skill Template",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "scripts": {
     "clean": "rimraf dist && rimraf tsconfig.tsbuildinfo",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,20 +2,8 @@
   "name": "@refly/utils",
   "version": "0.8.0",
   "description": "Refly Code Utils",
-  "main": "dist/index.js",
-  "module": "src/index.ts",
+  "main": "src/index.ts",
   "types": "src/index.ts",
-  "exports": {
-    ".": {
-      "development": "./src/index.ts",
-      "import": "./src/index.ts",
-      "require": "./dist/index.js",
-      "default": "./src/index.ts"
-    },
-    "./env": {
-      "default": "./src/env.ts"
-    }
-  },
   "scripts": {
     "clean": "rimraf dist && rimraf tsconfig.tsbuildinfo",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/utils/src/brand.ts
+++ b/packages/utils/src/brand.ts
@@ -1,1 +1,1 @@
-export const BRANDING_NAME = 'Refly2';
+export const BRANDING_NAME = 'Refly';


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configurations across multiple packages to reference TypeScript source files directly instead of compiled JavaScript files.
  * Simplified and removed certain module export fields in package configurations.
  * Adjusted development scripts to streamline the development workflow.

* **Style**
  * Updated branding name from "Refly2" to "Refly".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->