### PR TITLE
feat: enhance theme management and user login status handling

### DIFF
--- a/packages/ai-workspace-common/src/components/settings/appearance-setting/index.tsx
+++ b/packages/ai-workspace-common/src/components/settings/appearance-setting/index.tsx
@@ -6,6 +6,7 @@ import { ContentHeader } from '@refly-packages/ai-workspace-common/components/se
 import FlowDark from '@refly-packages/ai-workspace-common/assets/flow-dark.png';
 import FlowLight from '@refly-packages/ai-workspace-common/assets/flow-light.png';
 import Logo from '@refly-packages/ai-workspace-common/assets/logo.svg';
+import { useUserStore } from '@refly/stores';
 
 type ThemeMode = 'light' | 'dark' | 'system';
 
@@ -92,15 +93,22 @@ const SystemThemeCard = React.memo(
 
 export const AppearanceSetting = () => {
   const { t } = useTranslation();
-  const { themeMode, setThemeMode, initTheme } = useThemeStoreShallow((state) => ({
+  const userStore = useUserStore();
+  const isLoggedIn = !!userStore?.userProfile?.uid;
+
+  const { themeMode, setThemeMode, initTheme, setLoggedIn } = useThemeStoreShallow((state) => ({
     themeMode: state.themeMode,
     setThemeMode: state.setThemeMode,
     initTheme: state.initTheme,
+    setLoggedIn: state.setLoggedIn,
   }));
 
   useEffect(() => {
+    // Update login status in theme store
+    setLoggedIn(isLoggedIn);
+    // Initialize theme based on current login status
     initTheme();
-  }, [initTheme]);
+  }, [initTheme, isLoggedIn, setLoggedIn]);
 
   const handleThemeModeChange = useCallback(
     (theme: ThemeMode) => {

--- a/packages/ai-workspace-common/src/components/sider-menu-setting-list/index.tsx
+++ b/packages/ai-workspace-common/src/components/sider-menu-setting-list/index.tsx
@@ -6,7 +6,7 @@ import { useSiderStoreShallow } from '@refly/stores';
 import { useLogout } from '@refly-packages/ai-workspace-common/hooks/use-logout';
 import { EXTENSION_DOWNLOAD_LINK } from '@refly/utils/url';
 import { useThemeStoreShallow } from '@refly/stores';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { SettingsModalActiveTab } from '@refly/stores';
 import {
   Settings,
@@ -62,15 +62,26 @@ const ThemeAppearanceItem = React.memo(({ themeMode, t }: { themeMode: string; t
 export const SiderMenuSettingList = (props: { children: React.ReactNode }) => {
   const { t } = useTranslation();
   const userStore = useUserStore();
+  // Check if user is logged in by checking if userProfile exists and has email
+  const isLoggedIn = !!userStore?.userProfile?.email;
+
   const { setShowSettingModal, setSettingsModalActiveTab } = useSiderStoreShallow((state) => ({
     setShowSettingModal: state.setShowSettingModal,
     setSettingsModalActiveTab: state.setSettingsModalActiveTab,
   }));
   const { handleLogout, contextHolder } = useLogout();
-  const { themeMode, setThemeMode } = useThemeStoreShallow((state) => ({
+  const { themeMode, setThemeMode, setLoggedIn, initTheme } = useThemeStoreShallow((state) => ({
     themeMode: state.themeMode,
     setThemeMode: state.setThemeMode,
+    setLoggedIn: state.setLoggedIn,
+    initTheme: state.initTheme,
   }));
+
+  // Initialize theme based on login status
+  useEffect(() => {
+    setLoggedIn(isLoggedIn);
+    initTheme();
+  }, [isLoggedIn, setLoggedIn, initTheme]);
 
   // Handle menu item clicks
   const handleSettingsClick = useCallback(() => {

--- a/packages/web-core/src/components/landing-page-partials/Header.tsx
+++ b/packages/web-core/src/components/landing-page-partials/Header.tsx
@@ -133,7 +133,7 @@ function Header() {
         <GithubStar />
         <div className="flex shrink-0 mr-4 ml-5 self-stretch my-auto w-[1px] h-6 bg-refly-Card-Border" />
 
-        <div className="flex flex-row items-center">
+        <div className="flex flex-row items-center gap-3">
           {tabOptions.map((item) => (
             <Button
               type="text"

--- a/packages/web-core/src/pages/home-new/index.tsx
+++ b/packages/web-core/src/pages/home-new/index.tsx
@@ -87,7 +87,7 @@ const UnsignedFrontPage = memo(() => {
           >
             <Title />
 
-            <div className="w-full backdrop-blur-sm rounded-lg shadow-sm ring-1 ring-gray-200 mx-2 dark:ring-gray-600">
+            <div className="w-full rounded-[12px] shadow-md overflow-hidden border-[1px] border border-solid border-refly-primary-default bg-refly-bg-content-z2">
               <div className="p-4">
                 {selectedSkill && (
                   <div className="flex w-full justify-between">
@@ -168,7 +168,7 @@ const UnsignedFrontPage = memo(() => {
 
             {canvasTemplateEnabled && (
               <div className="h-full flex flex-col mt-10">
-                <div className="flex justify-between items-center pt-6 mx-2">
+                <div className="flex justify-between items-center mx-2">
                   <div>
                     <h3 className="text-base font-medium dark:text-gray-100">
                       {t('frontPage.fromCommunity')}


### PR DESCRIPTION
- Integrated user login status into theme management by adding isLoggedIn state in the theme store.
- Updated AppearanceSetting and SiderMenuSettingList components to reflect login status changes and initialize theme accordingly.
- Improved theme initialization logic to default to light mode when the user is not logged in.
- Enhanced code structure and performance by utilizing React hooks and memoization techniques.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
