### PR TITLE
fix(api): correct import path for pilot service

### DIFF
--- a/apps/api/src/modules/pilot/pilot-engine.ts
+++ b/apps/api/src/modules/pilot/pilot-engine.ts
@@ -11,7 +11,7 @@ import {
   PilotStepRawOutput,
   getRecommendedStageForEpoch,
 } from './prompt';
-import { MAX_EPOCH, MAX_STEPS_PER_EPOCH } from 'src/modules/pilot/pilot.service';
+import { MAX_EPOCH, MAX_STEPS_PER_EPOCH } from './pilot.service';
 
 export class PilotEngine {
   private logger = new Logger(PilotEngine.name);


### PR DESCRIPTION
# Summary

- Updated the import statement for `MAX_EPOCH` and `MAX_STEPS_PER_EPOCH` to use the correct relative path, enhancing code clarity and maintainability.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
