### PR TITLE
fix: enhance pilot engine and summary node locale

### DIFF
--- a/apps/api/src/modules/pilot/pilot-engine.ts
+++ b/apps/api/src/modules/pilot/pilot-engine.ts
@@ -69,7 +69,7 @@ export class PilotEngine {
         this.logger.log(`Generated research plan: ${JSON.stringify(steps)}`);
 
         if (recommendedStage === 'creation') {
-          return (
+          const creationSteps =
             steps
               .filter(
                 (step) =>
@@ -78,8 +78,12 @@ export class PilotEngine {
                   step.skillName === 'generateMedia' ||
                   step.skillName === 'commonQnA',
               )
-              .slice(0, 1) || []
-          );
+              .slice(0, 1) || [];
+          return creationSteps?.length > 0
+            ? creationSteps
+            : steps?.length > 0
+              ? [{ ...steps?.[0], skillName: 'commonQnA' }]
+              : [];
         } else {
           return (
             steps

--- a/apps/api/src/modules/pilot/prompt/summary.ts
+++ b/apps/api/src/modules/pilot/prompt/summary.ts
@@ -5,8 +5,9 @@ export function buildSummarySkillInput(params: {
   currentEpoch: number;
   maxEpoch: number;
   subtaskTitles?: string[];
+  locale?: string;
 }): SkillInput {
-  const { userQuestion, currentEpoch, maxEpoch, subtaskTitles = [] } = params;
+  const { userQuestion, currentEpoch, maxEpoch, subtaskTitles = [], locale = 'en-US' } = params;
 
   const subtaskListSection = subtaskTitles?.length
     ? `\nCompleted subtasks: ${subtaskTitles.map((t, i) => `${i + 1}. ${t}`).join(', ')}`
@@ -16,53 +17,76 @@ export function buildSummarySkillInput(params: {
 
   let stageFocus = '';
   if (progressRatio < 0.5) {
-    stageFocus = `**EARLY STAGE**: Focus on answer completeness assessment for "${userQuestion}"`;
+    stageFocus = '**EARLY STAGE**: Focus on answer completeness assessment';
   } else if (progressRatio < 0.75) {
-    stageFocus = `**MID STAGE**: Synthesize findings and evaluate answer reliability for "${userQuestion}"`;
+    stageFocus = '**MID STAGE**: Synthesize findings and evaluate answer reliability';
   } else {
-    stageFocus = `**LATE STAGE**: Finalize answer quality and prepare comprehensive progress report for "${userQuestion}"`;
+    stageFocus =
+      '**LATE STAGE**: Finalize answer quality and prepare comprehensive progress report';
   }
 
-  const query = `SUMMARY TASK: Context organization and direct answer generation
+  const query = `# SUMMARY TASK: Context Organization and Direct Answer Generation
 
-**TARGET**: "${userQuestion}"
-**PROGRESS**: Epoch ${currentEpoch}/${maxEpoch} (${Math.round(progressRatio * 100)}% complete)${subtaskListSection}
-${stageFocus}
+## TASK OVERVIEW
+**Target Question**: "${userQuestion}"
+**Progress**: Epoch ${currentEpoch}/${maxEpoch} (${Math.round(progressRatio * 100)}% complete)${subtaskListSection}
+**Language**: ${locale}
+**Current Stage**: ${stageFocus}
 
-## WORKFLOW
+## EXECUTION WORKFLOW
 
-**PHASE 1: CONTEXT SYNTHESIS**
-- Gather and organize all available information from sources
+### [Localized Phase 1 Title]
+**Objective**: Synthesize and organize all available information
+**Actions**:
+- Collect and categorize information from all sources
 - Identify key themes, patterns, and relationships
-- Structure information into logical categories
-- Prepare comprehensive context foundation
+- Create logical information structure
+- Establish comprehensive context foundation
 
-**PHASE 2: ANSWER GENERATION**
-Generate complete answer to: "${userQuestion}"
-- Provide comprehensive coverage of all question aspects
-- Structure with clear sections and logical flow
-- Include relevant examples, data points, and evidence
-- Address potential counterarguments or alternatives
-- Use clear, professional language
-- Include source citations [doc:ID], [res:ID], [artifact:ID]
-- Integrate appropriate charts, diagrams, or visual elements where beneficial
-- Ensure visual elements enhance understanding without overwhelming text content
+### [Localized Phase 2 Title]
+**Objective**: Generate complete and comprehensive answer
+**Requirements**:
+- Address all aspects of the target question
+- Use clear, logical structure with proper sections
+- Include relevant examples, data, and evidence
+- Consider counterarguments and alternatives
+- Use professional, clear language
+- Include proper citations: [doc:ID], [res:ID], [artifact:ID]
+- Add visual elements (charts, diagrams) where beneficial
+- Ensure visual elements enhance rather than overwhelm content
 
-**PHASE 3: QUALITY EVALUATION**
-Assess answer quality on two dimensions:
-- **Completeness**: Percentage of "${userQuestion}" answered
-- **Evidence Quality**: Reliability of supporting information
+### [Localized Phase 3 Title]
+**Objective**: Evaluate answer quality and reliability
+**Assessment Criteria**:
+- **Completeness**: X% - [Detailed explanation of coverage]
+- **Evidence Quality**: [Strong/Mixed/Weak] - [Reasoning for rating]
 
-## OUTPUT FORMAT
+### [Localized Phase 4 Title]
+**Objective**: Fill information gaps and ensure comprehensiveness
+**Actions**:
+- Identify missing or incomplete information
+- Attempt to fill gaps using available sources
+- Highlight areas where information is unavailable
+- Suggest alternative approaches for missing data
+- Ensure maximum comprehensiveness with available resources
 
-### COMPLETE ANSWER
-[Structured response to "${userQuestion}" with evidence citations]
+## OUTPUT REQUIREMENTS
 
-### QUALITY ASSESSMENT
-- **Completeness**: X% - [Explanation]
-- **Evidence Quality**: [Strong/Mixed/Weak] - [Reasoning]
+### [Localized Answer Title]
+[Provide structured response to the target question with proper evidence citations]
 
-**CONSTRAINT**: Maintain absolute focus on "${userQuestion}". Use commonQnA for synthesis.`;
+### [Localized Assessment Title]
+- **Completeness**: X% - [Explanation of what was covered and what was missed]
+- **Evidence Quality**: [Strong/Mixed/Weak] - [Detailed reasoning for the rating]
+
+## CONSTRAINTS & GUIDELINES
+- **Focus**: Maintain absolute focus on the target question
+- **Synthesis**: Use commonQnA for information synthesis
+- **Language**: All output must be in ${locale} language
+- **Localization**: Replace all placeholder titles with properly localized versions in ${locale}
+- **Structure**: Follow the exact workflow phases and output format specified above
+
+**Note**: Ensure all titles, including workflow phase titles and output format titles, are properly localized according to the ${locale} language specification.`;
 
   return { query };
 }


### PR DESCRIPTION
- Improved the filtering logic in PilotEngine to return creation steps more efficiently, utilizing optional chaining and nullish coalescing for better handling of undefined values.
- Added a new private method in PilotService to generate a localized summary title based on user locale preferences, ensuring fallback to English when necessary.
- Updated the buildSummarySkillInput function to include locale as a parameter, allowing for localized output formatting and improved clarity in generated summaries.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Localized summary titles and labels across subtasks and summaries, based on user language settings (defaulting to English).
  - Consistent use of localized titles in action results, steps, and canvas nodes.
  - Summary generation is now locale-aware with a standardized, clearer section structure (phases, workflow, output requirements).
  - Summary inputs include locale for more accurate, language-appropriate output.

- Bug Fixes
  - Improved reliability of creation outputs by providing a sensible fallback when no creation-specific steps are detected, reducing empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->