### PR TITLE
fix: initialize avatar properly in AccountSetting component

### DIFF
--- a/packages/ai-workspace-common/src/components/settings/account-setting/index.tsx
+++ b/packages/ai-workspace-common/src/components/settings/account-setting/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import getClient from '@refly-packages/ai-workspace-common/requests/proxiedRequest';
 import { AiOutlineUser } from 'react-icons/ai';
 
-import { useUserStore } from '@refly/stores';
+import { useUserStore, useUserStoreShallow } from '@refly/stores';
 // components
 import { useTranslation } from 'react-i18next';
 import { useDebouncedCallback } from 'use-debounce';
@@ -13,6 +13,7 @@ import { AiOutlineLoading3Quarters } from 'react-icons/ai';
 import { BiSolidEdit } from 'react-icons/bi';
 
 const { Title } = Typography;
+
 export const AccountSetting = () => {
   const [form] = Form.useForm();
   const userStore = useUserStore();
@@ -24,6 +25,14 @@ export const AccountSetting = () => {
   }));
   const [avatarKey, setAvatarKey] = useState('');
   const [avatarUrl, setAvatarUrl] = useState('');
+  const userProfile = useUserStoreShallow((state) => state.userProfile);
+
+  useEffect(() => {
+    if (userProfile?.avatar) {
+      setAvatarUrl(userProfile.avatar);
+    }
+  }, [userProfile?.avatar]);
+
   const [avatarError, setAvatarError] = useState(false);
 
   const [nameStatus, setNameStatus] = useState<'error' | 'success' | 'warning' | 'validating'>(


### PR DESCRIPTION
# Summary

- Added useUserStoreShallow to optimize user profile access.
- Implemented useEffect to set avatar URL based on user profile changes.
- Ensured optional chaining is used when accessing user profile properties.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
