### PR TITLE
feat(canvas): enhance CustomEdge component with start node connection…

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/edges/custom-edge.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/edges/custom-edge.tsx
@@ -22,8 +22,19 @@ const DeleteButton = ({ handleDelete }: { handleDelete: (e: React.MouseEvent) =>
 };
 
 export const CustomEdge = memo(
-  ({ sourceX, sourceY, targetX, targetY, selected, data, id }: EdgeProps) => {
+  ({ sourceX, sourceY, targetX, targetY, selected, data, id, source, target }: EdgeProps) => {
     const edgeStyles = useEdgeStyles();
+    const { getNode } = useReactFlow();
+
+    // Check if the edge is connected to a start node
+    const isConnectedToStartNode = useCallback(() => {
+      if (!source || !target) return false;
+
+      const sourceNode = getNode(source);
+      const targetNode = getNode(target);
+
+      return sourceNode?.type === 'start' || targetNode?.type === 'start';
+    }, [source, target, getNode]);
 
     const [edgePath, labelX, labelY] = getBezierPath({
       sourceX,
@@ -170,7 +181,8 @@ export const CustomEdge = memo(
           </foreignObject>
         ) : null}
 
-        {selected && (
+        {/* Only show delete button if selected and not connected to start node */}
+        {selected && !isConnectedToStartNode() && (
           <foreignObject
             width={20}
             height={20}


### PR DESCRIPTION
… handling

- Added logic to check if the edge is connected to a start node, preventing the display of the delete button in such cases.
- Utilized useCallback for performance optimization and ensured safe property access with optional chaining.
- Maintained consistent styling with Tailwind CSS throughout the component.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
