### PR TITLE
fix: incorrect artifact status change

### DIFF
--- a/apps/api/src/modules/skill/skill-invoker.service.ts
+++ b/apps/api/src/modules/skill/skill-invoker.service.ts
@@ -841,7 +841,6 @@ ${event.data?.input ? JSON.stringify(event.data?.input?.input) : ''}
                         entityId: artifact.entityId,
                         type: artifact.type,
                         title: artifact.title,
-                        status: 'generating',
                       },
                     });
                   }

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/code-artifact.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/code-artifact.tsx
@@ -54,7 +54,7 @@ const CodeArtifactNodePreviewComponent = ({ nodeId }: CodeArtifactNodePreviewPro
       },
     },
     null,
-    { enabled: Boolean(isLogin && !shareId && artifactId && status?.startsWith('finish')) },
+    { enabled: Boolean(isLogin && !shareId && artifactId) },
   );
   const { data: shareData, loading: isShareLoading } = useFetchShareData<CodeArtifact>(shareId);
 
@@ -95,19 +95,6 @@ const CodeArtifactNodePreviewComponent = ({ nodeId }: CodeArtifactNodePreviewPro
 
         if (data?.type !== currentType) {
           setCurrentType(detectActualTypeFromType(data?.type));
-        }
-
-        // Save to node metadata when status updates
-        if (artifactId) {
-          setNodeDataByEntity(
-            { type: 'codeArtifact', entityId: artifactId },
-            {
-              metadata: {
-                activeTab: data?.status === 'finish' ? 'preview' : 'code',
-                type: detectActualTypeFromType(data?.type),
-              },
-            },
-          );
         }
       }
     };

--- a/packages/ai-workspace-common/src/modules/artifacts/code-runner/monaco-editor/SimpleTextEditor.tsx
+++ b/packages/ai-workspace-common/src/modules/artifacts/code-runner/monaco-editor/SimpleTextEditor.tsx
@@ -54,7 +54,7 @@ const SimpleTextEditor = React.memo(
 
         <textarea
           ref={textareaRef}
-          className="w-full flex-1 p-4 font-mono text-sm resize-none focus:outline-none focus:ring-1 focus:ring-blue-500 bg-gray-50 dark:bg-gray-900 dark:focus:ring-blue-400 dark:text-gray-300"
+          className="w-full flex-1 p-4 font-mono text-sm resize-none border-none focus:outline-none focus:ring-1 focus:ring-blue-500 bg-gray-50 dark:bg-gray-900 dark:focus:ring-blue-400 dark:text-gray-300"
           value={displayContent}
           onChange={handleChange}
           readOnly={readOnly || isGenerating || canvasReadOnly}

--- a/packages/skill-template/src/skills/code-artifacts.ts
+++ b/packages/skill-template/src/skills/code-artifacts.ts
@@ -319,7 +319,7 @@ export class CodeArtifacts extends BaseSkill {
     this.emitEvent(
       {
         event: 'artifact',
-        artifact: { ...artifact, status: 'generating' },
+        artifact,
       },
       config,
     );

--- a/packages/skill-template/src/skills/generate-doc.ts
+++ b/packages/skill-template/src/skills/generate-doc.ts
@@ -324,7 +324,7 @@ ${recentHistory.map((msg) => `${(msg as HumanMessage)?.getType?.()}: ${msg.conte
     this.emitEvent(
       {
         event: 'artifact',
-        artifact: { ...artifact, status: 'generating' },
+        artifact,
       },
       config,
     );

--- a/packages/skill-template/src/skills/generate-media.ts
+++ b/packages/skill-template/src/skills/generate-media.ts
@@ -211,7 +211,6 @@ export class GenerateMedia extends BaseSkill {
         type: mediaType,
         entityId: resultId,
         title: cleanedQuery || `Generated ${this.getMediaTypeDisplayName(mediaType)}`,
-        status: 'generating',
       };
 
       this.emitEvent(


### PR DESCRIPTION
# Summary

- Removed the hardcoded 'generating' status from artifact emissions in multiple skill files.
- Updated the CodeArtifactNodePreviewComponent to simplify the enabled condition for fetching share data.
- Cleaned up unnecessary status checks and metadata updates in the CodeArtifactNodePreviewComponent.
- Adjusted the SimpleTextEditor component's textarea class for improved styling.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Artifact status is no longer forcibly set to "generating" in emitted events and stream responses, resulting in more accurate status reporting for code, document, and media artifacts.
* **Style**
  * Removed border styling from the text editor's textarea for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->