### PR TITLE
fix(preview-chat-input): ensure query is returned as a string

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/preview-chat-input.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/preview-chat-input.tsx
@@ -31,7 +31,7 @@ const PreviewChatInputComponent = (props: PreviewChatInputProps) => {
     if (!query) return null;
 
     // Return the original query text without variable parsing
-    return query;
+    return String(query);
   }, [query]);
 
   if (!enabled) {


### PR DESCRIPTION
- Updated the return value of the query to ensure it is always a string, preventing potential type issues.
- Maintained consistent use of optional chaining and nullish coalescing for safer property access.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
