### PR TITLE
feat(errors): add handling for model usage quota exceeded errors

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
@@ -9,7 +9,7 @@ import { Subscription } from 'refly-icons';
 import { actionEmitter } from '@refly-packages/ai-workspace-common/events/action';
 import { ActionStepCard } from './action-step';
 import { convertResultContextToItems, purgeContextItems } from '@refly/canvas-common';
-
+import { logEvent } from '@refly/telemetry-web';
 import { PreviewChatInput } from './preview-chat-input';
 import { SourceListModal } from '@refly-packages/ai-workspace-common/components/source-list/source-list-modal';
 import { useKnowledgeBaseStoreShallow } from '@refly/stores';
@@ -194,6 +194,8 @@ const SkillResponseNodePreviewComponent = ({ node, resultId }: SkillResponseNode
     (e?: React.MouseEvent) => {
       e?.stopPropagation();
       setSubscribeModalVisible(true);
+
+      logEvent('subscription::upgrade_click', 'skill_invoke');
     },
     [setSubscribeModalVisible],
   );
@@ -262,12 +264,6 @@ const SkillResponseNodePreviewComponent = ({ node, resultId }: SkillResponseNode
   }, [node.id]);
 
   const error = guessModelProviderError(result?.errors?.[0]);
-
-  useEffect(() => {
-    if (error instanceof ModelUsageQuotaExceeded && creditBalance <= 0 && isBalanceSuccess) {
-      handleSubscriptionClick();
-    }
-  }, [error, creditBalance, handleSubscriptionClick]);
 
   const isPending = result?.status === 'executing' || result?.status === 'waiting' || loading;
   const errDescription = useMemo(() => {

--- a/packages/ai-workspace-common/src/components/sider/layout.tsx
+++ b/packages/ai-workspace-common/src/components/sider/layout.tsx
@@ -141,10 +141,24 @@ const SettingItem = () => {
     setSubscribeModalVisible: state.setSubscribeModalVisible,
   }));
 
+  const { setShowSettingModal, setSettingsModalActiveTab } = useSiderStoreShallow((state) => ({
+    setShowSettingModal: state.setShowSettingModal,
+    setSettingsModalActiveTab: state.setSettingsModalActiveTab,
+  }));
+
   const handleSubscriptionClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
       setSubscribeModalVisible(true);
+    },
+    [setSubscribeModalVisible],
+  );
+
+  const handleCreditClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setSettingsModalActiveTab(SettingsModalActiveTab.Subscription);
+      setShowSettingModal(true);
     },
     [setSubscribeModalVisible],
   );
@@ -170,7 +184,7 @@ const SettingItem = () => {
 
           {subscriptionEnabled && isBalanceSuccess && (
             <div
-              onClick={handleSubscriptionClick}
+              onClick={handleCreditClick}
               className="h-8 p-2 flex items-center gap-1.5 text-refly-text-0 text-xs cursor-pointer
             rounded-[80px] border-[1px] border-solid border-refly-Card-Border bg-refly-bg-content-z2 whitespace-nowrap flex-shrink-0
             "
@@ -185,7 +199,10 @@ const SettingItem = () => {
                 <>
                   <Divider type="vertical" className="m-0" />
 
-                  <div className="text-[color:var(--primary---refly-primary-default,#0E9F77)] text-xs font-semibold leading-4 whitespace-nowrap">
+                  <div
+                    onClick={handleSubscriptionClick}
+                    className="text-[color:var(--primary---refly-primary-default,#0E9F77)] text-xs font-semibold leading-4 whitespace-nowrap"
+                  >
                     {t('common.upgrade')}
                   </div>
                 </>

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -291,8 +291,8 @@ export class StorageQuotaExceeded extends BaseError {
 export class ModelUsageQuotaExceeded extends BaseError {
   code = 'E2002';
   messageDict = {
-    en: 'Model usage quota exceeded, please upgrade your subscription',
-    'zh-CN': '模型使用额度不足，请升级订阅套餐',
+    en: 'Execution failed, credit quota insufficient, please upgrade your subscription',
+    'zh-CN': '执行失败，积分额度不足，请升级订阅套餐',
   };
 }
 

--- a/packages/errors/src/guess.ts
+++ b/packages/errors/src/guess.ts
@@ -3,6 +3,7 @@ import {
   ModelProviderRateLimitExceeded,
   ModelProviderTimeout,
   ActionAborted,
+  ModelUsageQuotaExceeded,
 } from './errors';
 
 export const guessModelProviderError = (error: string | Error) => {
@@ -16,6 +17,18 @@ export const guessModelProviderError = (error: string | Error) => {
     e.includes('stopped')
   ) {
     return new ActionAborted();
+  }
+
+  // Check for credit/quota related errors
+  // These patterns match the error messages thrown by the backend when credits are insufficient
+  if (
+    e.includes('credit not available') ||
+    e.includes('insufficient credits') ||
+    e.includes('model usage quota exceeded') ||
+    // Match backend error message format: "Available: X, Required minimum: Y"
+    (e.includes('available:') && e.includes('required minimum:'))
+  ) {
+    return new ModelUsageQuotaExceeded();
   }
 
   if (e.includes('limit exceed')) {

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -1407,6 +1407,7 @@ const translations = {
       downloadFile: 'Download File',
       editGroupNamePlaceholder: 'Please enter the group name',
       addToSlideshow: 'Add to Slideshow',
+      upgrade: 'Upgrade Plan',
       more: 'More Options',
     },
     nodeStatus: {

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -1368,6 +1368,7 @@ const translations = {
       downloadFile: '下载文件',
       editGroupNamePlaceholder: '请输入分组名称',
       addToSlideshow: '插入幻灯片',
+      upgrade: '升级套餐',
       more: '更多选项',
     },
     nodeStatus: {


### PR DESCRIPTION
- Implemented additional error handling in guessModelProviderError to recognize and return ModelUsageQuotaExceeded for credit and quota-related error messages.
- Enhanced the function to match specific error patterns from the backend for improved error management.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for scenarios where credit or quota limits are exceeded, providing clearer feedback when such limits are reached.
* **New Features**
  * Clicking the credit balance now opens the settings modal directly on the subscription tab for easier access.
  * The "Upgrade" link continues to open the subscription modal as before.
  * Added an "Upgrade Plan" button in error states when usage quota is exceeded and credit balance is insufficient, guiding users to subscription options.
  * Added new translation strings for the "Upgrade Plan" label in English and Simplified Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->