### PR TITLE
style: enhance component hover effects and improve context update logic

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/launchpad/context-manager/context-item.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/context-manager/context-item.tsx
@@ -117,7 +117,7 @@ export const ContextItem = ({
           <Close
             size={14}
             color={isLimit ? 'var(--refly-func-danger-default)' : 'var(--refly-text-1)'}
-            className="cursor-pointer flex-shrink-0"
+            className="cursor-pointer flex-shrink-0 hover:text-refly-text-0"
             onClick={(e) => {
               e.stopPropagation();
               onRemove?.(item);

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/preview-chat-input.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/preview-chat-input.tsx
@@ -31,7 +31,7 @@ const PreviewChatInputComponent = (props: PreviewChatInputProps) => {
 
   return (
     <div
-      className="rounded-lg bg-refly-bg-control-z0 p-2"
+      className="rounded-lg bg-refly-bg-control-z0 p-2 hover:bg-refly-tertiary-hover cursor-pointer"
       onClick={() => {
         if (!readonly) {
           setEditMode(true);

--- a/packages/ai-workspace-common/src/hooks/canvas/use-debounced-context-update.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-debounced-context-update.ts
@@ -5,6 +5,7 @@ import { CanvasNodeType } from '@refly/openapi-schema';
 import { Edge, useReactFlow } from '@xyflow/react';
 import { CanvasNode, ResponseNodeMeta } from '@refly/canvas-common';
 import { useFindThreadHistory } from './use-find-thread-history';
+import { genUniqueId } from '@refly/utils/id';
 
 interface UseContextUpdateByEdgesProps {
   readonly: boolean;
@@ -26,7 +27,15 @@ export const useContextUpdateByEdges = ({
   nodeId,
   updateNodeData,
 }: UseContextUpdateByEdgesProps) => {
-  const { getNodes } = useReactFlow();
+  const { getNodes, addEdges } = useReactFlow();
+
+  // Helper function to get child nodes of a group (excluding skill and group types)
+  const getGroupChildNodes = useCallback((groupId: string, allNodes: CanvasNode<any>[]) => {
+    return allNodes.filter((node) => {
+      const isInGroup = node.parentId === groupId;
+      return isInGroup && !['skill', 'group', 'mediaSkill'].includes(node.type);
+    });
+  }, []);
 
   const updateContextItemsByEdges = useCallback(
     (contextItems: IContextItem[], edges: Edge[]) => {
@@ -37,36 +46,64 @@ export const useContextUpdateByEdges = ({
 
       const nodes = getNodes() as CanvasNode<any>[];
 
-      // 克隆现有的所有 context items，保留所有已有项
+      // Clone existing context items to preserve all existing items
       const updatedContextItems = [...contextItems];
 
-      // 创建一个已存在的 entityId 集合，用于快速查找
+      // Create a set of existing entityIds for quick lookup
       const existingEntityIds = new Set(contextItems.map((item) => item.entityId));
+      const edgesToAdd = [];
 
-      // 为每个连线检查并添加新的 context item（如果不存在）
+      // Check each edge and add new context items if they don't exist
       for (const edge of currentEdges) {
         const sourceNode = nodes.find((node) => node.id === edge.source);
-        if (!sourceNode?.data?.entityId || ['skill', 'group'].includes(sourceNode?.type)) continue;
+        if (!sourceNode?.data?.entityId || ['skill', 'mediaSkill'].includes(sourceNode?.type))
+          continue;
 
         const entityId = sourceNode.data.entityId;
 
-        // 如果 entityId 已存在于现有 items 中，跳过
+        // If entityId already exists in current items, skip
         if (existingEntityIds.has(entityId)) continue;
 
-        // 添加新的 context item
-        updatedContextItems.push({
-          entityId,
-          type: sourceNode.type as CanvasNodeType,
-          title: sourceNode.data.title || '',
-        });
-      }
+        // Special handling for group type nodes
+        if (sourceNode.type === 'group') {
+          const childNodes = getGroupChildNodes(sourceNode.id, nodes);
 
-      // 只有在真正添加了新项目时才更新
-      if (updatedContextItems.length > contextItems.length) {
+          // Add child nodes to context items
+          for (const childNode of childNodes) {
+            if (childNode.data?.entityId && !existingEntityIds.has(childNode.data.entityId)) {
+              updatedContextItems.push({
+                entityId: childNode.data.entityId,
+                type: childNode.type as CanvasNodeType,
+                title: childNode.data.title || '',
+              });
+
+              edgesToAdd.push({
+                id: `edge-${genUniqueId()}`,
+                source: childNode.id,
+                target: nodeId,
+                type: 'default',
+              });
+              // Update existing entityIds set to avoid duplicates
+              existingEntityIds.add(childNode.data.entityId);
+            }
+          }
+        } else {
+          updatedContextItems.push({
+            entityId,
+            type: sourceNode.type as CanvasNodeType,
+            title: sourceNode.data.title || '',
+          });
+        }
+      }
+      // Only update if the context items have actually changed
+      if (updatedContextItems.length !== contextItems.length) {
+        if (edgesToAdd.length > 0) {
+          addEdges(edgesToAdd);
+        }
         updateNodeData({ metadata: { contextItems: updatedContextItems } });
       }
     },
-    [readonly, nodeId, getNodes, updateNodeData],
+    [readonly, nodeId, getNodes, updateNodeData, getGroupChildNodes],
   );
 
   const debouncedUpdateContextItems = useDebouncedCallback(


### PR DESCRIPTION
- Updated hover styles for `Close` and `PreviewChatInputComponent` to improve user interaction feedback.
- Refactored context update logic in `useContextUpdateByEdges` to handle group type nodes and ensure proper addition of context items.
- Added a helper function to filter child nodes of groups for better maintainability and performance.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
