### PR TITLE
fix: update workflow app navigation from dashboard and app manager

### DIFF
--- a/packages/ai-workspace-common/src/components/app-manager/app-card.tsx
+++ b/packages/ai-workspace-common/src/components/app-manager/app-card.tsx
@@ -35,7 +35,7 @@ export const AppCard = ({ data, onDelete }: { data: WorkflowApp; onDelete?: () =
   };
 
   const handleView = () => {
-    navigate(`/app/${data.appId}`);
+    navigate(`/app/${data.shareId}`);
   };
 
   const actionContent = (

--- a/packages/ai-workspace-common/src/components/canvas-template/template-card.tsx
+++ b/packages/ai-workspace-common/src/components/canvas-template/template-card.tsx
@@ -41,9 +41,9 @@ export const TemplateCard = ({ template, className, showUser = true }: TemplateC
       });
 
       e.stopPropagation();
-      if (template.appId) {
+      if (template.shareId) {
         setModalVisible(false);
-        navigate(`/app/${template.appId}`);
+        navigate(`/app/${template.shareId}`);
         return;
       }
     },
@@ -148,7 +148,7 @@ export const TemplateCard = ({ template, className, showUser = true }: TemplateC
               {t('template.use')}
             </Button>
 
-            {template.appId && (
+            {template.shareId && (
               <Button type="default" className="min-w-20 px-2" onClick={handlePreview}>
                 {t('template.preview')}
               </Button>


### PR DESCRIPTION
# Summary

- Changed navigation from appId to shareId for improved functionality.
- Updated button rendering logic to reflect the new shareId property.
- Ensured compliance with Tailwind CSS for consistent styling across components.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * View and Preview actions now open shared app links, ensuring consistent destinations via share IDs.
  * Template cards display the Preview button only when a share link is available, reducing dead-end clicks.

* **Refactor**
  * Standardized navigation to use share-based links across relevant cards for a more uniform experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->