### PR TITLE
fix: canvas sync issues

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/canvas-title.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/canvas-title.tsx
@@ -12,10 +12,12 @@ export const CanvasTitle = memo(
     canvasLoading,
     canvasTitle,
     language,
+    syncFailureCount,
   }: {
     canvasLoading: boolean;
     canvasTitle: string;
     language: LOCALE;
+    syncFailureCount: number;
   }) => {
     const { t } = useTranslation();
 
@@ -40,7 +42,7 @@ export const CanvasTitle = memo(
               className={`
               relative w-2.5 h-2.5 rounded-full
               transition-colors duration-700 ease-in-out
-              ${isSyncing ? 'bg-yellow-500 animate-pulse' : 'bg-green-400'}
+              ${canvasLoading || syncFailureCount > 0 ? 'bg-yellow-500 animate-pulse' : 'bg-green-400'}
             `}
             />
           </Tooltip>

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/index.tsx
@@ -52,7 +52,7 @@ export const TopToolbar: FC<TopToolbarProps> = memo(({ canvasId, mode, changeMod
   const isShareCanvas = useMatch('/share/canvas/:canvasId');
   const isPreviewCanvas = useMatch('/preview/canvas/:shareId');
 
-  const { loading, readonly, shareData, undo, redo } = useCanvasContext();
+  const { loading, readonly, shareData, undo, redo, syncFailureCount } = useCanvasContext();
 
   const { canvasInitialized, canvasTitle: canvasTitleFromStore } = useCanvasStoreShallow(
     (state) => ({
@@ -69,7 +69,7 @@ export const TopToolbar: FC<TopToolbarProps> = memo(({ canvasId, mode, changeMod
       setLoginModalOpen(true);
       return;
     }
-    duplicateCanvas(canvasId, () => {});
+    duplicateCanvas(canvasId);
   };
 
   return (
@@ -99,6 +99,7 @@ export const TopToolbar: FC<TopToolbarProps> = memo(({ canvasId, mode, changeMod
                 canvasTitle={canvasTitle}
                 canvasLoading={loading || !canvasInitialized}
                 language={language}
+                syncFailureCount={syncFailureCount}
               />
             </CanvasActionDropdown>
           )}

--- a/packages/ai-workspace-common/src/context/canvas.tsx
+++ b/packages/ai-workspace-common/src/context/canvas.tsx
@@ -142,6 +142,7 @@ export const CanvasProvider = ({
   children: React.ReactNode;
 }) => {
   const { t } = useTranslation();
+  const [modal, contextHolder] = Modal.useModal();
   const [lastUpdated, setLastUpdated] = useState<number>();
   const [loading, setLoading] = useState(false);
 
@@ -386,7 +387,7 @@ export const CanvasProvider = ({
 
       return new Promise((resolve) => {
         let selected: 'local' | 'remote' = 'local';
-        Modal.confirm({
+        modal.confirm({
           title: t('canvas.conflict.title'),
           centered: true,
           content: (
@@ -614,6 +615,7 @@ export const CanvasProvider = ({
         redo,
       }}
     >
+      {contextHolder}
       {children}
     </CanvasContext.Provider>
   );

--- a/packages/ai-workspace-common/src/context/canvas.tsx
+++ b/packages/ai-workspace-common/src/context/canvas.tsx
@@ -36,6 +36,9 @@ import { useGetCanvasDetail } from '@refly-packages/ai-workspace-common/queries'
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
 
+// Wait time for syncCanvasData to be called
+const SYNC_CANVAS_LOCAL_WAIT_TIME = 200;
+
 // Remote sync interval
 const SYNC_REMOTE_INTERVAL = 2000;
 
@@ -345,7 +348,7 @@ export const CanvasProvider = ({
     } finally {
       isSyncingLocalRef.current = false;
     }
-  }, 500);
+  }, SYNC_CANVAS_LOCAL_WAIT_TIME);
 
   // Function to update canvas data from state
   const updateCanvasDataFromState = useCallback(
@@ -494,8 +497,9 @@ export const CanvasProvider = ({
   useEffect(() => {
     if (readonly) return;
 
+    syncCanvasData.flush();
     initialFetchCanvasState(canvasId);
-  }, [canvasId, readonly, initialFetchCanvasState]);
+  }, [canvasId, readonly, initialFetchCanvasState, syncCanvasData]);
 
   const undo = useCallback(async () => {
     const currentState = await get(`canvas-state:${canvasId}`);

--- a/packages/ai-workspace-common/src/context/canvas.tsx
+++ b/packages/ai-workspace-common/src/context/canvas.tsx
@@ -35,6 +35,7 @@ import { IContextItem } from '@refly/common-types';
 import { useGetCanvasDetail } from '@refly-packages/ai-workspace-common/queries';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
+import { logEvent } from '@refly/telemetry-web';
 
 // Wait time for syncCanvasData to be called
 const SYNC_CANVAS_LOCAL_WAIT_TIME = 200;
@@ -234,6 +235,13 @@ export const CanvasProvider = ({
 
     if (conflict) {
       const userChoice = await handleConflictResolution(canvasId, conflict);
+      logEvent('canvas::conflict_version', userChoice, {
+        canvasId,
+        source: 'create_new_version',
+        localVersion: conflict.localState.version,
+        remoteVersion: conflict.remoteState.version,
+      });
+
       if (userChoice === 'local') {
         finalState = conflict.localState;
       } else {
@@ -488,6 +496,13 @@ export const CanvasProvider = ({
             localState,
             remoteState,
           });
+          logEvent('canvas::conflict_version', userChoice, {
+            canvasId,
+            source: 'initial_fetch',
+            localVersion: localState.version,
+            remoteVersion: remoteState.version,
+          });
+
           if (userChoice === 'local') {
             // Use local state, and set it to remote
             finalState = localState;

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -1328,6 +1328,12 @@ const translations = {
       local: 'Keep local version (Last modified: {{time}})',
       remote: 'Keep remote version (Last modified: {{time}})',
     },
+    syncFailure: {
+      title: 'Canvas Sync Failed',
+      content:
+        'There seems to be some issues syncing the canvas content with the server. Please check your internet connection or try again later.',
+      reload: 'Reload',
+    },
     contextSelector: {
       placeholder: 'Search nodes...',
     },

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -1296,6 +1296,11 @@ const translations = {
       local: '保留本地版本 (最后修改时间: {{time}})',
       remote: '保留远程版本 (最后修改时间: {{time}})',
     },
+    syncFailure: {
+      title: '画布同步失败',
+      content: '与服务器同步画布内容时似乎遇到了问题，请检查您的网络连接或稍后再试。',
+      reload: '重新加载',
+    },
     contextSelector: {
       placeholder: '搜索节点...',
     },


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning modal that appears if the canvas repeatedly fails to sync with the server, offering options to reload the page or dismiss the warning.
  * The canvas status indicator now shows a yellow pulsing animation not only when loading but also when sync failures occur.
* **Localization**
  * Added new translations for canvas sync failure messages in both English and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->