### PR TITLE
refactor(rich-chat-input): improve node icon rendering logic

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/launchpad/rich-chat-input.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/rich-chat-input.tsx
@@ -16,7 +16,10 @@ import { useRealtimeCanvasData } from '@refly-packages/ai-workspace-common/hooks
 import { useGetWorkflowVariables } from '@refly-packages/ai-workspace-common/queries';
 import type { IContextItem } from '@refly/common-types';
 import type { CanvasNodeType, ResourceType, ResourceMeta } from '@refly/openapi-schema';
-import { getStartNodeIcon } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/variable/getVariableIcon';
+import {
+  getStartNodeIcon,
+  getVariableIcon,
+} from '@refly-packages/ai-workspace-common/components/canvas/launchpad/variable/getVariableIcon';
 import { mentionStyles } from '@refly-packages/ai-workspace-common/components/canvas/launchpad/variable/mention-style';
 import { createRoot } from 'react-dom/client';
 import { useStore } from '@xyflow/react';
@@ -455,7 +458,10 @@ const MentionList = ({ items, command }: { items: MentionItem[]; command: any })
 
 // Helper function to render NodeIcon consistently
 const renderNodeIcon = (source: string, variableType: string, nodeAttrs: any) => {
-  if (source === 'stepRecord') {
+  if (source === 'startNode') {
+    // For startNode variables, use getStartNodeIcon to render variable type icons
+    return getVariableIcon(variableType);
+  } else if (source === 'stepRecord') {
     return React.createElement(NodeIcon, {
       type: 'skillResponse' as CanvasNodeType,
       small: true,


### PR DESCRIPTION
- Updated renderNodeIcon function to utilize getVariableIcon for startNode variables, enhancing consistency in icon rendering.
- Imported getVariableIcon alongside getStartNodeIcon for better modularity in icon management.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Rich Chat Input launchpad now shows dedicated variable icons for start nodes, improving clarity when scanning items.
  - Consistent icon handling for steps, results, and uploads maintained.
- Style
  - Unified icon rendering across list and icon views for start nodes, ensuring a consistent visual language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->