### PR TITLE
fix(workflow-app): enhance workflow execution handling with polling c…

### DIFF
--- a/packages/web-core/src/pages/workflow-app/index.tsx
+++ b/packages/web-core/src/pages/workflow-app/index.tsx
@@ -96,7 +96,11 @@ const WorkflowAppPage: React.FC = () => {
     return workflowApp?.variables ?? [];
   }, [workflowApp]);
 
-  const { data: workflowDetail, status } = useWorkflowExecutionPolling({
+  const {
+    data: workflowDetail,
+    status,
+    stopPolling,
+  } = useWorkflowExecutionPolling({
     executionId,
     enabled: true,
     interval: 1000,
@@ -174,6 +178,14 @@ const WorkflowAppPage: React.FC = () => {
       setIsRunning(false);
     }
   }, [executionId, status]);
+
+  useEffect(() => {
+    if (shareId) {
+      setFinalNodeExecutions([]);
+      stopPolling();
+      setIsRunning(false);
+    }
+  }, [shareId]);
 
   const nodeExecutions = useMemo(() => {
     // Use current workflowDetail if available, otherwise use final cached results


### PR DESCRIPTION
…ontrol

- Added stopPolling functionality to manage polling based on shareId changes.
- Updated useEffect to reset finalNodeExecutions and isRunning when shareId is present.
- Ensured compliance with optional chaining and nullish coalescing for safer property access.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow polling behavior when switching between different shared workflow instances—polling now properly halts and execution state resets on navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->