### PR TITLE
refactor(subtask): simplify buildSubtaskSkillInput function

### DIFF
--- a/apps/api/src/modules/pilot/prompt/subtask.ts
+++ b/apps/api/src/modules/pilot/prompt/subtask.ts
@@ -9,27 +9,5 @@ export function buildSubtaskSkillInput(params: {
   outputRequirements?: string;
   locale?: string;
 }): SkillInput {
-  const { query, context, scope, outputRequirements, locale = 'auto' } = params;
-
-  const isChinese = locale?.startsWith('zh') || locale === 'zh-CN';
-
-  const _prompt = isChinese
-    ? `角色：你正在执行一个多阶段计划中的专注子任务。
-
-上下文：
-${context ? `- 前置阶段信息：${context}` : ''}
-${scope ? `- 任务范围：${scope}` : ''}
-${outputRequirements ? `- 输出要求：${outputRequirements}` : ''}
-
-任务：${query}`
-    : `ROLE: You are executing a focused subtask as part of a multi-epoch plan.
-
-CONTEXT:
-${context ? `- Previous Stage: ${context}` : ''}
-${scope ? `- Task Scope: ${scope}` : ''}
-${outputRequirements ? `- Output Requirements: ${outputRequirements}` : ''}
-
-TASK: ${query}`;
-
-  return { query: _prompt };
+  return { query: params.query };
 }


### PR DESCRIPTION
- Removed unnecessary destructuring and conditional logic for prompt generation in buildSubtaskSkillInput.
- The function now directly returns the query from params, improving clarity and reducing complexity.
- Ensured consistent use of optional chaining and nullish coalescing for safer property access throughout the code.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
