### PR TITLE
refactor(canvas-resources): optimize activeNode handling in useEffect

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/index.tsx
@@ -36,28 +36,15 @@ export const CanvasResources = memo(
     }, [canvasId, resetState]);
 
     useEffect(() => {
-      if (activeNode) {
-        if (activeNode.type === 'resource') {
-          setParentType('myUpload');
-        }
-        if (['skillResponse'].includes(activeNode.type)) {
-          setParentType('stepsRecord');
-        }
-        if (
-          ['document', 'codeArtifact', 'website', 'video', 'audio'].includes(
-            activeNode.type as CanvasNodeType,
-          )
-        ) {
-          setParentType('resultsRecord');
-        }
-        if (activeNode.type === 'image' && !!activeNode.data?.metadata?.resultId) {
-          setParentType(activeNode.data?.metadata?.resultId ? 'resultsRecord' : 'myUpload');
-        }
-        if (activeNode.type === 'start') {
-          setParentType(null);
-        }
+      if (!activeNode) {
+        setParentType(null);
+        return;
       }
-      if (activeNode.type === 'skillResponse') {
+
+      if (activeNode.type === 'resource') {
+        setParentType('myUpload');
+      }
+      if (['skillResponse'].includes(activeNode.type)) {
         setParentType('stepsRecord');
       }
       if (['document', 'codeArtifact', 'website'].includes(activeNode.type as CanvasNodeType)) {
@@ -67,6 +54,9 @@ export const CanvasResources = memo(
         // Check if media has resultId to determine if it's from results or my upload
         const hasResultId = !!activeNode.data?.metadata?.resultId;
         setParentType(hasResultId ? 'resultsRecord' : 'myUpload');
+      }
+      if (activeNode.type === 'start') {
+        setParentType(null);
       }
     }, [activeNode]);
 


### PR DESCRIPTION
- Simplified the logic in the useEffect for setting parentType based on activeNode, improving readability and performance.
- Added early return for null activeNode to prevent unnecessary checks.
- Ensured adherence to code quality standards, including the use of optional chaining and nullish coalescing for safer property access.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
