### PR TITLE
fix(ToolsetIcon): enhance toolset handling and inventory lookup logic

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/launchpad/rich-chat-input/mention-node-view.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/rich-chat-input/mention-node-view.tsx
@@ -43,8 +43,8 @@ function renderNodeIcon(source: string, variableType: string, nodeAttrs: any) {
   if (source === 'toolsets' || source === 'tools') {
     return (
       <ToolsetIcon
+        toolsetKey={nodeAttrs?.id}
         toolset={nodeAttrs?.toolset}
-        disableInventoryLookup
         config={TOOLSET_ICON_CONFIG}
       />
     );

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/actions-in-canvas-dropdown.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/actions-in-canvas-dropdown.tsx
@@ -99,7 +99,12 @@ export const ActionsInCanvasDropdown = memo((props: ActionsInCanvasDropdownProps
   }, [setPopupVisible]);
 
   const handleDuplicate = useCallback(() => {
-    duplicateCanvas({ canvasId, title: canvasName, isCopy: true, onSuccess: hideDropdown });
+    duplicateCanvas({
+      canvasId,
+      title: canvasName ?? t('common.untitled'),
+      isCopy: true,
+      onSuccess: hideDropdown,
+    });
   }, [canvasId, canvasName, hideDropdown]);
 
   // Update CSS custom property for resize control scaling

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -282,7 +282,7 @@ const translations = {
     },
     dropImageHere: '拖放图片到这里',
     presetColors: '预设颜色',
-    duplicate: '复制',
+    duplicate: '副本',
     shareSuccess: '分享链接已复制到剪贴板!',
     shareError: '分享失败，请重试！',
     readonlyWarning: '只读模式',

--- a/packages/web-core/src/components/layout/index.tsx
+++ b/packages/web-core/src/components/layout/index.tsx
@@ -31,6 +31,7 @@ import { EnvironmentBanner } from './EnvironmentBanner';
 import { useGetMediaModel } from '@refly-packages/ai-workspace-common/hooks/use-get-media-model';
 import { useHandleUrlParamsCallback } from '@refly-packages/ai-workspace-common/hooks/use-handle-url-params-callback';
 import { useRouteCollapse } from '@refly-packages/ai-workspace-common/hooks/use-route-collapse';
+import cn from 'classnames';
 
 const Content = Layout.Content;
 
@@ -92,6 +93,8 @@ export const AppLayout = (props: AppLayoutProps) => {
 
   const routeLogin = useMatch('/');
   const isPricing = useMatch('/pricing');
+  const isWorkflowEmpty = useMatch('/canvas/:canvasId')?.params?.canvasId === 'empty';
+  const isWorkflow = !!useMatch('/canvas/:canvasId') && !isWorkflowEmpty;
 
   if (!isPublicAccessPage && !isPricing && !isDesktop()) {
     if (!userStore.isCheckingLoginStatus === undefined || userStore.isCheckingLoginStatus) {
@@ -116,7 +119,10 @@ export const AppLayout = (props: AppLayoutProps) => {
       >
         {showSider ? <SiderLayout source="sider" /> : null}
         <Layout
-          className="content-layout bg-transparent flex-grow overflow-y-auto overflow-x-hidden m-2 rounded-xl shadow-refly-m min-w-0 min-h-0 overscroll-contain"
+          className={cn(
+            'content-layout bg-transparent flex-grow overflow-y-auto overflow-x-hidden m-2 rounded-xl min-w-0 min-h-0 overscroll-contain',
+            isWorkflow ? '' : 'shadow-refly-m',
+          )}
           style={{ height: 'calc(var(--screen-height) - 16px)' }}
         >
           <Content>{props.children}</Content>


### PR DESCRIPTION
- Updated the ToolsetIcon component to accept an optional toolsetKey prop for improved flexibility in rendering toolset icons.
- Implemented inventory lookup when only toolsetKey is provided, ensuring proper handling of undefined toolset scenarios.
- Enhanced the ToolsetIconWithInventory component to utilize the provided toolsetKey for matching toolset definitions.
- Ensured compliance with coding standards, including the use of optional chaining and nullish coalescing for safer property access.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ToolsetIcon component now supports flexible toolset resolution via optional key, including builtin icon handling and inventory-based lookup.

* **Bug Fixes**
  * Duplicate action now displays "Untitled" as fallback title when canvas name is missing.

* **Style**
  * Removed shadow styling from content layout during active workflow sessions.

* **Chores**
  * Updated Chinese translation for duplicate action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->