### PR TITLE
feat/Add a new workflow initialization method to start running subtree nodes from specified start nodes

### DIFF
--- a/apps/api/src/modules/workflow/workflow.controller.ts
+++ b/apps/api/src/modules/workflow/workflow.controller.ts
@@ -26,7 +26,7 @@ export class WorkflowController {
       user,
       request.canvasId,
       request.newCanvasId,
-      request.startNodes,
+      request.startNodes ? request.startNodes : [],
     );
 
     return buildSuccessResponse({ workflowExecutionId: executionId });

--- a/apps/api/src/modules/workflow/workflow.controller.ts
+++ b/apps/api/src/modules/workflow/workflow.controller.ts
@@ -20,6 +20,7 @@ export class WorkflowController {
       user,
       request.canvasId,
       request.newCanvasId,
+      request.startNodes,
     );
 
     return buildSuccessResponse({ workflowExecutionId: executionId });

--- a/apps/api/src/modules/workflow/workflow.service.ts
+++ b/apps/api/src/modules/workflow/workflow.service.ts
@@ -119,6 +119,7 @@ export class WorkflowService {
     user: User,
     canvasId: string,
     newCanvasId?: string,
+    startNodes?: string[],
   ): Promise<string> {
     try {
       // Add a new execution mode: if a new canvas ID is provided, create a new canvas and add nodes to it one by one as they are executed.
@@ -190,17 +191,38 @@ export class WorkflowService {
         }
       }
 
-      // Find start nodes (nodes without parents)
-      const startNodes: string[] = [];
-      for (const [nodeId, parents] of parentMap) {
-        if (parents.length === 0) {
-          startNodes.push(nodeId);
+      if (startNodes.length === 0) {
+        for (const [nodeId, parents] of parentMap) {
+          if (parents.length === 0) {
+            startNodes.push(nodeId);
+          }
         }
       }
 
       if (startNodes.length === 0) {
         throw new Error('No start nodes found in workflow');
       }
+
+      // Helper function to find all nodes in the subtree starting from given start nodes
+      const findSubtreeNodes = (startNodeIds: string[]): Set<string> => {
+        const subtreeNodes = new Set<string>();
+        const queue = [...startNodeIds];
+
+        while (queue.length > 0) {
+          const currentNodeId = queue.shift()!;
+          if (!subtreeNodes.has(currentNodeId)) {
+            subtreeNodes.add(currentNodeId);
+            // Add all children to the queue
+            const children = childMap.get(currentNodeId) || [];
+            queue.push(...children);
+          }
+        }
+
+        return subtreeNodes;
+      };
+
+      // Determine which nodes should be in 'waiting' status
+      const subtreeNodes = findSubtreeNodes(startNodes);
 
       // If there's a new canvas ID, generate new node IDs for each node and store them in the new database field
       // Create node execution records
@@ -213,6 +235,9 @@ export class WorkflowService {
         // Generate new node ID if newCanvasId exists
         const newNodeId = newCanvasId ? genNodeID() : null;
 
+        // Set status based on whether the node is in the subtree
+        const status = subtreeNodes.has(node.id) ? 'waiting' : 'finish';
+
         const nodeExecution = await this.prisma.workflowNodeExecution.create({
           data: {
             nodeExecutionId,
@@ -221,7 +246,7 @@ export class WorkflowService {
             nodeType: node.type,
             entityId: node.data?.entityId || '',
             title: node.data?.title || '',
-            status: startNodes.includes(node.id) ? 'waiting' : 'waiting',
+            status,
             parentNodeIds: JSON.stringify(parents),
             childNodeIds: JSON.stringify(children),
             newNodeId, // Store the new node ID for new canvas mode
@@ -268,12 +293,15 @@ export class WorkflowService {
     canvasId: string,
     executionId?: string,
     newNodeId?: string,
+    startNodeId?: string,
   ): Promise<void> {
     // Check if the node is a skillResponse type
     if (node.type !== 'skillResponse') {
       this.logger.warn(`Node type ${node.type} is not skillResponse, skipping processing`);
       return;
     }
+
+    this.logger.log(`startNodeId: ${startNodeId}`);
 
     const { data } = node;
     const metadata = data?.metadata as ResponseNodeMeta;

--- a/packages/ai-workspace-common/src/requests/types.gen.ts
+++ b/packages/ai-workspace-common/src/requests/types.gen.ts
@@ -5777,6 +5777,10 @@ export type InitializeWorkflowRequest = {
    * New canvas ID
    */
   newCanvasId?: string;
+  /**
+   * Start node IDs
+   */
+  startNodes?: Array<string>;
 };
 
 export type InitializeWorkflowResponse = BaseResponse & {

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -9296,6 +9296,12 @@ components:
           type: string
           description: New canvas ID
           example: "canvas-456"
+        startNodes:
+          type: array
+          description: Start node IDs
+          items:
+            type: string
+            example: "node-123"
     InitializeWorkflowResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -8240,6 +8240,14 @@ export const InitializeWorkflowRequestSchema = {
       description: 'New canvas ID',
       example: 'canvas-456',
     },
+    startNodes: {
+      type: 'array',
+      description: 'Start node IDs',
+      items: {
+        type: 'string',
+        example: 'node-123',
+      },
+    },
   },
 } as const;
 

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -5777,6 +5777,10 @@ export type InitializeWorkflowRequest = {
    * New canvas ID
    */
   newCanvasId?: string;
+  /**
+   * Start node IDs
+   */
+  startNodes?: Array<string>;
 };
 
 export type InitializeWorkflowResponse = BaseResponse & {

--- a/packages/request/src/requests/types.gen.ts
+++ b/packages/request/src/requests/types.gen.ts
@@ -5777,6 +5777,10 @@ export type InitializeWorkflowRequest = {
    * New canvas ID
    */
   newCanvasId?: string;
+  /**
+   * Start node IDs
+   */
+  startNodes?: Array<string>;
 };
 
 export type InitializeWorkflowResponse = BaseResponse & {


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
