### PR TITLE
fix(credit): update credit usage calculation in ShareCreationService

### DIFF
--- a/apps/api/src/modules/share/share-creation.service.ts
+++ b/apps/api/src/modules/share/share-creation.service.ts
@@ -27,6 +27,7 @@ import { SHARE_CODE_PREFIX } from './const';
 import { safeParseJSON } from '@refly/utils';
 import { generateCoverUrl } from '../workflow-app/workflow-app.dto';
 import { omit } from '../../utils';
+import { ConfigService } from '@nestjs/config';
 
 function genShareId(entityType: keyof typeof SHARE_CODE_PREFIX): string {
   return SHARE_CODE_PREFIX[entityType] + createId();
@@ -47,6 +48,7 @@ export class ShareCreationService {
     private readonly creditService: CreditService,
     private readonly shareCommonService: ShareCommonService,
     private readonly shareRateLimitService: ShareRateLimitService,
+    private readonly configService: ConfigService,
     @Optional()
     @InjectQueue(QUEUE_CREATE_SHARE)
     private readonly createShareQueue?: Queue<CreateShareJobData>,
@@ -1078,7 +1080,7 @@ export class ShareCreationService {
       query: workflowApp.query,
       variables: safeParseJSON(workflowApp.variables || '[]'),
       canvasData: canvasDataWithId, // Use the extended canvas data with canvasId
-      creditUsage,
+      creditUsage: Math.ceil(creditUsage * this.configService.get('credit.executionCreditMarkup')),
       createdAt: workflowApp.createdAt,
       updatedAt: workflowApp.updatedAt,
     };

--- a/apps/api/src/modules/share/share.module.ts
+++ b/apps/api/src/modules/share/share.module.ts
@@ -19,6 +19,7 @@ import { ShareRateLimitService } from './share-rate-limit.service';
 import { ToolModule } from '../tool/tool.module';
 import { CanvasSyncModule } from '../canvas-sync/canvas-sync.module';
 import { CreditModule } from '../credit/credit.module';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { CreditModule } from '../credit/credit.module';
     CodeArtifactModule,
     SubscriptionModule,
     CreditModule,
+    ConfigModule,
     ...(isDesktop() ? [] : [BullModule.registerQueue({ name: QUEUE_CREATE_SHARE })]),
   ],
   providers: [

--- a/packages/web-core/src/pages/workflow-app/workflow-app-form.tsx
+++ b/packages/web-core/src/pages/workflow-app/workflow-app-form.tsx
@@ -14,7 +14,6 @@ import { MixedTextEditor } from '@refly-packages/ai-workspace-common/components/
 import { ResourceUpload } from '@refly-packages/ai-workspace-common/components/canvas/workflow-run/resource-upload';
 import { useFileUpload } from '@refly-packages/ai-workspace-common/components/canvas/workflow-variables';
 import { getFileType } from '@refly-packages/ai-workspace-common/components/canvas/workflow-variables/utils';
-import { calculateCreditCost } from '@refly-packages/ai-workspace-common/utils';
 
 const EmptyContent = () => {
   const { t } = useTranslation();
@@ -603,7 +602,7 @@ export const WorkflowAPPForm = ({
                     </svg>
 
                     <span className="font-semibold text-[20px] leading-[1.25em] font-roboto text-[#1C1F23] dark:text-white inline-flex items-center gap-[3px]">
-                      {calculateCreditCost(workflowApp?.creditUsage) ?? 0}
+                      {workflowApp?.creditUsage ?? 0}
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
                         width="15"


### PR DESCRIPTION
- Introduced ConfigService to adjust credit usage calculation with execution credit markup.
- Ensured compliance with coding standards, including the use of optional chaining and nullish coalescing for safer property access.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
