### PR TITLE
refactor(canvas): simplify SkillResponseNodePreview component and rem…

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, memo, useCallback, useRef } from 'react';
+import { useEffect, useState, useMemo, memo, useCallback } from 'react';
 import { Button, Divider, Result, Skeleton, Spin } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { useActionResultStoreShallow } from '@refly/stores';
@@ -57,33 +57,11 @@ const SkillResponseNodePreviewComponent = ({ node, resultId }: SkillResponseNode
   const { t } = useTranslation();
   const [editMode, setEditMode] = useState(false);
   const [loading, setLoading] = useState(!result);
-  const editChatInputRef = useRef<HTMLDivElement>(null);
 
   const shareId = node.data?.metadata?.shareId;
   const { data: shareData } = useFetchShareData(shareId);
 
   const [statusText, setStatusText] = useState('');
-
-  // Handle click outside to close edit mode
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        editMode &&
-        editChatInputRef.current &&
-        !editChatInputRef.current.contains(event.target as Node)
-      ) {
-        setEditMode(false);
-      }
-    };
-
-    if (editMode) {
-      document.addEventListener('mousedown', handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [editMode]);
 
   useEffect(() => {
     if (shareData && !result) {
@@ -182,6 +160,7 @@ const SkillResponseNodePreviewComponent = ({ node, resultId }: SkillResponseNode
   useEffect(() => {
     const skillName = actionMeta?.name || 'commonQnA';
     if (result?.status !== 'executing' && result?.status !== 'waiting') return;
+    setEditMode(false);
 
     const sortedSteps = sortSteps(steps);
 
@@ -272,28 +251,26 @@ const SkillResponseNodePreviewComponent = ({ node, resultId }: SkillResponseNode
     <div className="flex flex-col gap-4 h-full max-w-[1024px] mx-auto overflow-hidden">
       {title && (
         <div className="px-4 pt-4">
-          <div ref={editChatInputRef}>
-            <EditChatInput
-              enabled={editMode}
-              resultId={resultId}
-              version={version}
-              contextItems={contextItems}
-              query={title}
-              actionMeta={actionMeta}
-              modelInfo={
-                modelInfo ?? {
-                  name: '',
-                  label: '',
-                  provider: '',
-                  contextLimit: 0,
-                  maxOutput: 0,
-                }
+          <EditChatInput
+            enabled={editMode}
+            resultId={resultId}
+            version={version}
+            contextItems={contextItems}
+            query={title}
+            actionMeta={actionMeta}
+            modelInfo={
+              modelInfo ?? {
+                name: '',
+                label: '',
+                provider: '',
+                contextLimit: 0,
+                maxOutput: 0,
               }
-              setEditMode={setEditMode}
-              tplConfig={tplConfig}
-              runtimeConfig={runtimeConfig}
-            />
-          </div>
+            }
+            setEditMode={setEditMode}
+            tplConfig={tplConfig}
+            runtimeConfig={runtimeConfig}
+          />
           <PreviewChatInput
             enabled={!editMode}
             readonly={readonly}


### PR DESCRIPTION
…ove click outside handler

- Removed the click outside handler for managing edit mode state to streamline functionality.
- Updated the component structure by directly rendering EditChatInput without unnecessary wrapping.
- Ensured proper state management and utilized optional chaining and nullish coalescing for safer property access.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
