### PR TITLE
feat: memorize resource libraray status for each canvas

### DIFF
--- a/apps/web/src/antd-overrides.css
+++ b/apps/web/src/antd-overrides.css
@@ -83,6 +83,10 @@
   background-color: var(--refly-tertiary-hover) !important;
 }
 
+.ant-segmented .ant-segmented-item-selected:hover {
+  background-color: var(--refly-bg-control-z1) !important
+}
+
 .ant-segmented .ant-segmented-item-label {
   color: var(--text-refly-text-0) !important;
   text-align: center;

--- a/apps/web/src/antd-overrides.css
+++ b/apps/web/src/antd-overrides.css
@@ -84,7 +84,7 @@
 }
 
 .ant-segmented .ant-segmented-item-selected:hover {
-  background-color: var(--refly-bg-control-z1) !important
+  background-color: var(--refly-bg-control-z1) !important;
 }
 
 .ant-segmented .ant-segmented-item-label {

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/index.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useRef } from 'react';
 import { Modal } from 'antd';
 import { CanvasResourcesHeader } from './share/canvas-resources-header';
 import { ResourceOverview } from './share/resource-overview';
-import { useCanvasResourcesPanelStoreShallow } from '@refly/stores';
+import { useActiveNode, useCanvasResourcesPanelStoreShallow } from '@refly/stores';
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 import { PreviewComponent } from '@refly-packages/ai-workspace-common/components/canvas/node-preview';
 import { CanvasNodeType } from '@refly/openapi-schema';
@@ -14,15 +14,16 @@ interface CanvasResourcesProps {
 }
 
 export const CanvasResources = memo(({ className }: CanvasResourcesProps) => {
-  const { showLeftOverview, activeNode, resetState, setParentType } =
-    useCanvasResourcesPanelStoreShallow((state) => ({
+  const { canvasId } = useCanvasContext();
+  const { showLeftOverview, resetState, setParentType } = useCanvasResourcesPanelStoreShallow(
+    (state) => ({
       showLeftOverview: state.showLeftOverview,
-      activeNode: state.activeNode,
       resetState: state.resetState,
       setParentType: state.setParentType,
-    }));
+    }),
+  );
+  const { activeNode } = useActiveNode(canvasId);
 
-  const { canvasId } = useCanvasContext();
   const prevCanvasIdRef = useRef<string | null>(canvasId);
 
   useEffect(() => {

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/my-upload/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/my-upload/index.tsx
@@ -2,20 +2,20 @@ import { memo, useCallback, useMemo } from 'react';
 import { message } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { CanvasNode } from '@refly/canvas-common';
-import { useCanvasResourcesPanelStoreShallow } from '@refly/stores';
+import { useActiveNode, useCanvasResourcesPanelStoreShallow } from '@refly/stores';
 import { useRealtimeCanvasData } from '@refly-packages/ai-workspace-common/hooks/canvas/use-realtime-canvas-data';
 import { MyUploadItem } from './my-upload-item';
+import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 
 export const MyUploadList = memo(() => {
   const { t } = useTranslation();
   const { nodes } = useRealtimeCanvasData();
-  const { setParentType, setActiveNode, activeNode, searchKeyword } =
-    useCanvasResourcesPanelStoreShallow((state) => ({
-      setParentType: state.setParentType,
-      setActiveNode: state.setActiveNode,
-      activeNode: state.activeNode,
-      searchKeyword: state.searchKeyword,
-    }));
+  const { canvasId } = useCanvasContext();
+  const { setParentType, searchKeyword } = useCanvasResourcesPanelStoreShallow((state) => ({
+    setParentType: state.setParentType,
+    searchKeyword: state.searchKeyword,
+  }));
+  const { activeNode, setActiveNode } = useActiveNode(canvasId);
 
   // Filter nodes by resource type
   const resourceNodes = useMemo(() => {

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/result-list/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/result-list/index.tsx
@@ -4,23 +4,23 @@ import { useTranslation } from 'react-i18next';
 import { CanvasNode } from '@refly/canvas-common';
 import { CanvasNodeType } from '@refly/openapi-schema';
 import { cn } from '@refly/utils/cn';
-import { useCanvasResourcesPanelStoreShallow } from '@refly/stores';
+import { useActiveNode, useCanvasResourcesPanelStoreShallow } from '@refly/stores';
 import { useRealtimeCanvasData } from '@refly-packages/ai-workspace-common/hooks/canvas/use-realtime-canvas-data';
 import { NodeIcon } from '@refly-packages/ai-workspace-common/components/canvas/nodes/shared/node-icon';
 import { ResourceItemAction } from '../share/resource-item-action';
+import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 
 const { Text } = Typography;
 
 export const ResultList = memo(() => {
   const { t } = useTranslation();
   const { nodes } = useRealtimeCanvasData();
-  const { setParentType, setActiveNode, activeNode, searchKeyword } =
-    useCanvasResourcesPanelStoreShallow((state) => ({
-      setParentType: state.setParentType,
-      setActiveNode: state.setActiveNode,
-      activeNode: state.activeNode,
-      searchKeyword: state.searchKeyword,
-    }));
+  const { canvasId } = useCanvasContext();
+  const { setParentType, searchKeyword } = useCanvasResourcesPanelStoreShallow((state) => ({
+    setParentType: state.setParentType,
+    searchKeyword: state.searchKeyword,
+  }));
+  const { activeNode, setActiveNode } = useActiveNode(canvasId);
 
   // Filter nodes by the specified types and search keyword
   const resultNodes = useMemo(() => {

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/canvas-resources-header.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/canvas-resources-header.tsx
@@ -1,37 +1,41 @@
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Breadcrumb, Button, Tooltip, Typography } from 'antd';
+import { Button, Tooltip, Typography } from 'antd';
 import { Add, ScreenFull, ScreenDefault, SideRight } from 'refly-icons';
-import { useCanvasResourcesPanelStoreShallow, useImportResourceStoreShallow } from '@refly/stores';
+import {
+  useActiveNode,
+  useCanvasResourcesPanelStoreShallow,
+  useImportResourceStoreShallow,
+} from '@refly/stores';
 import { TopButtons } from './top-buttons';
+import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
+import cn from 'classnames';
 
 const { Text } = Typography;
 
 export const CanvasResourcesHeader = memo(() => {
   const { t } = useTranslation();
+  const { canvasId } = useCanvasContext();
   const {
     parentType,
-    activeNode,
+    setParentType,
     sidePanelVisible,
     wideScreenVisible,
-    setParentType,
     setSidePanelVisible,
     setWideScreenVisible,
-    setActiveNode,
     setActiveTab,
     setShowLeftOverview,
   } = useCanvasResourcesPanelStoreShallow((state) => ({
     setShowLeftOverview: state.setShowLeftOverview,
     parentType: state.parentType,
-    activeNode: state.activeNode,
     sidePanelVisible: state.sidePanelVisible,
     wideScreenVisible: state.wideScreenVisible,
     setParentType: state.setParentType,
     setSidePanelVisible: state.setSidePanelVisible,
     setWideScreenVisible: state.setWideScreenVisible,
-    setActiveNode: state.setActiveNode,
     setActiveTab: state.setActiveTab,
   }));
+  const { activeNode, setActiveNode } = useActiveNode(canvasId);
   const { setImportResourceModalVisible } = useImportResourceStoreShallow((state) => ({
     setImportResourceModalVisible: state.setImportResourceModalVisible,
   }));
@@ -78,36 +82,41 @@ export const CanvasResourcesHeader = memo(() => {
   }, [setWideScreenVisible]);
 
   return (
-    <div className="h-[65px] flex items-center justify-between p-3 border-solid border-refly-Card-Border border-[1px] border-x-0 border-t-0">
-      <div className="flex items-center gap-2">
+    <div className="w-full h-[65px] flex items-center justify-between p-3 border-solid border-refly-Card-Border border-[1px] border-x-0 border-t-0">
+      <div className="flex items-center gap-2 min-w-0 flex-1">
         {sidePanelVisible && (
           <Tooltip title={t('canvas.toolbar.closeResourcesPanel')} arrow={false}>
             <Button type="text" icon={<SideRight size={16} />} onClick={handleClose} />
           </Tooltip>
         )}
+
         {parentType ? (
-          <Breadcrumb>
-            <Breadcrumb.Item
+          <div className="min-w-0 flex-1 flex items-center gap-2">
+            <Button
+              type="text"
+              size="small"
               onClick={handleParentClick}
-              className={wideScreenVisible ? 'pointer-events-none' : ''}
+              className={cn(wideScreenVisible ? 'pointer-events-none' : '', 'px-0.5')}
             >
-              <a onMouseEnter={handleShowLeftOverview}>
+              <a
+                className="whitespace-nowrap text-refly-text-1 hover:refly-tertiary-hover hover:text-refly-text-1"
+                onMouseEnter={handleShowLeftOverview}
+              >
                 {t(`canvas.resourceLibrary.${parentType}`)}
               </a>
-            </Breadcrumb.Item>
-            <Breadcrumb.Item>
-              <Text ellipsis={{ tooltip: true }} style={{ width: 200 }}>
-                {activeNode?.data?.title || t('common.untitled')}
-              </Text>
-            </Breadcrumb.Item>
-          </Breadcrumb>
+            </Button>
+            <div className="text-refly-text-2">/</div>
+            <Text ellipsis={{ tooltip: true }} className="min-w-0 flex-1 !max-w-[400px]">
+              {activeNode?.data?.title || t('common.untitled')}
+            </Text>
+          </div>
         ) : (
-          <div className="text-refly-text-0 text-base font-semibold leading-[26px]">
+          <div className="text-refly-text-0 text-base font-semibold leading-[26px] min-w-0 flex-1">
             {t('canvas.resourceLibrary.title')}
           </div>
         )}
       </div>
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3 flex-shrink-0">
         {!parentType && (
           <Tooltip title={t('canvas.toolbar.addResource')} arrow={false}>
             <Button size="small" type="text" icon={<Add size={18} />} onClick={handleAddResource} />

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/canvas-resources-header.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/canvas-resources-header.tsx
@@ -39,7 +39,8 @@ export const CanvasResourcesHeader = memo(() => {
   const handleClose = useCallback(() => {
     setSidePanelVisible(false);
     setShowLeftOverview(false);
-  }, [setSidePanelVisible, setShowLeftOverview]);
+    setWideScreenVisible(false);
+  }, [setSidePanelVisible, setShowLeftOverview, setWideScreenVisible]);
 
   const handleShowLeftOverview = useCallback(() => {
     if (sidePanelVisible && !wideScreenVisible) {
@@ -86,7 +87,10 @@ export const CanvasResourcesHeader = memo(() => {
         )}
         {parentType ? (
           <Breadcrumb>
-            <Breadcrumb.Item onClick={handleParentClick}>
+            <Breadcrumb.Item
+              onClick={handleParentClick}
+              className={wideScreenVisible ? 'pointer-events-none' : ''}
+            >
               <a onMouseEnter={handleShowLeftOverview}>
                 {t(`canvas.resourceLibrary.${parentType}`)}
               </a>
@@ -111,6 +115,12 @@ export const CanvasResourcesHeader = memo(() => {
         )}
 
         <TopButtons />
+
+        {parentType && (
+          <Tooltip title={t('canvas.toolbar.addResource')} arrow={false}>
+            <Button size="small" type="text" icon={<Add size={16} />} onClick={handleAddResource} />
+          </Tooltip>
+        )}
 
         {activeNode && (
           <Tooltip

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/canvas-resources-header.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/canvas-resources-header.tsx
@@ -146,10 +146,10 @@ export const CanvasResourcesHeader = memo(() => {
 
   return (
     <div className="w-full h-[65px] flex gap-2 items-center justify-between p-3 border-solid border-refly-Card-Border border-[1px] border-x-0 border-t-0">
-      <div className="flex items-center gap-2 min-w-0 flex-1">
+      <div className="flex items-center gap-1 min-w-0 flex-1">
         {sidePanelVisible && (
           <Tooltip title={t('canvas.toolbar.closeResourcesPanel')} arrow={false}>
-            <Button type="text" icon={<SideRight size={16} />} onClick={handleClose} />
+            <Button type="text" icon={<SideRight size={18} />} onClick={handleClose} />
           </Tooltip>
         )}
 

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/resource-item-action.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/resource-item-action.tsx
@@ -7,7 +7,7 @@ import { useCallback } from 'react';
 import { useNodePosition } from '@refly-packages/ai-workspace-common/hooks/canvas/use-node-position';
 import { useReactFlow } from '@xyflow/react';
 import { useDeleteNode } from '@refly-packages/ai-workspace-common/hooks/canvas/use-delete-node';
-import { useCanvasResourcesPanelStoreShallow } from '@refly/stores';
+import { useActiveNode } from '@refly/stores';
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 
 export const ResourceItemAction = ({
@@ -18,14 +18,11 @@ export const ResourceItemAction = ({
   className?: string;
 }) => {
   const { t } = useTranslation();
-  const { readonly } = useCanvasContext();
+  const { readonly, canvasId } = useCanvasContext();
   const { setNodeCenter } = useNodePosition();
   const { getNodes } = useReactFlow();
   const { deleteNode } = useDeleteNode();
-  const { activeNode, setActiveNode } = useCanvasResourcesPanelStoreShallow((state) => ({
-    activeNode: state.activeNode,
-    setActiveNode: state.setActiveNode,
-  }));
+  const { activeNode, setActiveNode } = useActiveNode(canvasId);
   const handleLocateNode = (node: CanvasNode) => {
     if (node?.type === 'group') {
       return;

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/resource-overview.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/resource-overview.tsx
@@ -1,4 +1,4 @@
-import { useMemo, memo } from 'react';
+import { useMemo, memo, useEffect } from 'react';
 import {
   useCanvasResourcesPanelStoreShallow,
   useImportResourceStoreShallow,
@@ -19,12 +19,13 @@ export const ResourceOverview = memo(() => {
   const { nodes } = useRealtimeCanvasData();
   const { createSingleDocumentInCanvas, isCreating: isCreatingDocument } = useCreateDocument();
 
-  const { activeTab, searchKeyword, setActiveTab, setSearchKeyword } =
+  const { activeTab, searchKeyword, setActiveTab, setSearchKeyword, parentType } =
     useCanvasResourcesPanelStoreShallow((state) => ({
       activeTab: state.activeTab,
       searchKeyword: state.searchKeyword,
       setActiveTab: state.setActiveTab,
       setSearchKeyword: state.setSearchKeyword,
+      parentType: state.parentType,
     }));
   const { setImportResourceModalVisible } = useImportResourceStoreShallow((state) => ({
     setImportResourceModalVisible: state.setImportResourceModalVisible,
@@ -71,6 +72,12 @@ export const ResourceOverview = memo(() => {
       ).length > 0
     );
   }, [nodes]);
+
+  useEffect(() => {
+    if (parentType) {
+      setActiveTab(parentType);
+    }
+  }, [parentType, setActiveTab]);
 
   return (
     <div className="p-4 flex-grow flex flex-col gap-4 overflow-hidden">

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/code-artifact-top-buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/code-artifact-top-buttons.tsx
@@ -16,9 +16,13 @@ import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/ca
 export const CodeArtifactTopButtons = () => {
   const { t } = useTranslation();
   const { readonly } = useCanvasContext();
-  const { activeNode } = useCanvasResourcesPanelStoreShallow((state) => ({
-    activeNode: state.activeNode,
-  }));
+  const { activeNode, setWideScreenVisible, setParentType } = useCanvasResourcesPanelStoreShallow(
+    (state) => ({
+      activeNode: state.activeNode,
+      setWideScreenVisible: state.setWideScreenVisible,
+      setParentType: state.setParentType,
+    }),
+  );
 
   const entityId = activeNode?.data?.entityId ?? '';
   const title = activeNode?.data?.title ?? 'Code Artifact';
@@ -100,7 +104,9 @@ export const CodeArtifactTopButtons = () => {
       position: activeNode.position as any,
       data: activeNode.data as any,
     });
-  }, [activeNode, deleteNode]);
+    setWideScreenVisible(false);
+    setParentType(null);
+  }, [activeNode, deleteNode, setWideScreenVisible, setParentType]);
 
   const moreMenuItems: MenuProps['items'] = useMemo(() => {
     return [

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/code-artifact-top-buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/code-artifact-top-buttons.tsx
@@ -2,7 +2,7 @@ import { Button, Tooltip, message, Dropdown, Divider } from 'antd';
 import { Download, Share, More, Location, Delete } from 'refly-icons';
 import { useTranslation } from 'react-i18next';
 import { useCallback, useMemo } from 'react';
-import { useCanvasResourcesPanelStoreShallow } from '@refly/stores';
+import { useActiveNode, useCanvasResourcesPanelStoreShallow } from '@refly/stores';
 import getClient from '@refly-packages/ai-workspace-common/requests/proxiedRequest';
 import { getShareLink } from '@refly-packages/ai-workspace-common/utils/share';
 import { copyToClipboard } from '@refly-packages/ai-workspace-common/utils';
@@ -15,14 +15,12 @@ import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/ca
 
 export const CodeArtifactTopButtons = () => {
   const { t } = useTranslation();
-  const { readonly } = useCanvasContext();
-  const { activeNode, setWideScreenVisible, setParentType } = useCanvasResourcesPanelStoreShallow(
-    (state) => ({
-      activeNode: state.activeNode,
-      setWideScreenVisible: state.setWideScreenVisible,
-      setParentType: state.setParentType,
-    }),
-  );
+  const { readonly, canvasId } = useCanvasContext();
+  const { setWideScreenVisible, setParentType } = useCanvasResourcesPanelStoreShallow((state) => ({
+    setWideScreenVisible: state.setWideScreenVisible,
+    setParentType: state.setParentType,
+  }));
+  const { activeNode } = useActiveNode(canvasId);
 
   const entityId = activeNode?.data?.entityId ?? '';
   const title = activeNode?.data?.title ?? 'Code Artifact';

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/code-artifact-top-buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/code-artifact-top-buttons.tsx
@@ -108,6 +108,20 @@ export const CodeArtifactTopButtons = () => {
 
   const moreMenuItems: MenuProps['items'] = useMemo(() => {
     return [
+      ...(readonly
+        ? []
+        : [
+            {
+              key: 'share',
+              label: (
+                <div className="flex items-center gap-2 whitespace-nowrap">
+                  <Share size={16} color="var(--refly-text-0)" />
+                  {t('codeArtifact.buttons.share')}
+                </div>
+              ),
+              onClick: handleShare,
+            },
+          ]),
       {
         key: 'locateNode',
         label: (
@@ -138,18 +152,6 @@ export const CodeArtifactTopButtons = () => {
 
   return (
     <div className="flex items-center gap-3">
-      {!readonly && (
-        <Tooltip title={t('codeArtifact.buttons.share')}>
-          <Button
-            className="!h-5 !w-5 p-0"
-            size="small"
-            type="text"
-            onClick={handleShare}
-            icon={<Share size={16} />}
-          />
-        </Tooltip>
-      )}
-
       <Tooltip title={t('codeArtifact.buttons.download', { fileName })}>
         <Button
           className="!h-5 !w-5 p-0"
@@ -160,11 +162,10 @@ export const CodeArtifactTopButtons = () => {
         />
       </Tooltip>
 
-      <Divider type="vertical" className="h-4 bg-refly-Card-Border m-0" />
-
       <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">
         <Button className="!h-5 !w-5 p-0" size="small" type="text" icon={<More size={16} />} />
       </Dropdown>
+      <Divider type="vertical" className="h-4 bg-refly-Card-Border m-0" />
     </div>
   );
 };

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/document-top-buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/document-top-buttons.tsx
@@ -14,9 +14,13 @@ export const DocumentTopButtons = () => {
   const { t } = useTranslation();
   const { setNodeCenter } = useNodePosition();
   const { deleteNode } = useDeleteNode();
-  const { activeNode } = useCanvasResourcesPanelStoreShallow((state) => ({
-    activeNode: state.activeNode,
-  }));
+  const { activeNode, setWideScreenVisible, setParentType } = useCanvasResourcesPanelStoreShallow(
+    (state) => ({
+      activeNode: state.activeNode,
+      setWideScreenVisible: state.setWideScreenVisible,
+      setParentType: state.setParentType,
+    }),
+  );
   const [isSharing, setIsSharing] = useState(false);
   const { readonly } = useCanvasContext();
   const docId = activeNode?.data?.entityId ?? '';
@@ -131,7 +135,9 @@ export const DocumentTopButtons = () => {
   const handleDeleteNode = useCallback(() => {
     if (!activeNode) return;
     deleteNode(activeNode as any);
-  }, [activeNode, deleteNode]);
+    setWideScreenVisible(false);
+    setParentType(null);
+  }, [activeNode, deleteNode, setWideScreenVisible, setParentType]);
 
   const moreMenuItems: MenuProps['items'] = useMemo(() => {
     return [

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/document-top-buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/document-top-buttons.tsx
@@ -3,7 +3,7 @@ import type { MenuProps } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Share, Download, More, Location, Delete, Markdown, Doc1, Pdf } from 'refly-icons';
-import { useCanvasResourcesPanelStoreShallow } from '@refly/stores';
+import { useActiveNode, useCanvasResourcesPanelStoreShallow } from '@refly/stores';
 import { useNodePosition } from '@refly-packages/ai-workspace-common/hooks/canvas/use-node-position';
 import { useDeleteNode } from '@refly-packages/ai-workspace-common/hooks/canvas/use-delete-node';
 import { editorEmitter } from '@refly/utils/event-emitter/editor';
@@ -12,15 +12,14 @@ import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/ca
 
 export const DocumentTopButtons = () => {
   const { t } = useTranslation();
+  const { canvasId } = useCanvasContext();
   const { setNodeCenter } = useNodePosition();
   const { deleteNode } = useDeleteNode();
-  const { activeNode, setWideScreenVisible, setParentType } = useCanvasResourcesPanelStoreShallow(
-    (state) => ({
-      activeNode: state.activeNode,
-      setWideScreenVisible: state.setWideScreenVisible,
-      setParentType: state.setParentType,
-    }),
-  );
+  const { setWideScreenVisible, setParentType } = useCanvasResourcesPanelStoreShallow((state) => ({
+    setWideScreenVisible: state.setWideScreenVisible,
+    setParentType: state.setParentType,
+  }));
+  const { activeNode } = useActiveNode(canvasId);
   const [isSharing, setIsSharing] = useState(false);
   const { readonly } = useCanvasContext();
   const docId = activeNode?.data?.entityId ?? '';

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/document-top-buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/document-top-buttons.tsx
@@ -3,7 +3,7 @@ import type { MenuProps } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Share, Download, More, Location, Delete, Markdown, Doc1, Pdf } from 'refly-icons';
-import { useActiveNode, useCanvasResourcesPanelStoreShallow } from '@refly/stores';
+import { useActiveNode } from '@refly/stores';
 import { useNodePosition } from '@refly-packages/ai-workspace-common/hooks/canvas/use-node-position';
 import { useDeleteNode } from '@refly-packages/ai-workspace-common/hooks/canvas/use-delete-node';
 import { editorEmitter } from '@refly/utils/event-emitter/editor';
@@ -15,10 +15,7 @@ export const DocumentTopButtons = () => {
   const { canvasId } = useCanvasContext();
   const { setNodeCenter } = useNodePosition();
   const { deleteNode } = useDeleteNode();
-  const { setWideScreenVisible, setParentType } = useCanvasResourcesPanelStoreShallow((state) => ({
-    setWideScreenVisible: state.setWideScreenVisible,
-    setParentType: state.setParentType,
-  }));
+
   const { activeNode } = useActiveNode(canvasId);
   const [isSharing, setIsSharing] = useState(false);
   const { readonly } = useCanvasContext();
@@ -134,9 +131,7 @@ export const DocumentTopButtons = () => {
   const handleDeleteNode = useCallback(() => {
     if (!activeNode) return;
     deleteNode(activeNode as any);
-    setWideScreenVisible(false);
-    setParentType(null);
-  }, [activeNode, deleteNode, setWideScreenVisible, setParentType]);
+  }, [activeNode, deleteNode]);
 
   const moreMenuItems: MenuProps['items'] = useMemo(() => {
     return [
@@ -182,7 +177,7 @@ export const DocumentTopButtons = () => {
             },
           ]),
     ];
-  }, [handleDeleteNode, handleLocateNode, t]);
+  }, [handleDeleteNode, handleLocateNode, handleShare, readonly, isSharing, t]);
 
   const DownloadMenu = (
     <Dropdown menu={{ items: exportMenuItems }} trigger={['click']} placement="bottomRight">

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/document-top-buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/document-top-buttons.tsx
@@ -1,4 +1,4 @@
-import { Button, Dropdown, Tooltip, message } from 'antd';
+import { Button, Dropdown, message } from 'antd';
 import type { MenuProps } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -140,6 +140,22 @@ export const DocumentTopButtons = () => {
 
   const moreMenuItems: MenuProps['items'] = useMemo(() => {
     return [
+      ...(readonly
+        ? []
+        : [
+            {
+              key: 'share',
+              disabled: isSharing,
+              loading: isSharing,
+              label: (
+                <div className="flex items-center gap-2 whitespace-nowrap">
+                  <Share size={16} color="var(--refly-text-0)" />
+                  {t('document.share')}
+                </div>
+              ),
+              onClick: handleShare,
+            },
+          ]),
       {
         key: 'locateNode',
         label: (
@@ -176,22 +192,7 @@ export const DocumentTopButtons = () => {
 
   return (
     <div className="flex items-center gap-3">
-      {!readonly && (
-        <>
-          <Tooltip title={t('document.share', 'Share document')}>
-            <Button
-              className="!h-5 !w-5 p-0"
-              disabled={isSharing}
-              loading={isSharing}
-              size="small"
-              type="text"
-              onClick={handleShare}
-              icon={<Share size={16} />}
-            />
-          </Tooltip>
-          {DownloadMenu}
-        </>
-      )}
+      {!readonly && DownloadMenu}
 
       <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">
         <Button className="!h-5 !w-5 p-0" size="small" type="text" icon={<More size={16} />} />

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/index.tsx
@@ -1,13 +1,13 @@
 import { SkillResponseTopButtons } from './skill-response-top-buttons';
 import { CodeArtifactTopButtons } from './code-artifact-top-buttons';
-import { useCanvasResourcesPanelStoreShallow } from '@refly/stores';
+import { useActiveNode } from '@refly/stores';
 import { DocumentTopButtons } from './document-top-buttons';
 import { ResourceTopButtons } from './resource-top-buttons';
+import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 
 export const TopButtons = () => {
-  const { activeNode } = useCanvasResourcesPanelStoreShallow((state) => ({
-    activeNode: state.activeNode,
-  }));
+  const { canvasId } = useCanvasContext();
+  const { activeNode } = useActiveNode(canvasId);
 
   switch (activeNode?.type) {
     case 'skillResponse':

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/resource-top-buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/resource-top-buttons.tsx
@@ -16,7 +16,10 @@ export const ResourceTopButtons = () => {
   }));
   const { setNodeCenter } = useNodePosition();
   const { deleteNode } = useDeleteNode();
-
+  const { setWideScreenVisible, setParentType } = useCanvasResourcesPanelStoreShallow((state) => ({
+    setWideScreenVisible: state.setWideScreenVisible,
+    setParentType: state.setParentType,
+  }));
   const handleLocateNode = useCallback(() => {
     if (activeNode?.id) setNodeCenter(activeNode.id, true);
   }, [activeNode?.id, setNodeCenter]);
@@ -24,7 +27,9 @@ export const ResourceTopButtons = () => {
   const handleDeleteNode = useCallback(() => {
     if (!activeNode) return;
     deleteNode(activeNode as any);
-  }, [activeNode, deleteNode]);
+    setWideScreenVisible(false);
+    setParentType(null);
+  }, [activeNode, deleteNode, setWideScreenVisible, setParentType]);
 
   const moreMenuItems: MenuProps['items'] = useMemo(() => {
     return [

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/resource-top-buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/resource-top-buttons.tsx
@@ -3,17 +3,15 @@ import type { MenuProps } from 'antd';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { More, Location, Delete } from 'refly-icons';
-import { useCanvasResourcesPanelStoreShallow } from '@refly/stores';
+import { useActiveNode, useCanvasResourcesPanelStoreShallow } from '@refly/stores';
 import { useNodePosition } from '@refly-packages/ai-workspace-common/hooks/canvas/use-node-position';
 import { useDeleteNode } from '@refly-packages/ai-workspace-common/hooks/canvas/use-delete-node';
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 
 export const ResourceTopButtons = () => {
   const { t } = useTranslation();
-  const { readonly } = useCanvasContext();
-  const { activeNode } = useCanvasResourcesPanelStoreShallow((state) => ({
-    activeNode: state.activeNode,
-  }));
+  const { readonly, canvasId } = useCanvasContext();
+  const { activeNode } = useActiveNode(canvasId);
   const { setNodeCenter } = useNodePosition();
   const { deleteNode } = useDeleteNode();
   const { setWideScreenVisible, setParentType } = useCanvasResourcesPanelStoreShallow((state) => ({

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/resource-top-buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/resource-top-buttons.tsx
@@ -3,7 +3,7 @@ import type { MenuProps } from 'antd';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { More, Location, Delete } from 'refly-icons';
-import { useActiveNode, useCanvasResourcesPanelStoreShallow } from '@refly/stores';
+import { useActiveNode } from '@refly/stores';
 import { useNodePosition } from '@refly-packages/ai-workspace-common/hooks/canvas/use-node-position';
 import { useDeleteNode } from '@refly-packages/ai-workspace-common/hooks/canvas/use-delete-node';
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
@@ -14,10 +14,7 @@ export const ResourceTopButtons = () => {
   const { activeNode } = useActiveNode(canvasId);
   const { setNodeCenter } = useNodePosition();
   const { deleteNode } = useDeleteNode();
-  const { setWideScreenVisible, setParentType } = useCanvasResourcesPanelStoreShallow((state) => ({
-    setWideScreenVisible: state.setWideScreenVisible,
-    setParentType: state.setParentType,
-  }));
+
   const handleLocateNode = useCallback(() => {
     if (activeNode?.id) setNodeCenter(activeNode.id, true);
   }, [activeNode?.id, setNodeCenter]);
@@ -25,9 +22,7 @@ export const ResourceTopButtons = () => {
   const handleDeleteNode = useCallback(() => {
     if (!activeNode) return;
     deleteNode(activeNode as any);
-    setWideScreenVisible(false);
-    setParentType(null);
-  }, [activeNode, deleteNode, setWideScreenVisible, setParentType]);
+  }, [activeNode, deleteNode]);
 
   const moreMenuItems: MenuProps['items'] = useMemo(() => {
     return [

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/skill-response-top-buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/skill-response-top-buttons.tsx
@@ -9,7 +9,7 @@ import {
 } from '@refly-packages/ai-workspace-common/events/nodeActions';
 import { useMemo, useCallback, useState } from 'react';
 import { Delete, Doc, Location } from 'refly-icons';
-import { useActionResultStoreShallow } from '@refly/stores';
+import { useActiveNode, useActionResultStoreShallow } from '@refly/stores';
 import { useCreateDocument } from '@refly-packages/ai-workspace-common/hooks/canvas/use-create-document';
 import { parseMarkdownCitationsAndCanvasTags } from '@refly/utils/parse';
 import { getShareLink } from '@refly-packages/ai-workspace-common/utils/share';
@@ -27,7 +27,7 @@ interface SkillResponseTopButtonsProps {
 }
 export const SkillResponseTopButtons = ({ node }: SkillResponseTopButtonsProps) => {
   const { t } = useTranslation();
-  const { readonly } = useCanvasContext();
+  const { readonly, canvasId } = useCanvasContext();
 
   const resultId = node?.data?.entityId ?? '';
   const { result } = useActionResultStoreShallow((state) => ({
@@ -39,12 +39,11 @@ export const SkillResponseTopButtons = ({ node }: SkillResponseTopButtonsProps) 
   const { removeLinearThreadMessageByNodeId } = useCanvasStore((state) => ({
     removeLinearThreadMessageByNodeId: state.removeLinearThreadMessageByNodeId,
   }));
-  const { setActiveNode, setParentType, setWideScreenVisible } =
-    useCanvasResourcesPanelStoreShallow((state) => ({
-      setActiveNode: state.setActiveNode,
-      setParentType: state.setParentType,
-      setWideScreenVisible: state.setWideScreenVisible,
-    }));
+  const { setParentType, setWideScreenVisible } = useCanvasResourcesPanelStoreShallow((state) => ({
+    setParentType: state.setParentType,
+    setWideScreenVisible: state.setWideScreenVisible,
+  }));
+  const { setActiveNode } = useActiveNode(canvasId);
   const [isSharing, setIsSharing] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
 

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/skill-response-top-buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/skill-response-top-buttons.tsx
@@ -1,5 +1,5 @@
 import { Reload, More, Share } from 'refly-icons';
-import { Button, Divider, Dropdown, Tooltip } from 'antd';
+import { Button, Dropdown, Tooltip } from 'antd';
 import type { MenuProps } from 'antd';
 import { CanvasNode } from '@refly/canvas-common';
 import { useTranslation } from 'react-i18next';
@@ -207,18 +207,15 @@ export const SkillResponseTopButtons = ({ node }: SkillResponseTopButtonsProps) 
   return (
     <div className="flex items-center gap-3">
       {!readonly && (
-        <>
-          <Tooltip title={t('canvas.nodeActions.rerun')}>
-            <Button
-              className="!h-5 !w-5 p-0"
-              size="small"
-              type="text"
-              icon={<Reload size={16} />}
-              onClick={handleReRun}
-            />
-          </Tooltip>
-          <Divider type="vertical" className="m-0 h-4 bg-refly-Card-Border" />
-        </>
+        <Tooltip title={t('canvas.nodeActions.rerun')}>
+          <Button
+            className="!h-5 !w-5 p-0"
+            size="small"
+            type="text"
+            icon={<Reload size={16} />}
+            onClick={handleReRun}
+          />
+        </Tooltip>
       )}
 
       <Dropdown

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/skill-response-top-buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/share/top-buttons/skill-response-top-buttons.tsx
@@ -39,10 +39,12 @@ export const SkillResponseTopButtons = ({ node }: SkillResponseTopButtonsProps) 
   const { removeLinearThreadMessageByNodeId } = useCanvasStore((state) => ({
     removeLinearThreadMessageByNodeId: state.removeLinearThreadMessageByNodeId,
   }));
-  const { setActiveNode, setParentType } = useCanvasResourcesPanelStoreShallow((state) => ({
-    setActiveNode: state.setActiveNode,
-    setParentType: state.setParentType,
-  }));
+  const { setActiveNode, setParentType, setWideScreenVisible } =
+    useCanvasResourcesPanelStoreShallow((state) => ({
+      setActiveNode: state.setActiveNode,
+      setParentType: state.setParentType,
+      setWideScreenVisible: state.setWideScreenVisible,
+    }));
   const [isSharing, setIsSharing] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
@@ -73,7 +75,7 @@ export const SkillResponseTopButtons = ({ node }: SkillResponseTopButtonsProps) 
   const handleShare = useCallback(async () => {
     if (!result) return;
     setIsSharing(true);
-    const loadingMessage = message.loading(t('codeArtifact.sharing'), 0);
+    const loadingMessage = message.loading(t('common.sharing'), 0);
     try {
       const { data, error } = await getClient().createShare({
         body: {
@@ -120,8 +122,8 @@ export const SkillResponseTopButtons = ({ node }: SkillResponseTopButtonsProps) 
         entityId: node?.data?.entityId ?? resultId,
       },
     });
-    setActiveNode(null);
-    setParentType('stepsRecord');
+    setWideScreenVisible(false);
+    setParentType(null);
   }, [
     deleteNode,
     node,
@@ -130,6 +132,7 @@ export const SkillResponseTopButtons = ({ node }: SkillResponseTopButtonsProps) 
     resultId,
     setActiveNode,
     setParentType,
+    setWideScreenVisible,
   ]);
 
   const moreMenuItems: MenuProps['items'] = useMemo(() => {

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/step-list/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/step-list/index.tsx
@@ -4,7 +4,7 @@ import { CanvasNode } from '@refly/canvas-common';
 import { useTranslation } from 'react-i18next';
 import { useRealtimeCanvasData } from '@refly-packages/ai-workspace-common/hooks/canvas/use-realtime-canvas-data';
 import { EventDataNode } from 'antd/es/tree';
-import { useCanvasResourcesPanelStoreShallow } from '@refly/stores';
+import { useActiveNode, useCanvasResourcesPanelStoreShallow } from '@refly/stores';
 import { NodeIcon } from '@refly-packages/ai-workspace-common/components/canvas/nodes/shared/node-icon';
 import { Location, Delete } from 'refly-icons';
 import { useReactFlow } from '@xyflow/react';
@@ -83,13 +83,12 @@ const StepRowTitle = memo(({ node, isActive, onLocate, onDelete }: StepRowTitleP
 export const StepList = memo(() => {
   const { t } = useTranslation();
   const { nodes, nodesSignature } = useRealtimeCanvasData();
-  const { setParentType, setActiveNode, activeNode, searchKeyword } =
-    useCanvasResourcesPanelStoreShallow((state) => ({
-      setParentType: state.setParentType,
-      setActiveNode: state.setActiveNode,
-      activeNode: state.activeNode,
-      searchKeyword: state.searchKeyword,
-    }));
+  const { canvasId } = useCanvasContext();
+  const { setParentType, searchKeyword } = useCanvasResourcesPanelStoreShallow((state) => ({
+    setParentType: state.setParentType,
+    searchKeyword: state.searchKeyword,
+  }));
+  const { activeNode, setActiveNode } = useActiveNode(canvasId);
   const { setNodeCenter } = useNodePosition();
   const { getNodes } = useReactFlow();
   const { deleteNode } = useDeleteNode();

--- a/packages/ai-workspace-common/src/components/canvas/empty-guide/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/empty-guide/index.tsx
@@ -1,26 +1,14 @@
 import { useTranslation } from 'react-i18next';
-import { Button } from 'antd';
-import {
-  IconTemplate,
-  IconImportResource,
-} from '@refly-packages/ai-workspace-common/components/common/icon';
+
 import { TemplatesGuide } from './templates-guide';
-import { useCanvasTemplateModal, useImportResourceStoreShallow } from '@refly/stores';
 import { canvasTemplateEnabled } from '@refly/ui-kit';
 
 export const EmptyGuide = ({ canvasId }: { canvasId: string }) => {
   const { t } = useTranslation();
-  const { setVisible } = useCanvasTemplateModal((state) => ({
-    setVisible: state.setVisible,
-  }));
-
-  const { setImportResourceModalVisible } = useImportResourceStoreShallow((state) => ({
-    setImportResourceModalVisible: state.setImportResourceModalVisible,
-  }));
 
   return (
     <div
-      className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[70%]"
+      className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[80%]"
       style={{ pointerEvents: 'none' }}
     >
       <div
@@ -30,34 +18,8 @@ export const EmptyGuide = ({ canvasId }: { canvasId: string }) => {
         <div className="text-[20px]" style={{ pointerEvents: 'none' }}>
           {t('canvas.emptyText')}
         </div>
-        <div className="flex gap-4" style={{ pointerEvents: 'none' }}>
-          <Button
-            icon={<IconImportResource className="-mr-1 flex items-center justify-center" />}
-            type="text"
-            className="text-[20px] text-[#0E9F77] py-[4px] px-[8px]"
-            onClick={() => setImportResourceModalVisible(true)}
-            data-cy="canvas-import-resource-button"
-            style={{ pointerEvents: 'auto' }}
-          >
-            {t('canvas.toolbar.importResource')}
-          </Button>
-
-          {canvasTemplateEnabled && (
-            <Button
-              icon={<IconTemplate className="-mr-1 flex items-center justify-center" />}
-              type="text"
-              className="text-[20px] text-[#0E9F77] py-[4px] px-[8px]"
-              onClick={() => setVisible(true)}
-              data-cy="canvas-create-document-button"
-              style={{ pointerEvents: 'auto' }}
-            >
-              {t('loggedHomePage.siderMenu.template')}
-            </Button>
-          )}
-        </div>
       </div>
-
-      <TemplatesGuide canvasId={canvasId} />
+      {canvasTemplateEnabled && <TemplatesGuide canvasId={canvasId} />}
     </div>
   );
 };

--- a/packages/ai-workspace-common/src/components/canvas/empty-guide/templates-guide.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/empty-guide/templates-guide.tsx
@@ -21,15 +21,10 @@ export const TemplatesGuide = ({ canvasId }: { canvasId: string }) => {
     setShowTemplates: state.setShowTemplates,
   }));
   const { data, refetch } = useListCanvasTemplates({
-    // TODO: add search
-    query: { page: 1, pageSize: 3 },
+    query: { page: 1, pageSize: 2 },
   });
 
   const debouncedRefetch = useDebouncedCallback(() => refetch(), 300);
-
-  // const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-  //   setSearch(e.target.value);
-  // };
 
   useEffect(() => {
     debouncedRefetch();
@@ -42,15 +37,9 @@ export const TemplatesGuide = ({ canvasId }: { canvasId: string }) => {
   return (
     showTemplates &&
     canvasTemplateEnabled && (
-      <div className="mt-20" style={{ pointerEvents: 'none' }}>
+      <div className="mt-10" style={{ pointerEvents: 'none' }}>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            {/* <Input
-              placeholder={t('template.searchPlaceholder')}
-              value={search}
-              onChange={handleSearchChange}
-              className="w-80"
-            /> */}
             {data?.data?.length === 0 && (
               <div className="text-gray-500 text-[14px]">{t('template.noRelatedTemplates')}</div>
             )}
@@ -66,7 +55,7 @@ export const TemplatesGuide = ({ canvasId }: { canvasId: string }) => {
         </div>
         <Divider className="mt-4 mb-2" />
 
-        <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-1">
+        <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-1">
           {(data?.data?.length ?? 0) > 0 &&
             data?.data?.map((template) => (
               <div key={template.templateId} style={{ pointerEvents: 'auto' }}>

--- a/packages/ai-workspace-common/src/components/canvas/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/index.tsx
@@ -694,7 +694,7 @@ const Flow = memo(({ canvasId }: { canvasId: string }) => {
       <MemoizedMiniMap
         position="bottom-left"
         style={miniMapStyles}
-        className="bg-white/80 dark:bg-gray-900/80 w-[140px] h-[92px] !mb-3 !ml-3 rounded-lg shadow-refly-m p-2 [&>svg]:w-full [&>svg]:h-full"
+        className="bg-white/80 dark:bg-gray-900/80 w-[140px] h-[92px] !mb-2 !ml-2 rounded-lg shadow-refly-m p-2 [&>svg]:w-full [&>svg]:h-full"
         zoomable={false}
         pannable={false}
         nodeComponent={MiniMapNode}

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
@@ -159,7 +159,7 @@ const SkillResponseNodePreviewComponent = ({ node, resultId }: SkillResponseNode
 
   useEffect(() => {
     const skillName = actionMeta?.name || 'commonQnA';
-    if (result?.status !== 'executing') return;
+    if (result?.status !== 'executing' && result?.status !== 'waiting') return;
 
     const sortedSteps = sortSteps(steps);
 

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/preview-chat-input.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/preview-chat-input.tsx
@@ -1,7 +1,9 @@
+import { Typography } from 'antd';
 import { IContextItem } from '@refly/common-types';
 import { PreviewContextManager } from './preview-context-manager';
 import { useMemo, memo } from 'react';
 import { SelectedSkillHeader } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/selected-skill-header';
+const { Paragraph } = Typography;
 
 interface PreviewChatInputProps {
   enabled: boolean;
@@ -47,9 +49,12 @@ const PreviewChatInputComponent = (props: PreviewChatInputProps) => {
         />
       )}
       {contextItems?.length > 0 && <PreviewContextManager contextItems={contextItems} />}
-      <div className="text-base break-all text-refly-text-0 font-semibold leading-[26px]">
+      <Paragraph
+        className="text-base break-all text-refly-text-0 font-semibold leading-[26px] !mb-0"
+        ellipsis={{ rows: 4 }}
+      >
         {query}
-      </div>
+      </Paragraph>
     </div>
   );
 };

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/preview-context-manager.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/preview-context-manager.tsx
@@ -27,7 +27,7 @@ const PreviewContextManagerComponent = (props: PreviewContextManagerProps) => {
   );
 
   return (
-    <div className="pb-2 flex flex-wrap content-start gap-1 w-full">{renderedContextItems}</div>
+    <div className="py-2 flex flex-wrap content-start gap-1 w-full">{renderedContextItems}</div>
   );
 };
 

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/buttons.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/buttons.tsx
@@ -1,16 +1,13 @@
 import { useState, useCallback, memo, useMemo } from 'react';
-import { Button, Tooltip, Popover, Dropdown, Divider } from 'antd';
+import { Button, Tooltip, Dropdown, Divider } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
 import {
   IconAskAI,
   IconSlideshow,
 } from '@refly-packages/ai-workspace-common/components/common/icon';
-import { Download, Search, Touchpad, Mouse, ArrowDown, SideLeft } from 'refly-icons';
-import { NodeSelector } from '../common/node-selector';
-import { useNodePosition } from '@refly-packages/ai-workspace-common/hooks/canvas/use-node-position';
-import { IContextItem } from '@refly/common-types';
-import { useReactFlow } from '@xyflow/react';
+import { Download, Touchpad, Mouse, ArrowDown, SideLeft } from 'refly-icons';
+
 import { HoverCard } from '@refly-packages/ai-workspace-common/components/hover-card';
 import { useHoverCard } from '@refly-packages/ai-workspace-common/hooks/use-hover-card';
 import { useExportCanvasAsImage } from '@refly-packages/ai-workspace-common/hooks/use-export-canvas-as-image';
@@ -87,10 +84,7 @@ export const ToolbarButtons = memo(
   }) => {
     const { t } = useTranslation();
     const { exportCanvasAsImage, isLoading } = useExportCanvasAsImage();
-    const [searchOpen, setSearchOpen] = useState(false);
     const [modeOpen, setModeOpen] = useState(false);
-    const { setNodeCenter } = useNodePosition();
-    const { getNodes } = useReactFlow();
     const { hoverCardEnabled } = useHoverCard();
     const { readonly, canvasId } = useCanvasContext();
     const { sidePanelVisible, setSidePanelVisible } = useCanvasResourcesPanelStoreShallow(
@@ -111,17 +105,6 @@ export const ToolbarButtons = memo(
         setShowSlideshow: state.setShowSlideshow,
         setShowLinearThread: state.setShowLinearThread,
       }));
-
-    const handleNodeSelect = useCallback(
-      (item: IContextItem) => {
-        const nodes = getNodes();
-        const node = nodes.find((n) => n.data?.entityId === item.entityId);
-        if (node) {
-          setNodeCenter(node.id, true);
-        }
-      },
-      [getNodes, setNodeCenter],
-    );
 
     // Memoize static configurations for mode selector
     const modeItems = useMemo(
@@ -217,28 +200,6 @@ export const ToolbarButtons = memo(
 
         <div className="flex items-center">
           {!readonly && <Tooltip title={t('canvas.toolbar.slideshow')}>{slideshowButton}</Tooltip>}
-
-          <Popover
-            open={searchOpen}
-            onOpenChange={setSearchOpen}
-            styles={{ body: { padding: 0, boxShadow: 'none' } }}
-            trigger="click"
-            placement="bottomRight"
-            content={
-              <NodeSelector
-                onSelect={handleNodeSelect}
-                showFooterActions={true}
-                onClickOutside={() => setSearchOpen(false)}
-              />
-            }
-            classNames={{
-              root: 'node-search-popover',
-            }}
-          >
-            <Tooltip title={t('canvas.toolbar.searchNode')}>
-              <Button type="text" icon={<Search size={18} />} />
-            </Tooltip>
-          </Popover>
 
           <Tooltip title={t('canvas.toolbar.exportImage')}>{exportImageButton}</Tooltip>
 

--- a/packages/ai-workspace-common/src/components/sider/layout.tsx
+++ b/packages/ai-workspace-common/src/components/sider/layout.tsx
@@ -402,7 +402,7 @@ const SiderLoggedIn = (props: { source: 'sider' | 'popover' }) => {
         <div className="flex flex-col gap-2 flex-1 overflow-hidden">
           <SiderLogo
             source={source}
-            navigate={source === 'sider' ? (path) => navigate(path) : undefined}
+            navigate={(path) => navigate(path)}
             collapse={collapse}
             setCollapse={setCollapse}
           />

--- a/packages/ai-workspace-common/src/components/sider/sider-logged-out.tsx
+++ b/packages/ai-workspace-common/src/components/sider/sider-logged-out.tsx
@@ -59,7 +59,7 @@ export const SiderLoggedOut = (props: { source: 'sider' | 'popover' }) => {
         <div className="p-4 pt-6">
           <SiderLogo
             source={source}
-            navigate={source === 'sider' ? (path) => navigate(path) : undefined}
+            navigate={(path) => navigate(path)}
             collapse={collapse}
             setCollapse={setCollapse}
           />

--- a/packages/ai-workspace-common/src/hooks/canvas/use-delete-node.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-delete-node.ts
@@ -4,19 +4,18 @@ import { useReactFlow } from '@xyflow/react';
 import { useTranslation } from 'react-i18next';
 import { CanvasNode } from '@refly/canvas-common';
 import DeleteNodeMessageContent from '../../components/message/delete-node-message';
-import { useCanvasResourcesPanelStoreShallow } from '@refly/stores';
+import { useActiveNode } from '@refly/stores';
+import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 
 interface DeleteNodeOptions {
   showMessage?: boolean;
 }
 
 export const useDeleteNode = () => {
+  const { canvasId } = useCanvasContext();
   const { setNodes, setEdges } = useReactFlow();
   const { t } = useTranslation();
-  const { setActiveNode, activeNode } = useCanvasResourcesPanelStoreShallow((state) => ({
-    setActiveNode: state.setActiveNode,
-    activeNode: state.activeNode,
-  }));
+  const { setActiveNode, activeNode } = useActiveNode(canvasId);
 
   const deleteSingleNode = useCallback(
     (node: CanvasNode<any>, options: DeleteNodeOptions = {}) => {

--- a/packages/ai-workspace-common/src/hooks/canvas/use-delete-node.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-delete-node.ts
@@ -61,7 +61,16 @@ export const useDeleteNode = () => {
 
       return true;
     },
-    [setNodes, setEdges, t, activeNode?.id, setActiveNode],
+    [
+      setNodes,
+      setEdges,
+      t,
+      activeNode?.id,
+      setActiveNode,
+      wideScreenVisible,
+      setWideScreenVisible,
+      setParentType,
+    ],
   );
 
   const deleteNodes = useCallback(

--- a/packages/ai-workspace-common/src/hooks/canvas/use-delete-node.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-delete-node.ts
@@ -6,6 +6,7 @@ import { CanvasNode } from '@refly/canvas-common';
 import DeleteNodeMessageContent from '../../components/message/delete-node-message';
 import { useActiveNode } from '@refly/stores';
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
+import { useCanvasResourcesPanelStoreShallow } from '@refly/stores';
 
 interface DeleteNodeOptions {
   showMessage?: boolean;
@@ -16,6 +17,12 @@ export const useDeleteNode = () => {
   const { setNodes, setEdges } = useReactFlow();
   const { t } = useTranslation();
   const { setActiveNode, activeNode } = useActiveNode(canvasId);
+  const { wideScreenVisible, setWideScreenVisible, setParentType } =
+    useCanvasResourcesPanelStoreShallow((state) => ({
+      wideScreenVisible: state.wideScreenVisible,
+      setWideScreenVisible: state.setWideScreenVisible,
+      setParentType: state.setParentType,
+    }));
 
   const deleteSingleNode = useCallback(
     (node: CanvasNode<any>, options: DeleteNodeOptions = {}) => {
@@ -30,6 +37,10 @@ export const useDeleteNode = () => {
       // Clear active node if the deleted node is the active one
       if (activeNode?.id === node.id) {
         setActiveNode(null);
+        if (wideScreenVisible) {
+          setWideScreenVisible(false);
+        }
+        setParentType(null);
       }
 
       if (showMessage) {

--- a/packages/ai-workspace-common/src/hooks/canvas/use-node-preview-control.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-node-preview-control.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from 'react';
 import {
   useCanvasResourcesPanelStoreShallow,
+  useActiveNode,
   useCanvasStore,
   useCanvasStoreShallow,
 } from '@refly/stores';
@@ -49,8 +50,8 @@ export const useNodePreviewControl = ({
     nodePreviews: state.config[canvasId]?.nodePreviews || [],
     canvasInitialized: state.canvasInitialized[canvasId],
   }));
-  const { setActiveNode, setSidePanelVisible } = useCanvasResourcesPanelStoreShallow((state) => ({
-    setActiveNode: state.setActiveNode,
+  const { setActiveNode } = useActiveNode(canvasId);
+  const { setSidePanelVisible } = useCanvasResourcesPanelStoreShallow((state) => ({
     setSidePanelVisible: state.setSidePanelVisible,
   }));
 

--- a/packages/ai-workspace-common/src/hooks/use-update-node-title.tsx
+++ b/packages/ai-workspace-common/src/hooks/use-update-node-title.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useSetNodeDataByEntity } from '@refly-packages/ai-workspace-common/hooks/canvas/use-set-node-data-by-entity';
-import { useCanvasStore, useCanvasStoreShallow } from '@refly/stores';
+import { useActiveNode } from '@refly/stores';
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 import { CanvasNodeType } from '@refly/openapi-schema';
 import { editorEmitter } from '@refly/utils/event-emitter/editor';
@@ -10,23 +10,22 @@ import { useSiderStoreShallow } from '@refly/stores';
 export const useUpdateNodeTitle = () => {
   const { projectId } = useGetProjectCanvasId();
   const { canvasId } = useCanvasContext();
-  const { updateNodePreview } = useCanvasStoreShallow((state) => ({
-    updateNodePreview: state.updateNodePreview,
-  }));
+
   const { sourceList, setSourceList } = useSiderStoreShallow((state) => ({
     sourceList: state.sourceList,
     setSourceList: state.setSourceList,
   }));
 
+  const { activeNode, setActiveNode } = useActiveNode(canvasId);
+
   const setNodeDataByEntity = useSetNodeDataByEntity();
 
   const handleTitleUpdate = useCallback(
     (newTitle: string, entityId: string, nodeId: string, nodeType: CanvasNodeType) => {
-      const latestNodePreviews = useCanvasStore.getState().config[canvasId]?.nodePreviews || [];
-      const preview = latestNodePreviews.find((p) => p?.id === nodeId);
+      const preview = activeNode?.id === nodeId ? activeNode : null;
 
       if (preview) {
-        updateNodePreview(canvasId, {
+        setActiveNode({
           ...preview,
           data: {
             ...preview.data,
@@ -56,7 +55,15 @@ export const useUpdateNodeTitle = () => {
         }
       }
     },
-    [setNodeDataByEntity, updateNodePreview, canvasId, sourceList, setSourceList, projectId],
+    [
+      setNodeDataByEntity,
+      canvasId,
+      sourceList,
+      setSourceList,
+      projectId,
+      activeNode,
+      setActiveNode,
+    ],
   );
 
   return handleTitleUpdate;

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -1093,7 +1093,7 @@ const translations = {
     file: 'File',
   },
   canvas: {
-    emptyText: 'Double-click canvas to open menu or select ',
+    emptyText: 'Double-click canvas to open menu',
     shareNotFound: 'Canvas Not Found',
     shareNotFoundHint:
       "The shared canvas you're trying to access could not be found. It might have been deleted or the link may be incorrect.",

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -142,6 +142,7 @@ const translations = {
     generating: 'Generating...',
     yes: 'Yes',
     no: 'No',
+    sharing: 'Sharing...',
   },
   mode: {
     ask: 'Ask',

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -302,6 +302,7 @@ const translations = {
     generating: '生成中...',
     yes: '是',
     no: '否',
+    sharing: '分享中...',
   },
   mode: {
     ask: '提问',

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -1071,7 +1071,7 @@ const translations = {
     file: '文件',
   },
   canvas: {
-    emptyText: '双击画布打开菜单或选择',
+    emptyText: '双击画布打开菜单',
     shareNotFound: '画布不存在',
     shareNotFoundHint: '你尝试访问的共享画布无法找到。它可能已被删除，或者链接可能有误。',
     frontPageWelcome: '今天我能为您完成什么工作？',

--- a/packages/stores/src/index.ts
+++ b/packages/stores/src/index.ts
@@ -59,6 +59,7 @@ export { useSubscriptionStore, useSubscriptionStoreShallow } from './stores/subs
 export {
   useCanvasResourcesPanelStore,
   useCanvasResourcesPanelStoreShallow,
+  useActiveNode,
   type CanvasResourcesParentType,
 } from './stores/canvas-resources-panel';
 export {

--- a/packages/stores/src/stores/canvas-resources-panel.ts
+++ b/packages/stores/src/stores/canvas-resources-panel.ts
@@ -1,4 +1,5 @@
 import { CanvasNode } from '@refly/canvas-common';
+import { useCallback, useMemo } from 'react';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { useShallow } from 'zustand/react/shallow';
@@ -98,10 +99,14 @@ export const useCanvasResourcesPanelStoreShallow = <T>(
   return useCanvasResourcesPanelStore(useShallow(selector));
 };
 
-// Custom hook to get activeNode for a specific canvas
 export const useActiveNode = (canvasId: string) => {
-  return useCanvasResourcesPanelStoreShallow((state) => ({
-    activeNode: state.activeNodes[canvasId] ?? null,
-    setActiveNode: (node: CanvasNode | null) => state.setActiveNode(canvasId, node),
-  }));
+  const activeNode = useCanvasResourcesPanelStore((state) => state.activeNodes[canvasId] ?? null);
+  const setActiveNodeImpl = useCanvasResourcesPanelStore((state) => state.setActiveNode);
+
+  const setActiveNode = useCallback(
+    (node: CanvasNode | null) => setActiveNodeImpl(canvasId, node),
+    [canvasId, setActiveNodeImpl],
+  );
+
+  return useMemo(() => ({ activeNode, setActiveNode }), [activeNode, setActiveNode]);
 };

--- a/packages/stores/src/stores/canvas-resources-panel.ts
+++ b/packages/stores/src/stores/canvas-resources-panel.ts
@@ -15,7 +15,8 @@ interface CanvasResourcesPanelState {
   showLeftOverview: boolean;
   parentType: CanvasResourcesParentType | null;
   activeTab: CanvasResourcesParentType;
-  activeNode: CanvasNode | null;
+  // Change from single activeNode to map of canvasId to activeNode
+  activeNodes: Record<string, CanvasNode | null>;
   searchKeyword: string;
 
   // Methods
@@ -25,29 +26,32 @@ interface CanvasResourcesPanelState {
   setShowLeftOverview: (show: boolean) => void;
   setParentType: (type: CanvasResourcesParentType | null) => void;
   setActiveTab: (tab: CanvasResourcesParentType) => void;
-  setActiveNode: (node: CanvasNode | null) => void;
+  // Update setActiveNode to accept canvasId parameter
+  setActiveNode: (canvasId: string, node: CanvasNode | null) => void;
+  // Add helper method to get activeNode for a specific canvas
+  getActiveNode: (canvasId: string) => CanvasNode | null;
   setSearchKeyword: (keyword: string) => void;
 
   resetState: () => void;
 }
 
 const DEFAULT_PANEL_WIDTH = 480;
-
 const defaultState = {
-  panelWidth: DEFAULT_PANEL_WIDTH,
-  sidePanelVisible: false,
+  sidePanelVisible: true,
   wideScreenVisible: false,
   showLeftOverview: false,
   parentType: null,
   activeTab: 'stepsRecord' as const,
-  activeNode: null,
+  // Initialize activeNodes as empty object
   searchKeyword: '',
 };
 
 export const useCanvasResourcesPanelStore = create<CanvasResourcesPanelState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       // Default state
+      panelWidth: DEFAULT_PANEL_WIDTH,
+      activeNodes: {},
       ...defaultState,
 
       // Methods
@@ -57,7 +61,19 @@ export const useCanvasResourcesPanelStore = create<CanvasResourcesPanelState>()(
       setShowLeftOverview: (show: boolean) => set({ showLeftOverview: show }),
       setParentType: (type: CanvasResourcesParentType | null) => set({ parentType: type }),
       setActiveTab: (tab: CanvasResourcesParentType) => set({ activeTab: tab }),
-      setActiveNode: (node: CanvasNode | null) => set({ activeNode: node }),
+      // Update setActiveNode to handle canvasId
+      setActiveNode: (canvasId: string, node: CanvasNode | null) =>
+        set((state) => ({
+          activeNodes: {
+            ...state.activeNodes,
+            [canvasId]: node,
+          },
+        })),
+      // Add helper method to get activeNode for a specific canvas
+      getActiveNode: (canvasId: string) => {
+        const state = get();
+        return state.activeNodes[canvasId] ?? null;
+      },
       setSearchKeyword: (keyword: string) => set({ searchKeyword: keyword }),
       resetState: () => set(defaultState),
     }),
@@ -65,7 +81,8 @@ export const useCanvasResourcesPanelStore = create<CanvasResourcesPanelState>()(
       name: 'canvas-resources-panel-storage',
       partialize: (state) => ({
         activeTab: state.activeTab,
-        activeNode: state.activeNode,
+        // Persist activeNodes for all canvases
+        activeNodes: state.activeNodes,
         parentType: state.parentType,
         panelWidth: state.panelWidth,
         sidePanelVisible: state.sidePanelVisible,
@@ -79,4 +96,12 @@ export const useCanvasResourcesPanelStoreShallow = <T>(
   selector: (state: CanvasResourcesPanelState) => T,
 ) => {
   return useCanvasResourcesPanelStore(useShallow(selector));
+};
+
+// Custom hook to get activeNode for a specific canvas
+export const useActiveNode = (canvasId: string) => {
+  return useCanvasResourcesPanelStoreShallow((state) => ({
+    activeNode: state.activeNodes[canvasId] ?? null,
+    setActiveNode: (node: CanvasNode | null) => state.setActiveNode(canvasId, node),
+  }));
 };


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Inline editing of resource titles in the header.
  - Document export options: Markdown, DOCX, PDF.
  - Active resource selection is now scoped per canvas (selection persists per canvas).

- UI/UX
  - Resources header redesigned; Share moved into More menu.
  - Removed node search from top toolbar.
  - Editing exits on outside click in skill response preview.
  - Improved text ellipsis and spacing; MiniMap padding reduced.
  - Empty state simplified; templates grid tightened; page size 2.
  - Clicking logo now navigates from popover mode.
  - Added “Sharing…” status and updated canvas empty hint text.

- Bug Fixes
  - Hovering a selected segmented control retains its selected background.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->