### PR TITLE
fix: enhance Markdown component with remarkGfm support and URL extrac…

### DIFF
--- a/packages/ai-workspace-common/src/components/markdown/index.tsx
+++ b/packages/ai-workspace-common/src/components/markdown/index.tsx
@@ -9,7 +9,7 @@ import { cn, markdownCitationParse } from '@refly/utils';
 // plugins
 import LinkElement from './plugins/link';
 import rehypeHighlight from './custom-plugins/rehype-highlight';
-
+import remarkGfm from 'remark-gfm';
 // styles
 import './styles/markdown.scss';
 import './styles/highlight.scss';
@@ -139,11 +139,21 @@ export const Markdown = memo(
               plugins.RehypeKatex &&
               plugins.RehypeHighlight && (
                 <ReactMarkdown
-                  remarkPlugins={[RemarkBreaks, plugins.RemarkMath]}
+                  remarkPlugins={[
+                    RemarkBreaks,
+                    [
+                      remarkGfm,
+                      {
+                        singleTilde: false, // 禁用单波浪线删除线以减少冲突
+                        tablePipeAlign: true, // 保持表格对齐功能
+                        tableCellPadding: true, // 保持表格单元格填充
+                      },
+                    ],
+                    plugins.RemarkMath,
+                  ]}
                   rehypePlugins={[
+                    // Ensure MCPCallElement processes before other plugins that might affect URLs
                     ...rehypePlugins,
-                    rehypeHighlight,
-                    plugins.RehypeKatex,
                     [
                       plugins.RehypeHighlight,
                       {
@@ -151,6 +161,8 @@ export const Markdown = memo(
                         ignoreMissing: true,
                       },
                     ],
+                    rehypeHighlight,
+                    plugins.RehypeKatex,
                   ]}
                   components={{
                     ...artifactComponents,


### PR DESCRIPTION


# Summary
FIx Conflict of remarkPlugins between remarkGfm and MCPCallElement

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.
Fixes #1142
# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

Before 
<img width="950" height="1574" alt="image" src="https://github.com/user-attachments/assets/b4ccc117-4e74-473c-9a0d-935b1366a824" />

After 
<img width="554" height="559" alt="截屏2025-07-31 23 00 24" src="https://github.com/user-attachments/assets/a840d018-d390-4405-a362-6b7f029be93f" />

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
