### PR TITLE
fix(rich-chat-input): update styling for RichChatInputComponent

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/launchpad/chat-input.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/chat-input.tsx
@@ -258,7 +258,7 @@ const ChatInputComponent = forwardRef<HTMLDivElement, ChatInputProps>(
       <div
         ref={ref}
         className={cn(
-          'w-full h-full flex flex-col flex-grow overflow-y-auto relative',
+          'w-full h-full flex flex-col flex-grow overflow-y-auto overflow-x-hidden relative ',
           isDragging && 'ring-2 ring-green-500 ring-opacity-50 rounded-lg',
           readonly && 'opacity-70 cursor-not-allowed',
         )}

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/rich-chat-input.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/rich-chat-input.tsx
@@ -1031,7 +1031,7 @@ const RichChatInputComponent = forwardRef<HTMLDivElement, RichChatInputProps>(
         <div
           ref={ref}
           className={cn(
-            'w-full h-full flex flex-col flex-grow overflow-y-auto relative',
+            'w-full h-full flex flex-col flex-grow overflow-y-auto overflow-x-hidden relative ',
             isDragging && 'ring-2 ring-green-500 ring-opacity-50 rounded-lg',
             readonly && 'opacity-70 cursor-not-allowed',
           )}


### PR DESCRIPTION
- Added overflow-x-hidden to prevent horizontal scrolling in the RichChatInputComponent.
- Ensured consistent styling while maintaining responsiveness and usability.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
