### PR TITLE
Update link for self deploy guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ cd deploy/kubernetes
 kubectl apply -f refly-deployment.yaml
 ```
 
-For the following steps, you can visit [Self-deploy Guide](https://docs.refly.ai/guide/self-deploy) for more details.
+For the following steps, you can visit [Self-deploy Guide](https://docs.refly.ai/community-version/self-deploy/) for more details.
 
-For core deployment tutorials, environment variable configuration, and FAQs, please refer to 👉 [Deployment Guide](https://docs.refly.ai/guide/self-deploy).
+For core deployment tutorials, environment variable configuration, and FAQs, please refer to 👉 [Deployment Guide](https://docs.refly.ai/community-version/self-deploy/).
 
 ### Local Development
 


### PR DESCRIPTION
# Summary

Modified the link to the **self-deploy guide** to point to the updated or correct documentation URL.

This change ensures users can access the accurate and most recent deployment instructions without confusion or broken links.  
Fixes navigation issues previously reported by community users.

> [!Tip]  
> Close issue syntax: `Fixes #1234` or `Resolves #1234`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues  
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)  
- [ ] Context Memory & References  
- [ ] Knowledge Base Integration & RAG  
- [ ] Quotes & Citations  
- [ ] AI Document Editing & WYSIWYG  
- [ ] Free-form Canvas Interface  
- [x] Other: **Documentation Links**

# Screenshots/Videos

| Before                             | After                              |
|------------------------------------|-------------------------------------|
| `https://docs.refly.ai/guide/self-deploy` | `https://docs.refly.ai/community-version/self-deploy/` |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [x] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
