### PR TITLE
fix: remove variable extraction test page

### DIFF
--- a/packages/web-core/src/components/landing-page-partials/Header.tsx
+++ b/packages/web-core/src/components/landing-page-partials/Header.tsx
@@ -100,10 +100,6 @@ function Header() {
       value: 'docs',
     },
     {
-      label: '测试页面',
-      value: 'test',
-    },
-    {
       label: (
         <Dropdown menu={{ items: feedbackItems }} placement="bottom">
           <div className="flex cursor-pointer items-center gap-1">
@@ -118,11 +114,7 @@ function Header() {
 
   useEffect(() => {
     const path = location.pathname.split('/')[1];
-    if (path === 'test') {
-      setValue('test');
-    } else {
-      setValue(path || 'product');
-    }
+    setValue(path || 'product');
   }, [location.pathname]);
 
   // Add effect to check for openLogin parameter
@@ -157,9 +149,6 @@ function Header() {
                     break;
                   case 'pricing':
                     navigate('/pricing');
-                    break;
-                  case 'test':
-                    navigate('/test/variable-extraction');
                     break;
                 }
               }}

--- a/packages/web-core/src/pages/home-new/index.tsx
+++ b/packages/web-core/src/pages/home-new/index.tsx
@@ -12,14 +12,12 @@ import { TemplateList } from '@refly-packages/ai-workspace-common/components/can
 import { useAuthStoreShallow } from '@refly/stores';
 import { canvasTemplateEnabled } from '@refly/ui-kit';
 import Header from '../../components/landing-page-partials/Header';
-import { useNavigate } from 'react-router-dom';
 
 import cn from 'classnames';
 import { Title } from '@refly-packages/ai-workspace-common/components/canvas/front-page/title';
 
 const UnsignedFrontPage = memo(() => {
   const { t, i18n } = useTranslation();
-  const navigate = useNavigate();
   const [form] = Form.useForm();
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
   const templateLanguage = i18n.language;
@@ -160,21 +158,6 @@ const UnsignedFrontPage = memo(() => {
                     handleAbort={() => {}}
                   />
                 </div>
-              </div>
-            </div>
-
-            {/* Test Page Link */}
-            <div className="mt-8 text-center">
-              <div className="inline-flex items-center gap-2 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
-                <span className="text-sm text-blue-700 dark:text-blue-300">开发者测试工具</span>
-                <Button
-                  type="link"
-                  size="small"
-                  className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-200"
-                  onClick={() => navigate('/test/variable-extraction')}
-                >
-                  变量提取接口测试 →
-                </Button>
               </div>
             </div>
 


### PR DESCRIPTION
…andling

- Deleted the 'test' page option from the header dropdown and removed associated navigation logic.
- Simplified pathname handling in the useEffect to set the default value based on the current path.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
