### PR TITLE
style: adjust UI for subscription and credit points

### DIFF
--- a/packages/ai-workspace-common/src/components/settings/subscribe-modal/index.scss
+++ b/packages/ai-workspace-common/src/components/settings/subscribe-modal/index.scss
@@ -251,7 +251,7 @@
         }
 
         &:hover:not(:disabled) {
-          background-color: #e5e7eb;
+          background: var(--primary---refly-primary-hover, #1b9774);
           border-color: #9ca3af;
         }
       }

--- a/packages/ai-workspace-common/src/components/settings/subscribe-modal/index.tsx
+++ b/packages/ai-workspace-common/src/components/settings/subscribe-modal/index.tsx
@@ -3,16 +3,26 @@ import { useTranslation } from 'react-i18next';
 import { logEvent } from '@refly/telemetry-web';
 // styles
 import './index.scss';
-import { useSubscriptionStoreShallow } from '@refly/stores';
+import { useSiderStoreShallow, useSubscriptionStoreShallow } from '@refly/stores';
 import { PriceContent } from './priceContent';
 
 export const SubscribeModal = () => {
   const { t } = useTranslation('ui');
-  const { subscribeModalVisible: visible, setSubscribeModalVisible: setVisible } =
-    useSubscriptionStoreShallow((state) => ({
-      subscribeModalVisible: state.subscribeModalVisible,
-      setSubscribeModalVisible: state.setSubscribeModalVisible,
-    }));
+  const {
+    subscribeModalVisible: visible,
+    setSubscribeModalVisible: setVisible,
+    openedFromSettings,
+    setOpenedFromSettings,
+  } = useSubscriptionStoreShallow((state) => ({
+    subscribeModalVisible: state.subscribeModalVisible,
+    setSubscribeModalVisible: state.setSubscribeModalVisible,
+    openedFromSettings: state.openedFromSettings,
+    setOpenedFromSettings: state.setOpenedFromSettings,
+  }));
+
+  const { setShowSettingModal } = useSiderStoreShallow((state) => ({
+    setShowSettingModal: state.setShowSettingModal,
+  }));
 
   return (
     <Modal
@@ -28,6 +38,11 @@ export const SubscribeModal = () => {
       className="subscribe-modal !p-0"
       onCancel={() => {
         setVisible(false);
+        // Only reopen SettingModal if SubscribeModal was opened from it
+        if (openedFromSettings) {
+          setShowSettingModal(true);
+          setOpenedFromSettings(false); // Reset the flag
+        }
         logEvent('subscription::price_table_close', 'settings');
       }}
     >

--- a/packages/ai-workspace-common/src/components/settings/subscription/index.scss
+++ b/packages/ai-workspace-common/src/components/settings/subscription/index.scss
@@ -249,6 +249,11 @@
           border-radius: 16px;
         }
       }
+
+      // Ensure consistent border radius during transitions
+      .ant-segmented-thumb {
+        border-radius: 16px !important;
+      }
     }
 
     .history-table {
@@ -274,11 +279,14 @@
       .ant-table-thead > tr > th {
         background: #fff !important;
         border-bottom: none;
-        color: var(--text-icon-refly-text-0, #1c1f23);
-        font-weight: normal;
+        color: var(--text-icon-refly-text-1, rgba(28, 31, 35, 0.8));
+        font-family: "PingFang SC";
+        font-size: 14px;
+        font-style: normal;
+        font-weight: 600;
+        line-height: 20px;
         padding: 12px 16px;
         border-right: none !important;
-        font-size: 14px;
 
         // Remove the separator line (::before pseudo-element)
         &::before {
@@ -383,6 +391,11 @@
             border-radius: 16px;
           }
         }
+
+        // Ensure consistent border radius during transitions
+        .ant-segmented-thumb {
+          border-radius: 16px !important;
+        }
       }
 
       .history-table {
@@ -405,12 +418,15 @@
 
         .ant-table-thead > tr > th {
           background: #222222 !important;
-          color: rgba(255, 255, 255, 0.85);
+          color: rgba(255, 255, 255, 0.8);
           border-bottom: none;
           border-right: none !important;
-          font-weight: 500;
-          padding: 12px 16px;
+          font-family: "PingFang SC";
           font-size: 14px;
+          font-style: normal;
+          font-weight: 600;
+          line-height: 20px;
+          padding: 12px 16px;
 
           // Remove the separator line (::before pseudo-element)
           &::before {

--- a/packages/ai-workspace-common/src/components/settings/subscription/index.tsx
+++ b/packages/ai-workspace-common/src/components/settings/subscription/index.tsx
@@ -76,13 +76,13 @@ export const Subscription = () => {
 
   const { planType: subscriptionPlanType, cancelAt } = displaySubscription ?? {};
 
-  const { setSubscribeModalVisible, setPlanType, planType } = useSubscriptionStoreShallow(
-    (state) => ({
+  const { setSubscribeModalVisible, setPlanType, planType, setOpenedFromSettings } =
+    useSubscriptionStoreShallow((state) => ({
       setSubscribeModalVisible: state.setSubscribeModalVisible,
       setPlanType: state.setPlanType,
       planType: state.planType,
-    }),
-  );
+      setOpenedFromSettings: state.setOpenedFromSettings,
+    }));
 
   const { setShowSettingModal } = useSiderStoreShallow((state) => ({
     setShowSettingModal: state.setShowSettingModal,
@@ -299,8 +299,9 @@ export const Subscription = () => {
   const handleClickSubscription = useCallback(() => {
     logEvent('subscription::upgrade_click', 'settings');
     setShowSettingModal(false);
+    setOpenedFromSettings(true);
     setSubscribeModalVisible(true);
-  }, [setSubscribeModalVisible, setShowSettingModal]);
+  }, [setSubscribeModalVisible, setShowSettingModal, setOpenedFromSettings]);
 
   const PaidPlanCard = () => {
     return (
@@ -355,6 +356,7 @@ export const Subscription = () => {
             className="upgrade-button ant-btn-primary"
             onClick={() => {
               setShowSettingModal(false);
+              setOpenedFromSettings(true);
               setSubscribeModalVisible(true);
             }}
           >

--- a/packages/stores/src/stores/subscription.ts
+++ b/packages/stores/src/stores/subscription.ts
@@ -8,11 +8,13 @@ interface SubscriptionState {
   planType: SubscriptionPlanType;
   subscribeModalVisible: boolean;
   storageExceededModalVisible: boolean;
+  openedFromSettings: boolean; // Track if SubscribeModal was opened from SettingModal
 
   // method
   setPlanType: (val: SubscriptionPlanType) => void;
   setSubscribeModalVisible: (val: boolean) => void;
   setStorageExceededModalVisible: (val: boolean) => void;
+  setOpenedFromSettings: (val: boolean) => void; // Method to set the openedFromSettings state
 }
 
 export const useSubscriptionStore = create<SubscriptionState>()(
@@ -20,10 +22,12 @@ export const useSubscriptionStore = create<SubscriptionState>()(
     planType: 'free',
     subscribeModalVisible: false,
     storageExceededModalVisible: false,
+    openedFromSettings: false,
 
     setPlanType: (val: SubscriptionPlanType) => set({ planType: val }),
     setSubscribeModalVisible: (val: boolean) => set({ subscribeModalVisible: val }),
     setStorageExceededModalVisible: (val: boolean) => set({ storageExceededModalVisible: val }),
+    setOpenedFromSettings: (val: boolean) => set({ openedFromSettings: val }),
   })),
 );
 


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The subscription modal now automatically reopens the settings modal upon closing if it was originally opened from the settings page, improving navigation flow.

* **Style**
  * Updated the hover color for the subscription button to match the primary theme color.
  * Enhanced table header typography and border-radius styling for consistent appearance in both light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->