### PR TITLE
refactor: enhance sider menu settings with improved theme management …

### DIFF
--- a/packages/ai-workspace-common/src/components/sider-menu-setting-list/index.scss
+++ b/packages/ai-workspace-common/src/components/sider-menu-setting-list/index.scss
@@ -1,41 +1,83 @@
-.sider-menu-setting-list-drop-list {
-  min-width: 248px;
-  max-width: 440px;
-  padding: 8px 20px;
-  box-sizing: border-box;
-  .sider-menu-setting-list-menu {
-    .arco-menu-item {
-      border: 1px solid transparent;
-      line-height: 2;
-      font-size: 15px;
+.sider-menu-setting-list-dropdown {
+  .ant-dropdown-menu {
+    width: 232px;
+    padding: 8px;
+    background-color: var(--refly-bg-content-z2);
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    border: 1px solid var(--refly-Card-Border);
+  }
+
+  
+
+  .ant-dropdown-menu-item {
+    padding: 8px 6px !important;
+    height: 36px;
+    line-height: 20px;
+    border-radius: 8px;
+    color: var(--refly-text-0);
+
+    &:hover {
+      background-color: var(--refly-tertiary-hover)!important;
+    }
+
+    &.ant-dropdown-menu-item-disabled {
+      color: var(--refly-text-0);
+      background-color: transparent;
+      cursor: default;
     }
   }
 
-  .sider-menu-setting-list-drop-list-content {
-    box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
-    background-color: #fff;
+  .ant-dropdown-menu-item-group {
+    .user-header{
+      height: auto!important;
+      padding: 0!important;
+    }
+    .ant-dropdown-menu-item-group-title {
+      display: none;
+    }
+    .ant-dropdown-menu-item-disabled {
+      background-color: transparent!important;
+      cursor: default!important;
+    }
+  }
+
+
+  .ant-dropdown-menu-submenu-open {
+    background-color: var(--refly-tertiary-hover);
+  }
+
+  .ant-dropdown-menu-submenu {
     border-radius: 8px;
-    padding: 0 8px;
-    .profile {
-      padding: 13px 16px;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-      .avatar {
-        flex-shrink: 0;
-      }
-      .username {
-        .nickname {
-          font-size: 16px;
-          font-weight: 600;
-          color: #000;
-        }
-        .email {
-          font-size: 12px;
-          color: #999;
-        }
+    &:hover {
+      background-color: var(--refly-tertiary-hover);
+    }
+
+    .ant-dropdown-menu-submenu-title {
+      padding: 8px 6px;
+      height: 36px;
+      line-height: 20px;
+      color: var(--refly-text-0);
+
+      &:hover {
+        background-color: var(--refly-bg-content-z1);
       }
     }
   }
+
+  .ant-dropdown-menu-sub {
+    width: 160px;
+    padding: 8px;
+    background-color: var(--refly-bg-content-z2);
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    border: 1px solid var(--refly-Card-Border);
+  }
+
+  .ant-dropdown-menu-divider {
+    margin: 4px 0;
+    background-color: var(--refly-Card-Border);
+  }
+
+
 }

--- a/packages/ai-workspace-common/src/components/sider-menu-setting-list/index.tsx
+++ b/packages/ai-workspace-common/src/components/sider-menu-setting-list/index.tsx
@@ -1,86 +1,249 @@
 import { useTranslation } from 'react-i18next';
-import { MenuProps, Dropdown } from 'antd';
-import { LuSettings, LuLogOut } from 'react-icons/lu';
+import { Dropdown } from 'antd';
+import { LuLogOut, LuMonitor } from 'react-icons/lu';
 import { useUserStore } from '@refly/stores';
 import { useSiderStoreShallow } from '@refly/stores';
 import { useLogout } from '@refly-packages/ai-workspace-common/hooks/use-logout';
 import { GrGroup } from 'react-icons/gr';
-import { MemoizedIcon } from '@refly-packages/ai-workspace-common/components/common/icon';
-import { IconChrome } from '@refly-packages/ai-workspace-common/components/common/icon';
 import { EXTENSION_DOWNLOAD_LINK } from '@refly/utils/url';
+import { useThemeStoreShallow } from '@refly/stores';
+import { useCallback, useMemo } from 'react';
+import { SettingsModalActiveTab } from '@refly/stores';
+import {
+  Setting,
+  Subscription,
+  InterfaceDark,
+  InterfaceLight,
+  ArrowRight,
+  Cuttools,
+} from 'refly-icons';
+import './index.scss';
+import React from 'react';
+
+// Reusable dropdown item component
+const DropdownItem = React.memo(
+  ({
+    icon,
+    children,
+  }: {
+    icon: React.ReactNode;
+    children: React.ReactNode;
+  }) => (
+    <div className="flex items-center gap-2">
+      {icon}
+      <span>{children}</span>
+    </div>
+  ),
+);
+
+// User info component
+const UserInfo = React.memo(({ nickname, email }: { nickname?: string; email?: string }) => (
+  <div className="px-1.5 py-2">
+    <div className="text-sm font-semibold text-refly-text-0 leading-5 truncate">{nickname}</div>
+    <div className="text-xs text-refly-text-2 leading-4 truncate">
+      {email ?? 'No email provided'}
+    </div>
+  </div>
+));
+
+// Theme appearance item component
+const ThemeAppearanceItem = React.memo(({ themeMode, t }: { themeMode: string; t: any }) => (
+  <div className="flex items-center gap-2">
+    {themeMode === 'dark' ? <InterfaceDark size={18} /> : <InterfaceLight size={18} />}
+    <div className="flex flex-1 items-center justify-between gap-1">
+      <span>{t('loggedHomePage.siderMenu.systemTheme')}</span>
+      <ArrowRight size={16} />
+    </div>
+  </div>
+));
+
 export const SiderMenuSettingList = (props: { children: React.ReactNode }) => {
   const { t } = useTranslation();
   const userStore = useUserStore();
-  const { setShowSettingModal } = useSiderStoreShallow((state) => ({
+  const { setShowSettingModal, setSettingsModalActiveTab } = useSiderStoreShallow((state) => ({
     setShowSettingModal: state.setShowSettingModal,
+    setSettingsModalActiveTab: state.setSettingsModalActiveTab,
   }));
   const { handleLogout, contextHolder } = useLogout();
+  const { themeMode, setThemeMode } = useThemeStoreShallow((state) => ({
+    themeMode: state.themeMode,
+    setThemeMode: state.setThemeMode,
+  }));
 
-  const items: MenuProps['items'] = [
-    {
-      key: 'profile',
-      label: (
-        <div className="px-4 py-1 cursor-text">
-          <div className="text-sm font-semibold text-black dark:text-gray-100">
-            {userStore?.userProfile?.nickname}
-          </div>
-          <div className="text-xs text-gray-500 dark:text-gray-400 max-w-36 truncate">
-            {userStore?.userProfile?.email ?? 'No email provided'}
-          </div>
-        </div>
-      ),
-      disabled: true,
-    },
-    {
-      type: 'divider',
-    },
-    {
-      key: 'settings',
-      icon: <LuSettings size={14} />,
-      label: t('loggedHomePage.siderMenu.settings'),
-    },
-    {
-      key: 'contactUs',
-      icon: <GrGroup size={14} />,
-      label: t('loggedHomePage.siderMenu.contactUs'),
-    },
-    {
-      key: 'addToChrome',
-      icon: <MemoizedIcon icon={IconChrome} className="w-[14px] h-[14px]" />,
-      label: t('loggedHomePage.siderMenu.addToChrome'),
-    },
-    {
-      type: 'divider',
-    },
-    {
-      key: 'logout',
-      icon: <LuLogOut size={14} />,
-      label: t('loggedHomePage.siderMenu.logout'),
-    },
-  ];
+  // Handle menu item clicks
+  const handleSettingsClick = useCallback(() => {
+    setShowSettingModal(true);
+  }, [setShowSettingModal]);
 
-  const handleMenuClick = (key: string) => {
-    if (key === 'contactUs') {
-      window.open('https://docs.refly.ai/community/contact-us', '_blank');
-    } else if (key === 'settings') {
-      setShowSettingModal(true);
-    } else if (key === 'logout') {
-      handleLogout();
-    } else if (key === 'addToChrome') {
-      window.open(EXTENSION_DOWNLOAD_LINK, '_blank');
-    }
-  };
+  const handleSubscriptionClick = useCallback(() => {
+    setSettingsModalActiveTab(SettingsModalActiveTab.Subscription);
+    setShowSettingModal(true);
+  }, [setSettingsModalActiveTab, setShowSettingModal]);
+
+  const handleContactUsClick = useCallback(() => {
+    window.open('https://docs.refly.ai/community/contact-us', '_blank');
+  }, []);
+
+  const handleChromeExtensionClick = useCallback(() => {
+    window.open(EXTENSION_DOWNLOAD_LINK, '_blank');
+  }, []);
+
+  const handleLogoutClick = useCallback(() => {
+    handleLogout();
+  }, [handleLogout]);
+
+  // Theme mode options
+  const themeOptions = useMemo(
+    () => [
+      {
+        key: 'light',
+        label: t('settings.appearance.lightMode'),
+        icon: <InterfaceLight size={18} />,
+        active: themeMode === 'light',
+      },
+      {
+        key: 'dark',
+        label: t('settings.appearance.darkMode'),
+        icon: <InterfaceDark size={18} />,
+        active: themeMode === 'dark',
+      },
+      {
+        key: 'system',
+        label: t('settings.appearance.systemMode'),
+        icon: <LuMonitor size={14} />,
+        active: themeMode === 'system',
+      },
+    ],
+    [themeMode, t],
+  );
+
+  const handleThemeModeChange = useCallback(
+    (mode: 'light' | 'dark' | 'system') => {
+      setThemeMode(mode);
+    },
+    [setThemeMode],
+  );
+
+  // Theme dropdown items
+  const themeDropdownItems = useMemo(
+    () => [
+      {
+        key: 'theme-submenu',
+        type: 'group' as const,
+        className: 'theme-dropdown-submenu',
+        children: themeOptions.map((option) => ({
+          key: option.key,
+          label: <DropdownItem icon={option.icon}>{option.label}</DropdownItem>,
+          onClick: () => handleThemeModeChange(option.key as 'light' | 'dark' | 'system'),
+          className: option.active ? 'bg-refly-bg-content-z1' : '',
+        })),
+      },
+    ],
+    [themeOptions, handleThemeModeChange],
+  );
+
+  // Main dropdown items
+  const dropdownItems = useMemo(
+    () => [
+      {
+        key: 'user-info',
+        type: 'group' as const,
+        children: [
+          {
+            key: 'user-header',
+            className: 'user-header',
+            label: (
+              <UserInfo
+                nickname={userStore?.userProfile?.nickname}
+                email={userStore?.userProfile?.email}
+              />
+            ),
+            disabled: true,
+          },
+        ],
+      },
+      {
+        type: 'divider' as const,
+      },
+      {
+        key: 'settings',
+        label: (
+          <DropdownItem icon={<Setting size={18} />}>
+            {t('loggedHomePage.siderMenu.settings')}
+          </DropdownItem>
+        ),
+        onClick: handleSettingsClick,
+      },
+      {
+        key: 'subscription',
+        label: (
+          <DropdownItem icon={<Subscription size={18} />}>
+            {t('loggedHomePage.siderMenu.subscription')}
+          </DropdownItem>
+        ),
+        onClick: handleSubscriptionClick,
+      },
+      {
+        key: 'appearance',
+        type: 'submenu' as const,
+        label: <ThemeAppearanceItem themeMode={themeMode} t={t} />,
+        children: themeDropdownItems,
+      },
+      {
+        type: 'divider' as const,
+      },
+      {
+        key: 'contact-us',
+        label: (
+          <DropdownItem icon={<GrGroup size={18} />}>
+            {t('loggedHomePage.siderMenu.contactUs')}
+          </DropdownItem>
+        ),
+        onClick: handleContactUsClick,
+      },
+      {
+        key: 'chrome-extension',
+        label: (
+          <DropdownItem icon={<Cuttools size={18} />}>
+            {t('loggedHomePage.siderMenu.addToChrome')}
+          </DropdownItem>
+        ),
+        onClick: handleChromeExtensionClick,
+      },
+      {
+        key: 'logout',
+        label: (
+          <DropdownItem icon={<LuLogOut size={18} />}>
+            {t('loggedHomePage.siderMenu.logout')}
+          </DropdownItem>
+        ),
+        onClick: handleLogoutClick,
+      },
+    ],
+    [
+      userStore?.userProfile?.nickname,
+      userStore?.userProfile?.email,
+      t,
+      handleSettingsClick,
+      handleSubscriptionClick,
+      themeMode,
+      themeDropdownItems,
+      handleContactUsClick,
+      handleChromeExtensionClick,
+      handleLogoutClick,
+    ],
+  );
 
   return (
     <div>
       <Dropdown
+        menu={{ items: dropdownItems }}
         trigger={['click']}
-        arrow={false}
         placement="bottom"
-        menu={{
-          items,
-          onClick: ({ key }) => handleMenuClick(key),
-          className: '[&_.ant-dropdown-menu-item-disabled]:!p-0',
+        overlayClassName="sider-menu-setting-list-dropdown"
+        arrow={false}
+        align={{
+          offset: [0, 10],
         }}
       >
         {props.children}

--- a/packages/ai-workspace-common/src/components/sider/layout.tsx
+++ b/packages/ai-workspace-common/src/components/sider/layout.tsx
@@ -8,13 +8,7 @@ import {
 } from '@refly-packages/ai-workspace-common/utils/router';
 
 import { IconCanvas } from '@refly-packages/ai-workspace-common/components/common/icon';
-import {
-  Project as IconProject,
-  KnowledgeBase as IconKnowledgeBase,
-  InterfaceDark,
-  InterfaceLight,
-  Setting,
-} from 'refly-icons';
+import { Project as IconProject, KnowledgeBase as IconKnowledgeBase, Setting } from 'refly-icons';
 import cn from 'classnames';
 import { Logo } from '@refly-packages/ai-workspace-common/components/common/logo';
 
@@ -47,7 +41,6 @@ import { LuList } from 'react-icons/lu';
 import './layout.scss';
 import { ProjectDirectory } from '../project/project-directory';
 import { GithubStar } from '@refly-packages/ai-workspace-common/components/common/github-star';
-import { useThemeStoreShallow } from '@refly/stores';
 
 const Sider = Layout.Sider;
 
@@ -120,10 +113,7 @@ const SettingItem = () => {
   const { userProfile } = useUserStoreShallow((state) => ({
     userProfile: state.userProfile,
   }));
-  const { isDarkMode, setThemeMode } = useThemeStoreShallow((state) => ({
-    isDarkMode: state.isDarkMode,
-    setThemeMode: state.setThemeMode,
-  }));
+
   const { setShowSettingModal } = useSiderStoreShallow((state) => ({
     setShowSettingModal: state.setShowSettingModal,
   }));
@@ -143,14 +133,6 @@ const SettingItem = () => {
             </span>
           </div>
           <div className="flex items-center">
-            <Button
-              type="text"
-              icon={isDarkMode ? <InterfaceDark size={20} /> : <InterfaceLight size={20} />}
-              onClick={(e) => {
-                e.stopPropagation();
-                setThemeMode(isDarkMode ? 'light' : 'dark');
-              }}
-            />
             <Button
               type="text"
               icon={<Setting size={20} />}

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -1785,6 +1785,7 @@ const translations = {
       tour: 'View Tutorial',
       template: 'Template',
       home: 'Home',
+      systemTheme: 'System Theme',
     },
   },
   knowledgeLibrary: {

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -1568,7 +1568,7 @@ const translations = {
       libraryTitle: '知识库',
       libraryDescription:
         '创建、编辑和查看知识库，包含所有导入的资源以及创建的文档，支持 AI 语义搜索和回答。',
-      subscription: '订阅',
+      subscription: '订阅管理',
       canvas: '画布',
       newCanvas: '新建画布',
       news: '新特性',
@@ -1592,6 +1592,7 @@ const translations = {
       tour: '查看教程',
       template: '模板',
       home: '首页',
+      systemTheme: '系统主题',
     },
   },
   knowledgeLibrary: {


### PR DESCRIPTION
…and styling

- Simplified the imports in the layout component by removing unused icons.
- Refactored the SettingItem component to remove direct theme mode handling and utilize a more modular approach.
- Introduced reusable dropdown item components for better code maintainability.
- Updated the theme mode options and dropdown items to improve user experience.
- Enhanced styling in the sider menu setting list using Tailwind CSS for consistency.
- Added translations for the system theme in both English and Chinese.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
