### PR TITLE
Feature/new agent UI

### DIFF
--- a/packages/ai-workspace-common/src/components/pilot/nosession.tsx
+++ b/packages/ai-workspace-common/src/components/pilot/nosession.tsx
@@ -1,20 +1,27 @@
 import { memo, useCallback, useMemo, useState } from 'react';
 // import { useTranslation } from 'react-i18next';
 import cn from 'classnames';
-import { useChatStoreShallow, useFrontPageStoreShallow, useUserStoreShallow } from '@refly/stores';
+import {
+  useChatStoreShallow,
+  useFrontPageStoreShallow,
+  useUserStoreShallow,
+  usePilotStoreShallow,
+} from '@refly/stores';
 import { MediaChatInput } from '@refly-packages/ai-workspace-common/components/canvas/nodes/media/media-input';
 import { ChatModeSelector } from '@refly-packages/ai-workspace-common/components/canvas/front-page/chat-mode-selector';
 import { ChatInput } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/chat-input';
 import { McpSelectorPopover } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/mcp-selector-panel';
-import { Button } from 'antd';
+import { Button, message } from 'antd';
 import { logEvent } from '@refly/telemetry-web';
-import { useCreateCanvas } from '@refly-packages/ai-workspace-common/hooks/canvas/use-create-canvas';
+
 import { ModelSelector } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/chat-actions/model-selector';
 import { Send } from 'refly-icons';
 import { useTranslation } from 'react-i18next';
 import { useAddNode } from '@refly-packages/ai-workspace-common/hooks/canvas/use-add-node';
 import { useInvokeAction } from '@refly-packages/ai-workspace-common/hooks/canvas/use-invoke-action';
 import { genActionResultID } from '@refly/utils/id';
+import { CreatePilotSessionRequest } from '@refly/openapi-schema';
+import getClient from '@refly-packages/ai-workspace-common/requests/proxiedRequest';
 
 /**
  * NoSession
@@ -23,17 +30,12 @@ import { genActionResultID } from '@refly/utils/id';
  */
 export const NoSession = memo(({ canvasId }: { canvasId: string }) => {
   const { t } = useTranslation();
-  const { debouncedCreateCanvas, isCreating } = useCreateCanvas({
-    projectId: undefined,
-    afterCreateSuccess: () => {
-      // When canvas is created successfully, data is already in the store
-      // No need to use localStorage anymore
-    },
-  });
-  const [_isExecuting, setIsExecuting] = useState<boolean>(false);
-  const { query, setQuery } = useFrontPageStoreShallow((state) => ({
-    query: state.query,
+
+  const [isExecuting, setIsExecuting] = useState<boolean>(false);
+  const { query, setQuery, clearCanvasQuery } = useFrontPageStoreShallow((state) => ({
+    query: state.getQuery?.(canvasId) || '',
     setQuery: state.setQuery,
+    clearCanvasQuery: state.clearCanvasQuery,
   }));
   const { chatMode, setChatMode, skillSelectedModel, setSkillSelectedModel } = useChatStoreShallow(
     (state) => ({
@@ -46,9 +48,54 @@ export const NoSession = memo(({ canvasId }: { canvasId: string }) => {
   const userStore = useUserStoreShallow((state) => ({
     isLogin: state.isLogin,
   }));
+  const { setActiveSessionId, setIsPilotOpen } = usePilotStoreShallow((state) => ({
+    setActiveSessionId: state.setActiveSessionId,
+    setIsPilotOpen: state.setIsPilotOpen,
+  }));
   const isPilotActivated = useMemo(() => chatMode === 'agent', [chatMode]);
   const { addNode } = useAddNode();
   const { invokeAction } = useInvokeAction({ source: 'nosession-ask' });
+
+  // Create wrapper function for setting query with canvasId
+  const setCanvasQuery = useCallback(
+    (newQuery: string) => {
+      setQuery?.(newQuery, canvasId);
+    },
+    [setQuery, canvasId],
+  );
+
+  const handleCreatePilotSession = useCallback(
+    async (param: CreatePilotSessionRequest) => {
+      setIsExecuting(true);
+      const { data, error } = await getClient().createPilotSession({
+        body: param,
+      });
+      if (error) {
+        message.error(
+          t('pilot.createPilotSessionFailed', {
+            defaultValue: 'Failed to create pilot session',
+          }),
+        );
+        setIsExecuting(false);
+        return;
+      }
+
+      const sessionId = data?.data?.sessionId;
+      if (sessionId) {
+        setActiveSessionId(sessionId);
+        setIsPilotOpen(true);
+        // clearCanvasQuery?.(canvasId); // Clear canvas query after successful pilot session creation
+      } else {
+        message.error(
+          t('pilot.createPilotSessionFailed', {
+            defaultValue: 'Failed to create pilot session',
+          }),
+        );
+      }
+      setIsExecuting(false);
+    },
+    [t, setActiveSessionId, setIsPilotOpen, canvasId],
+  );
 
   const handleSendMessage = useCallback(() => {
     if (!query?.trim()) return;
@@ -92,23 +139,30 @@ export const NoSession = memo(({ canvasId }: { canvasId: string }) => {
           },
         },
       });
-      setQuery('');
+      clearCanvasQuery?.(canvasId); // Clear canvas query after ask action
       setIsExecuting(false);
-    } else {
-      debouncedCreateCanvas('front-page', {
-        isPilotActivated: chatMode === 'agent',
-        isAsk: chatMode === 'ask',
+    } else if (chatMode === 'agent' && canvasId) {
+      // Create pilot session for agent mode
+      handleCreatePilotSession({
+        targetId: canvasId,
+        targetType: 'canvas',
+        title: query,
+        input: { query },
+        maxEpoch: 3,
+        providerItemId: skillSelectedModel?.providerItemId,
       });
+    } else {
+      setIsExecuting(false);
     }
   }, [
     query,
-    debouncedCreateCanvas,
     chatMode,
     canvasId,
     addNode,
     invokeAction,
     skillSelectedModel,
-    setQuery,
+    //clearCanvasQuery,
+    handleCreatePilotSession,
   ]);
 
   return (
@@ -122,7 +176,7 @@ export const NoSession = memo(({ canvasId }: { canvasId: string }) => {
                   <MediaChatInput
                     readonly={false}
                     query={query}
-                    setQuery={setQuery}
+                    setQuery={setCanvasQuery}
                     showChatModeSelector
                   />
                 </div>
@@ -136,7 +190,7 @@ export const NoSession = memo(({ canvasId }: { canvasId: string }) => {
                       )}
                       readonly={false}
                       query={query}
-                      setQuery={setQuery}
+                      setQuery={setCanvasQuery}
                       handleSendMessage={handleSendMessage}
                       maxRows={6}
                       inputClassName="px-3 pt-5 pb-4 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
@@ -163,8 +217,8 @@ export const NoSession = memo(({ canvasId }: { canvasId: string }) => {
                           type="primary"
                           icon={<Send size={20} />}
                           onClick={handleSendMessage}
-                          disabled={isCreating || !query?.trim()}
-                          loading={isCreating}
+                          disabled={isExecuting || !query?.trim()}
+                          loading={isExecuting}
                         />
                       </div>
                     </div>

--- a/packages/ai-workspace-common/src/components/pilot/session-container.tsx
+++ b/packages/ai-workspace-common/src/components/pilot/session-container.tsx
@@ -105,7 +105,7 @@ export const SessionContainer = memo(
       setActiveSessionId: state.setActiveSessionId,
     }));
     const { query } = useFrontPageStoreShallow((state) => ({
-      query: state.query,
+      query: state.getQuery?.(canvasId) || '',
     }));
 
     const handleSessionClick = useCallback(

--- a/packages/stores/src/stores/front-page.ts
+++ b/packages/stores/src/stores/front-page.ts
@@ -15,11 +15,14 @@ export interface MediaQueryData {
 
 interface FrontPageState {
   query: string;
+  canvasQueries: Record<string, string>; // Map canvasId to query
   selectedSkill: Skill | null;
   tplConfig: SkillTemplateConfig | null;
   runtimeConfig: SkillRuntimeConfig | null;
   mediaQueryData: MediaQueryData | null;
-  setQuery?: (query: string) => void;
+  setQuery?: (query: string, canvasId?: string) => void;
+  getQuery?: (canvasId?: string) => string;
+  clearCanvasQuery?: (canvasId: string) => void;
   setSelectedSkill?: (skill: Skill | null) => void;
   setTplConfig?: (tplConfig: SkillTemplateConfig | null) => void;
   setRuntimeConfig?: (runtimeConfig: SkillRuntimeConfig | null) => void;
@@ -29,15 +32,42 @@ interface FrontPageState {
 
 const initialState: FrontPageState = {
   query: '',
+  canvasQueries: {},
   selectedSkill: null,
   tplConfig: null,
   runtimeConfig: { disableLinkParsing: true, enabledKnowledgeBase: false },
   mediaQueryData: null,
 };
 
-export const useFrontPageStore = create<FrontPageState>((set) => ({
+export const useFrontPageStore = create<FrontPageState>((set, get) => ({
   ...initialState,
-  setQuery: (query) => set({ query }),
+  setQuery: (query, canvasId) => {
+    if (canvasId) {
+      // Set query for specific canvas
+      set((state) => ({
+        canvasQueries: {
+          ...state.canvasQueries,
+          [canvasId]: query,
+        },
+      }));
+    } else {
+      // Set global query (for backward compatibility)
+      set({ query });
+    }
+  },
+  getQuery: (canvasId) => {
+    const state = get();
+    if (canvasId) {
+      return state.canvasQueries[canvasId] || '';
+    }
+    return state.query;
+  },
+  clearCanvasQuery: (canvasId) => {
+    set((state) => {
+      const { [canvasId]: _, ...remainingQueries } = state.canvasQueries;
+      return { canvasQueries: remainingQueries };
+    });
+  },
   setSelectedSkill: (selectedSkill) => set({ selectedSkill }),
   setTplConfig: (tplConfig) => {
     set({ tplConfig });


### PR DESCRIPTION
# Summary


This pull request enhances the handling of chat queries in the pilot "NoSession" experience by introducing per-canvas query management, improving the user experience for multi-canvas workflows. The changes include refactoring state management in the `front-page` store to support queries scoped to individual canvases, updating the `NoSession` component to use these new APIs, and improving the logic for sending messages and creating pilot sessions.

**Per-canvas query management:**

* Added a `canvasQueries` map and new methods (`setQuery`, `getQuery`, `clearCanvasQuery`) to the `front-page` store, enabling queries to be stored and retrieved on a per-canvas basis instead of globally. [[1]](diffhunk://#diff-12f287e8c540d62413765e257919dbd40e3bc264d0d24fa66ea3bd87490d77bdR18-R25) [[2]](diffhunk://#diff-12f287e8c540d62413765e257919dbd40e3bc264d0d24fa66ea3bd87490d77bdR35-R70)
* Updated usages in `NoSession` and `SessionContainer` components to utilize the new per-canvas query APIs, ensuring each canvas maintains its own chat input state. [[1]](diffhunk://#diff-e43460e53a6292047e7dd939a95541269b5265098d570e9b564e2c79387cbc4bL23-R38) [[2]](diffhunk://#diff-9f382bad7647e9fed758768b25f9a11a7dd7464b822f057c395ed5a312bf6144L108-R108)

**Refactoring and feature improvements in `NoSession`:**

* Replaced the previous canvas creation logic with new flows for both "ask" and "agent" chat modes: "ask" now invokes an action and adds a node, while "agent" initiates a pilot session, both using the per-canvas query state. [[1]](diffhunk://#diff-e43460e53a6292047e7dd939a95541269b5265098d570e9b564e2c79387cbc4bR51-R99) [[2]](diffhunk://#diff-e43460e53a6292047e7dd939a95541269b5265098d570e9b564e2c79387cbc4bL55-R167)
* Updated UI bindings to use the new `setCanvasQuery` function, ensuring chat input components interact with the correct per-canvas query. [[1]](diffhunk://#diff-e43460e53a6292047e7dd939a95541269b5265098d570e9b564e2c79387cbc4bL72-R179) [[2]](diffhunk://#diff-e43460e53a6292047e7dd939a95541269b5265098d570e9b564e2c79387cbc4bL86-R193)
* Improved execution state handling by introducing an `isExecuting` flag, replacing the previous `isCreating` logic for better feedback on async operations.

These changes collectively make the pilot chat experience more robust, especially when working with multiple canvases simultaneously.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
