### PR TITLE
fix(editor): improve readonly editor initialization and content setting

### DIFF
--- a/packages/ai-workspace-common/src/components/document/readonly-editor.tsx
+++ b/packages/ai-workspace-common/src/components/document/readonly-editor.tsx
@@ -19,6 +19,7 @@ export const ReadonlyEditor = memo(
     const document = useDocumentStoreShallow((state) => state.data[docId]?.document);
     const [isPreviewModalVisible, setIsPreviewModalVisible] = useState(false);
     const [imageUrl, setImageUrl] = useState<string | null>(null);
+    const [isEditorReady, setIsEditorReady] = useState(false);
 
     const handleNodeClick = useCallback(
       (event: MouseEvent) => {
@@ -85,19 +86,25 @@ export const ReadonlyEditor = memo(
     }, [docId]);
 
     useEffect(() => {
-      if (document?.content && editorRef.current) {
-        editorRef.current?.commands.setContent(document.content);
-      }
-    }, [document?.content]);
+      if (!editorRef.current) return;
+      const content = document?.content ?? '';
+      editorRef.current?.commands.setContent(content);
+    }, [isEditorReady, document?.content, docId]);
 
     return (
       <div className={classNames('w-full', 'ai-note-editor-content-container')}>
         <div className="w-full h-full">
           <EditorRoot>
             <EditorContent
+              key={docId}
               extensions={extensions}
               onCreate={({ editor }) => {
                 editorRef.current = editor;
+                setIsEditorReady(true);
+                const initialContent = document?.content ?? '';
+                if (initialContent !== undefined) {
+                  editorRef.current?.commands.setContent(initialContent);
+                }
               }}
               editable={false}
               className="w-full h-full border-muted sm:rounded-lg"


### PR DESCRIPTION
# Summary

- Introduced a new state variable, isEditorReady, to manage editor readiness and ensure proper content setting.
- Updated useEffect to conditionally set content based on editor readiness and document availability, enhancing performance and reliability.
- Ensured compliance with coding standards, including the use of optional chaining and nullish coalescing for safer property access.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed document content loading and display in the editor
  * Improved content synchronization when switching between documents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->