### PR TITLE
fix(action-module): enhance action handling and step integration

### DIFF
--- a/apps/api/src/modules/action/action.dto.ts
+++ b/apps/api/src/modules/action/action.dto.ts
@@ -41,6 +41,7 @@ export function toolCallResultPO2DTO(toolCall: ToolCallResultModel): ToolCallRes
     uid: toolCall.uid,
     toolsetId: toolCall.toolsetId,
     toolName: toolCall.toolName,
+    stepName: toolCall.stepName,
     input: safeParseJSON(toolCall.input || '{}'),
     output: safeParseJSON(toolCall.output || '{}'),
     error: toolCall.error || '',

--- a/apps/api/src/modules/action/action.module.ts
+++ b/apps/api/src/modules/action/action.module.ts
@@ -1,5 +1,6 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { CommonModule } from '../common/common.module';
+import { StepModule } from '../step/step.module';
 import { ProviderModule } from '../provider/provider.module';
 import { SkillModule } from '../skill/skill.module';
 import { ToolCallModule } from '../tool-call/tool-call.module';
@@ -7,7 +8,13 @@ import { ActionController } from './action.controller';
 import { ActionService } from './action.service';
 
 @Module({
-  imports: [CommonModule, ProviderModule, ToolCallModule, forwardRef(() => SkillModule)],
+  imports: [
+    CommonModule,
+    StepModule,
+    ProviderModule,
+    ToolCallModule,
+    forwardRef(() => SkillModule),
+  ],
   controllers: [ActionController],
   providers: [ActionService],
   exports: [ActionService],

--- a/apps/api/src/modules/skill/skill.module.ts
+++ b/apps/api/src/modules/skill/skill.module.ts
@@ -4,6 +4,7 @@ import { KnowledgeModule } from '../knowledge/knowledge.module';
 import { SkillService } from './skill.service';
 import { SkillController } from './skill.controller';
 import { CommonModule } from '../common/common.module';
+import { StepModule } from '../step/step.module';
 import { SearchModule } from '../search/search.module';
 import { RAGModule } from '../rag/rag.module';
 import {
@@ -35,6 +36,7 @@ import { ToolCallModule } from '../tool-call/tool-call.module';
 @Module({
   imports: [
     CommonModule,
+    StepModule,
     forwardRef(() => ActionModule),
     LabelModule,
     SearchModule,

--- a/apps/api/src/modules/step/step.module.ts
+++ b/apps/api/src/modules/step/step.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CommonModule } from '../common/common.module';
+import { StepService } from './step.service';
+
+@Module({
+  imports: [CommonModule],
+  providers: [StepService],
+  exports: [StepService],
+})
+export class StepModule {}

--- a/apps/api/src/modules/step/step.service.ts
+++ b/apps/api/src/modules/step/step.service.ts
@@ -1,0 +1,99 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ActionStep } from '../../generated/client';
+import { PrismaService } from '../common/prisma.service';
+import { RedisService } from '../common/redis.service';
+
+const DEFAULT_TTL_SECONDS = 60 * 3;
+
+/**
+ * Service for managing steps of action results
+ * Implements cache-first strategy: tries cache first, falls back to database
+ */
+@Injectable()
+export class StepService {
+  private readonly logger = new Logger(StepService.name);
+
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  buildCacheKey(resultId: string, version: number): string {
+    return `skill:steps:${resultId}:${version}`;
+  }
+
+  /**
+   * Set steps cache to Redis
+   */
+  async setStepsCache(
+    resultId: string,
+    version: number,
+    steps: Record<string, ActionStep>,
+    ttlSeconds = DEFAULT_TTL_SECONDS,
+  ): Promise<void> {
+    const cacheKey = this.buildCacheKey(resultId, version);
+    await this.redisService.setJSON(cacheKey, steps, ttlSeconds);
+  }
+
+  /**
+   * Get steps with cache-first strategy
+   * 1. Try to get from Redis cache
+   * 2. If cache miss, fetch from database
+   * 3. Cache the DB results for future requests
+   */
+  async getSteps(resultId: string, version: number): Promise<ActionStep[] | null> {
+    // Try cache first
+    const cacheKey = this.buildCacheKey(resultId, version);
+    const cached = await this.redisService.getJSON<Record<string, ActionStep>>(cacheKey);
+
+    if (cached && Object.keys(cached).length > 0) {
+      // Convert Record to Array, sorted by step name
+      const sortedSteps = Object.values(cached).sort(
+        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+      );
+      return sortedSteps;
+    }
+
+    const stepsFromDb = await this.prisma.actionStep.findMany({
+      where: {
+        resultId,
+        version,
+        deletedAt: null,
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    if (!stepsFromDb || stepsFromDb.length === 0) {
+      return null;
+    }
+
+    // Convert array to Record<string, ActionStep> format for caching (using step name as key)
+    const stepsMap: Record<string, ActionStep> = {};
+    for (const step of stepsFromDb) {
+      stepsMap[step.name] = step;
+    }
+
+    // Cache the DB results for future requests
+    await this.setStepsCache(resultId, version, stepsMap);
+    return stepsFromDb;
+  }
+
+  /**
+   * Clear steps cache
+   */
+  async clearCache(resultId: string, version: number): Promise<void> {
+    const cacheKey = this.buildCacheKey(resultId, version);
+    await this.redisService.del(cacheKey);
+  }
+  /**
+   * Alias for setStepsCache (backward compatibility with result.ts)
+   * Accepts any snapshot structure for backward compatibility
+   */
+  async setCache<T = any>(
+    cacheKey: string,
+    object: T,
+    ttlSeconds = DEFAULT_TTL_SECONDS,
+  ): Promise<void> {
+    await this.redisService.setJSON(cacheKey, object, ttlSeconds);
+  }
+}

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
@@ -1,5 +1,4 @@
 import { EditChatInput } from '@refly-packages/ai-workspace-common/components/canvas/node-preview/skill-response/edit-chat-input';
-import { IconLoading } from '@refly-packages/ai-workspace-common/components/common/icon';
 import { SourceListModal } from '@refly-packages/ai-workspace-common/components/source-list/source-list-modal';
 import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
 import { actionEmitter } from '@refly-packages/ai-workspace-common/events/action';
@@ -26,7 +25,7 @@ import {
 import { cn } from '@refly/utils/cn';
 import { sortSteps } from '@refly/utils/step';
 import { useReactFlow } from '@xyflow/react';
-import { Button, Divider, Result, Skeleton, Spin } from 'antd';
+import { Button, Divider, Result, Skeleton } from 'antd';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Thinking } from 'refly-icons';
@@ -321,13 +320,7 @@ const SkillResponseNodePreviewComponent = ({ node, resultId }: SkillResponseNode
             />
           </div>
         ) : (
-          <Spin
-            spinning={!isStreaming && result?.status === 'executing'}
-            indicator={<IconLoading className="animate-spin" />}
-            size="large"
-            tip={t('canvas.skillResponse.generating')}
-            wrapperClassName="h-full w-full flex flex-col"
-          >
+          <div className="h-full w-full flex flex-col">
             <div
               className={cn(
                 'h-full overflow-auto preview-container transition-opacity duration-500',
@@ -363,7 +356,7 @@ const SkillResponseNodePreviewComponent = ({ node, resultId }: SkillResponseNode
                 <FailureNotice result={result} handleRetry={handleRetry} />
               )}
             </div>
-          </Spin>
+          </div>
         )}
       </div>
 

--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
@@ -46,7 +46,6 @@ import { truncateContent } from '@refly-packages/ai-workspace-common/utils/conte
 import { usePilotStoreShallow } from '@refly/stores';
 import cn from 'classnames';
 import { NodeActionButtons } from './shared/node-action-buttons';
-import { NodeExecutionOverlay } from './shared/node-execution-overlay';
 import { NodeExecutionStatus } from './shared/node-execution-status';
 
 import { MultimodalContentPreview } from '@refly-packages/ai-workspace-common/components/canvas/nodes/shared/multimodal-content-preview';
@@ -809,8 +808,6 @@ export const SkillResponseNode = memo(
             />
           </>
         )}
-
-        <NodeExecutionOverlay status={executionStatus} />
 
         <div
           style={nodeStyle}

--- a/packages/ai-workspace-common/src/hooks/canvas/use-action-polling.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-action-polling.ts
@@ -100,7 +100,7 @@ export const useActionPolling = () => {
             return;
           }
         }
-
+        onUpdateResult(resultId, result.data);
         updateLastPollTime(resultId);
       } catch (error) {
         console.error('Polling error:', error);

--- a/packages/ai-workspace-common/src/utils/content.ts
+++ b/packages/ai-workspace-common/src/utils/content.ts
@@ -31,9 +31,9 @@ export const truncateContent = (
 export const removeToolUseTags = (content: string): string => {
   if (!content) return '';
 
-  // Remove all <tool_use> tags and their content (global match)
-  const toolUseRegex = /<tool_use>[\s\S]*?<\/tool_use>/g;
-  return content.replace(toolUseRegex, '');
+  const markdownToolUseRegex = /```tool_use(?:_result)?[^\n]*[\s\S]*?```/g;
+  const htmlToolUseRegex = /<tool_use[\s\S]*?<\/tool_use>/g;
+  return content.replace(markdownToolUseRegex, '').replace(htmlToolUseRegex, '');
 };
 
 /**

--- a/packages/i18n/src/en-US/skill.ts
+++ b/packages/i18n/src/en-US/skill.ts
@@ -37,6 +37,10 @@ const translations = {
         name: 'Question Answering',
         description: 'Generating answer...',
       },
+      start: {
+        name: 'Start',
+        description: 'Analyzing requirements...',
+      },
     },
   },
   customPrompt: {

--- a/packages/i18n/src/zh-Hans/skill.ts
+++ b/packages/i18n/src/zh-Hans/skill.ts
@@ -37,6 +37,10 @@ const translations = {
         name: '问题回答',
         description: '生成答案中...',
       },
+      start: {
+        name: '开始',
+        description: '分析需求中...',
+      },
     },
   },
   customPrompt: {


### PR DESCRIPTION
- Added stepName to the ToolCallResultDTO for improved action context.
- Integrated StepModule into ActionModule to streamline step management.
- Refactored ActionService to utilize StepService for fetching steps, enhancing maintainability and performance.
- Updated ToolCallService to improve tool call processing and ensure safer property access using optional chaining.
- Enhanced ResultAggregator to persist step data in Redis, improving caching and retrieval efficiency.
- Ensured compliance with coding standards, including the use of optional chaining and nullish coalescing for safer property access.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
