### PR TITLE
feat: add a PublicFileUrlProvider context + selection modal scoping 

### DIFF
--- a/apps/api/src/modules/credit/credit.controller.ts
+++ b/apps/api/src/modules/credit/credit.controller.ts
@@ -10,6 +10,7 @@ import {
   GetCreditUsageByResultIdResponse,
   GetCreditUsageByExecutionIdResponse,
   GetCreditUsageByCanvasIdResponse,
+  GetCanvasCommissionByCanvasIdResponse,
 } from '@refly/openapi-schema';
 import { buildSuccessResponse } from '../../utils';
 import { ConfigService } from '@nestjs/config';
@@ -96,6 +97,19 @@ export class CreditController {
     const total = await this.creditService.countCanvasCreditUsageByCanvasId(user, canvasId);
     return buildSuccessResponse({
       total: Math.ceil(total * (1 + this.configService.get('credit.canvasCreditCommissionRate'))),
+    });
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('/commission')
+  async getCanvasCommissionByCanvasId(
+    @LoginedUser() user: User,
+    @Query() query: { canvasId: string },
+  ): Promise<GetCanvasCommissionByCanvasIdResponse> {
+    const { canvasId } = query;
+    const total = await this.creditService.countCanvasCreditUsageByCanvasId(user, canvasId);
+    return buildSuccessResponse({
+      total: Math.ceil(total * this.configService.get('credit.canvasCreditCommissionRate')),
     });
   }
 }

--- a/apps/api/src/modules/misc/misc.service.ts
+++ b/apps/api/src/modules/misc/misc.service.ts
@@ -63,6 +63,22 @@ export class MiscService implements OnModuleInit {
     }
   }
 
+  async fileStorageExists(
+    storageKey: string,
+    visibility: FileVisibility = 'public',
+  ): Promise<boolean> {
+    if (!storageKey) {
+      return false;
+    }
+    try {
+      const minio = this.minioClient(visibility);
+      await minio.statObject(storageKey);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   private async setupCleanStaticFilesCronjob() {
     if (!this.cleanStaticFilesQueue) return;
 

--- a/packages/ai-workspace-common/src/components/canvas/launchpad/context-manager/context-preview.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/context-manager/context-preview.tsx
@@ -1,15 +1,13 @@
 import { memo } from 'react';
-import {
-  DocumentNode,
-  ResourceNode,
-  MemoNode,
-  ImageNode,
-  CodeArtifactNode,
-  WebsiteNode,
-  SkillResponseNode,
-  VideoNode,
-  AudioNode,
-} from '@refly-packages/ai-workspace-common/components/canvas/nodes';
+import { DocumentNode } from '@refly-packages/ai-workspace-common/components/canvas/nodes/document';
+import { ResourceNode } from '@refly-packages/ai-workspace-common/components/canvas/nodes/resource';
+import { MemoNode } from '@refly-packages/ai-workspace-common/components/canvas/nodes/memo/memo';
+import { ImageNode } from '@refly-packages/ai-workspace-common/components/canvas/nodes/image';
+import { CodeArtifactNode } from '@refly-packages/ai-workspace-common/components/canvas/nodes/code-artifact';
+import { WebsiteNode } from '@refly-packages/ai-workspace-common/components/canvas/nodes/website';
+import { SkillResponseNode } from '@refly-packages/ai-workspace-common/components/canvas/nodes/skill-response';
+import { VideoNode } from '@refly-packages/ai-workspace-common/components/canvas/nodes/video';
+import { AudioNode } from '@refly-packages/ai-workspace-common/components/canvas/nodes/audio';
 import {
   DocumentNodeProps,
   MemoNodeProps,

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/index.tsx
@@ -42,7 +42,6 @@ export const PreviewComponent = memo(
     const basicPropsEqual =
       prevProps.node?.type === nextProps.node?.type &&
       prevProps.node?.data?.entityId === nextProps.node?.data?.entityId;
-
     if (!basicPropsEqual) return false;
 
     // Check content preview

--- a/packages/ai-workspace-common/src/components/markdown/plugins/tool-call/product-card.tsx
+++ b/packages/ai-workspace-common/src/components/markdown/plugins/tool-call/product-card.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { getShareLink } from '@refly-packages/ai-workspace-common/utils/share';
 import { copyToClipboard } from '@refly-packages/ai-workspace-common/utils';
 import getClient from '@refly-packages/ai-workspace-common/requests/proxiedRequest';
+import { usePublicFileUrlContext } from '@refly-packages/ai-workspace-common/context/public-file-url';
 const { Paragraph } = Typography;
 
 // Convert DriveFile type to ResourceType
@@ -59,6 +60,7 @@ export const ProductCard = memo(({ file, classNames, source = 'card' }: ProductC
   const { setCurrentFile } = useActionResultStoreShallow((state) => ({
     setCurrentFile: state.setCurrentFile,
   }));
+  const inheritedUsePublicFileUrl = usePublicFileUrlContext();
   const { t } = useTranslation();
   const { handleDownload, isDownloading } = useDownloadFile();
 
@@ -77,8 +79,8 @@ export const ProductCard = memo(({ file, classNames, source = 'card' }: ProductC
   }, [file.type]);
 
   const handlePreview = useCallback(() => {
-    setCurrentFile(file);
-  }, [file, setCurrentFile]);
+    setCurrentFile(file, { usePublicFileUrl: inheritedUsePublicFileUrl });
+  }, [file, inheritedUsePublicFileUrl, setCurrentFile]);
 
   const handleDownloadProduct = useCallback(() => {
     handleDownload({

--- a/packages/ai-workspace-common/src/components/slideshow/components/NodeRenderer.tsx
+++ b/packages/ai-workspace-common/src/components/slideshow/components/NodeRenderer.tsx
@@ -15,6 +15,7 @@ import { Share } from 'refly-icons';
 import { logEvent } from '@refly/telemetry-web';
 import { CanvasNode } from '@refly/openapi-schema';
 import { ResultItemPreview } from '@refly-packages/ai-workspace-common/components/workflow-app/ResultItemPreview';
+import { usePublicFileUrlContext } from '@refly-packages/ai-workspace-common/context/public-file-url';
 
 // Content renderer component
 const NodeRenderer = memo(
@@ -39,6 +40,7 @@ const NodeRenderer = memo(
     inModal?: boolean;
   }) => {
     const { t } = useTranslation();
+    const usePublicFileUrl = usePublicFileUrlContext();
 
     // Check if node has downloadable data
     const nodeData: NodeData = useMemo(
@@ -64,8 +66,8 @@ const NodeRenderer = memo(
           title: nodeData.title,
         });
       }
-      await downloadNodeData(nodeData, t);
-    }, [nodeData, t, fromProducts]);
+      await downloadNodeData(nodeData, t, { usePublicFileUrl });
+    }, [nodeData, t, fromProducts, usePublicFileUrl]);
 
     // Handle share for any node type
     const handleShare = useCallback(async () => {

--- a/packages/ai-workspace-common/src/components/workflow-app/ResultItemPreview.tsx
+++ b/packages/ai-workspace-common/src/components/workflow-app/ResultItemPreview.tsx
@@ -16,6 +16,10 @@ import { NodeRelation } from '@refly-packages/ai-workspace-common/components/sli
 import { Modal } from 'antd';
 import { CloseCircleOutlined } from '@ant-design/icons';
 import { NodeRenderer } from '@refly-packages/ai-workspace-common/components/slideshow/components/NodeRenderer';
+import {
+  PublicFileUrlProvider,
+  usePublicFileUrlContext,
+} from '@refly-packages/ai-workspace-common/context/public-file-url';
 
 // Global media manager to stop all playing media
 const mediaManager = {
@@ -318,6 +322,7 @@ DefaultPreview.displayName = 'DefaultPreview';
 export const ResultItemPreview = memo(
   ({ node, inModal = false }: { node: CanvasNode; inModal?: boolean }) => {
     const [wideModeOpen, setWideModeOpen] = useState(false);
+    const inheritedUsePublicFileUrl = usePublicFileUrlContext();
     const [isHovered, setIsHovered] = useState(false);
 
     // Construct DriveFile from node metadata if fileId exists
@@ -413,6 +418,11 @@ export const ResultItemPreview = memo(
           onCancel={handleWideModeClose}
           width="85%"
           style={{ top: 20 }}
+          modalRender={(modalNode) => (
+            <PublicFileUrlProvider value={inheritedUsePublicFileUrl}>
+              {modalNode}
+            </PublicFileUrlProvider>
+          )}
           styles={{
             body: {
               maxHeight: 'calc(var(--screen-height) - 100px)',

--- a/packages/ai-workspace-common/src/components/workflow-app/create-modal.tsx
+++ b/packages/ai-workspace-common/src/components/workflow-app/create-modal.tsx
@@ -14,7 +14,7 @@ import { SelectedResultsGrid } from './selected-results-grid';
 import BannerSvg from './banner.svg';
 import { useRealtimeCanvasData } from '@refly-packages/ai-workspace-common/hooks/canvas/use-realtime-canvas-data';
 import { CanvasNode, DriveFile } from '@refly/openapi-schema';
-import { useGetCreditUsageByCanvasId } from '../../queries/queries';
+import { useGetCanvasCommissionByCanvasId } from '../../queries/queries';
 import { mapDriveFilesToCanvasNodes } from '@refly/utils';
 import { useVariablesManagement } from '@refly-packages/ai-workspace-common/hooks/use-variables-management';
 
@@ -141,7 +141,7 @@ export const CreateWorkflowAppModal = ({
   const { forceSyncState } = useCanvasContext();
 
   // Fetch credit usage data when modal is visible
-  const { data: creditUsageData } = useGetCreditUsageByCanvasId(
+  const { data: creditUsageData } = useGetCanvasCommissionByCanvasId(
     {
       query: { canvasId },
     },

--- a/packages/ai-workspace-common/src/components/workflow-app/products.tsx
+++ b/packages/ai-workspace-common/src/components/workflow-app/products.tsx
@@ -7,11 +7,16 @@ import { CloseCircleOutlined } from '@ant-design/icons';
 import { NodeRenderer } from '@refly-packages/ai-workspace-common/components/slideshow/components/NodeRenderer';
 import { type NodeRelation } from '@refly-packages/ai-workspace-common/components/slideshow/components/ArtifactRenderer';
 import { safeParseJSON } from '@refly/utils/parse';
+import {
+  PublicFileUrlProvider,
+  usePublicFileUrlContext,
+} from '@refly-packages/ai-workspace-common/context/public-file-url';
 
 export const WorkflowAppProducts = ({ products }: { products: WorkflowNodeExecution[] }) => {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
   const [itemsPerRow, setItemsPerRow] = useState<number>(2);
+  const inheritedUsePublicFileUrl = usePublicFileUrlContext();
 
   // State for fullscreen modal
   const [fullscreenNode, setFullscreenNode] = useState<NodeRelation | null>(null);
@@ -171,6 +176,11 @@ export const WorkflowAppProducts = ({ products }: { products: WorkflowNodeExecut
         width="100%"
         className="fullscreen-modal top-0 p-0 max-w-screen"
         wrapClassName="fullscreen-modal-wrap"
+        modalRender={(modalNode) => (
+          <PublicFileUrlProvider value={inheritedUsePublicFileUrl}>
+            {modalNode}
+          </PublicFileUrlProvider>
+        )}
         styles={{
           body: {
             height: 'var(--screen-height)',
@@ -215,6 +225,11 @@ export const WorkflowAppProducts = ({ products }: { products: WorkflowNodeExecut
             },
           }}
           closeIcon={<CloseCircleOutlined className="text-gray-500 hover:text-red-500" />}
+          modalRender={(modalNode) => (
+            <PublicFileUrlProvider value={inheritedUsePublicFileUrl}>
+              {modalNode}
+            </PublicFileUrlProvider>
+          )}
         >
           <div className="bg-white h-full w-full flex flex-col rounded-lg overflow-hidden dark:bg-gray-900">
             {/* Wide mode content */}

--- a/packages/ai-workspace-common/src/components/workflow-app/selected-results-grid.tsx
+++ b/packages/ai-workspace-common/src/components/workflow-app/selected-results-grid.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Modal } from 'antd';
 import { useActionResultStoreShallow } from '@refly/stores';
 import { ProductCard } from '@refly-packages/ai-workspace-common/components/markdown/plugins/tool-call/product-card';
+import { PublicFileUrlProvider } from '@refly-packages/ai-workspace-common/context/public-file-url';
 
 export interface SelectedResultsGridProps {
   selectedResults: string[];
@@ -21,10 +22,12 @@ export const SelectedResultsGrid = memo(
     const containerRef = useRef<HTMLDivElement>(null);
     const [itemHeight, setItemHeight] = useState<number | null>(null);
     const [itemsPerRow, setItemsPerRow] = useState<number>(3);
-    const { currentFile, setCurrentFile } = useActionResultStoreShallow((state) => ({
-      currentFile: state.currentFile,
-      setCurrentFile: state.setCurrentFile,
-    }));
+    const { currentFile, currentFileUsePublicFileUrl, setCurrentFile } =
+      useActionResultStoreShallow((state) => ({
+        currentFile: state.currentFile,
+        currentFileUsePublicFileUrl: state.currentFileUsePublicFileUrl,
+        setCurrentFile: state.setCurrentFile,
+      }));
 
     // Filter options to only show selected ones
     const selectedNodes = options.filter((node) => selectedResults.includes(node.id));
@@ -226,6 +229,11 @@ export const SelectedResultsGrid = memo(
             onCancel={() => setCurrentFile(null)}
             width="85%"
             style={{ top: 20 }}
+            modalRender={(modalNode) => (
+              <PublicFileUrlProvider value={currentFileUsePublicFileUrl}>
+                {modalNode}
+              </PublicFileUrlProvider>
+            )}
             styles={{
               body: {
                 maxHeight: 'calc(var(--screen-height, 100vh) - 100px)',

--- a/packages/ai-workspace-common/src/context/public-file-url.tsx
+++ b/packages/ai-workspace-common/src/context/public-file-url.tsx
@@ -1,0 +1,19 @@
+import React, { createContext, useContext } from 'react';
+
+type PublicFileUrlContextValue = boolean | undefined;
+
+const PublicFileUrlContext = createContext<PublicFileUrlContextValue>(undefined);
+
+export const PublicFileUrlProvider = ({
+  value,
+  children,
+}: {
+  value?: boolean;
+  children: React.ReactNode;
+}) => {
+  return <PublicFileUrlContext.Provider value={value}>{children}</PublicFileUrlContext.Provider>;
+};
+
+export const usePublicFileUrlContext = (): PublicFileUrlContextValue => {
+  return useContext(PublicFileUrlContext);
+};

--- a/packages/ai-workspace-common/src/hooks/canvas/use-download-file.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-download-file.ts
@@ -7,6 +7,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useMatch } from 'react-router-dom';
 import { getDriveFileUrl } from './use-drive-file-url';
+import { usePublicFileUrlContext } from '@refly-packages/ai-workspace-common/context/public-file-url';
 import type { DriveFile } from '@refly/openapi-schema';
 
 interface DownloadableFile {
@@ -23,11 +24,13 @@ interface DownloadFileParams {
 export const useDownloadFile = () => {
   const { t } = useTranslation();
   const [isDownloading, setIsDownloading] = useState(false);
+  const usePublicFileUrl = usePublicFileUrlContext();
 
   // Check if current page is any share page (consistent with use-file-url.ts)
   const isShareCanvas = useMatch('/share/canvas/:canvasId');
   const isShareFile = useMatch('/share/file/:shareId');
-  const isSharePage = Boolean(isShareCanvas || isShareFile);
+  const isWorkflowApp = useMatch('/app/:shareId');
+  const isSharePage = Boolean(isShareCanvas || isShareFile || isWorkflowApp);
 
   const handleDownload = useCallback(
     async ({ currentFile, contentType }: DownloadFileParams) => {
@@ -55,7 +58,7 @@ export const useDownloadFile = () => {
       try {
         const file = currentFile as DriveFile;
         // Use async getFileUrl which handles publicURL fetching automatically
-        const { fileUrl } = getDriveFileUrl(file, isSharePage);
+        const { fileUrl } = getDriveFileUrl(file, isSharePage, usePublicFileUrl);
 
         if (!fileUrl) {
           throw new Error('File URL not available');
@@ -94,7 +97,7 @@ export const useDownloadFile = () => {
         setIsDownloading(false);
       }
     },
-    [isDownloading, t, isSharePage],
+    [isDownloading, t, isSharePage, usePublicFileUrl],
   );
 
   return {

--- a/packages/ai-workspace-common/src/hooks/canvas/use-drive-file-url.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-drive-file-url.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { usePublicFileUrlContext } from '@refly-packages/ai-workspace-common/context/public-file-url';
 import { useMatch } from 'react-router-dom';
 import { serverOrigin } from '@refly/ui-kit';
 import type { DriveFile } from '@refly/openapi-schema';
@@ -19,11 +20,20 @@ interface UseFileUrlResult {
 export const getDriveFileUrl = (
   file: DriveFile | null | undefined,
   isSharePage: boolean,
+  usePublicFileUrl?: boolean,
   download = false,
 ): UseFileUrlResult => {
   if (!file?.fileId) {
     return {
       fileUrl: null,
+    };
+  }
+
+  if (usePublicFileUrl !== undefined) {
+    return {
+      fileUrl: usePublicFileUrl
+        ? `${serverOrigin}/v1/drive/file/public/${file.fileId}`
+        : `${serverOrigin}/v1/drive/file/content/${file.fileId}${download ? '?download=1' : ''}`,
     };
   }
 
@@ -57,6 +67,7 @@ export const useDriveFileUrl = ({
   file,
   download = false,
 }: UseFileUrlOptions): UseFileUrlResult => {
+  const contextUsePublicFileUrl = usePublicFileUrlContext();
   // Check if current page is any share page
   const isShareCanvas = useMatch('/share/canvas/:canvasId');
   const isShareFile = useMatch('/share/file/:shareId');
@@ -65,6 +76,6 @@ export const useDriveFileUrl = ({
   const isSharePage = Boolean(isShareCanvas || isShareFile || isWorkflowApp);
 
   return useMemo(() => {
-    return getDriveFileUrl(file, isSharePage, download);
-  }, [file?.fileId, isSharePage, download]);
+    return getDriveFileUrl(file, isSharePage, contextUsePublicFileUrl, download);
+  }, [file?.fileId, isSharePage, download, contextUsePublicFileUrl]);
 };

--- a/packages/ai-workspace-common/src/queries/common.ts
+++ b/packages/ai-workspace-common/src/queries/common.ts
@@ -71,6 +71,7 @@ import {
   generateMedia,
   getActionResult,
   getAuthConfig,
+  getCanvasCommissionByCanvasId,
   getCanvasData,
   getCanvasDetail,
   getCanvasState,
@@ -720,6 +721,18 @@ export const UseGetCreditUsageByCanvasIdKeyFn = (
   clientOptions: Options<unknown, true>,
   queryKey?: Array<unknown>,
 ) => [useGetCreditUsageByCanvasIdKey, ...(queryKey ?? [clientOptions])];
+export type GetCanvasCommissionByCanvasIdDefaultResponse = Awaited<
+  ReturnType<typeof getCanvasCommissionByCanvasId>
+>['data'];
+export type GetCanvasCommissionByCanvasIdQueryResult<
+  TData = GetCanvasCommissionByCanvasIdDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useGetCanvasCommissionByCanvasIdKey = 'GetCanvasCommissionByCanvasId';
+export const UseGetCanvasCommissionByCanvasIdKeyFn = (
+  clientOptions: Options<unknown, true>,
+  queryKey?: Array<unknown>,
+) => [useGetCanvasCommissionByCanvasIdKey, ...(queryKey ?? [clientOptions])];
 export type ListInvitationCodesDefaultResponse = Awaited<
   ReturnType<typeof listInvitationCodes>
 >['data'];

--- a/packages/ai-workspace-common/src/queries/ensureQueryData.ts
+++ b/packages/ai-workspace-common/src/queries/ensureQueryData.ts
@@ -9,6 +9,7 @@ import {
   exportDocument,
   getActionResult,
   getAuthConfig,
+  getCanvasCommissionByCanvasId,
   getCanvasData,
   getCanvasDetail,
   getCanvasState,
@@ -75,6 +76,7 @@ import {
   ExportCanvasData,
   ExportDocumentData,
   GetActionResultData,
+  GetCanvasCommissionByCanvasIdData,
   GetCanvasDataData,
   GetCanvasDetailData,
   GetCanvasStateData,
@@ -523,6 +525,15 @@ export const ensureUseGetCreditUsageByCanvasIdData = (
   queryClient.ensureQueryData({
     queryKey: Common.UseGetCreditUsageByCanvasIdKeyFn(clientOptions),
     queryFn: () => getCreditUsageByCanvasId({ ...clientOptions }).then((response) => response.data),
+  });
+export const ensureUseGetCanvasCommissionByCanvasIdData = (
+  queryClient: QueryClient,
+  clientOptions: Options<GetCanvasCommissionByCanvasIdData, true>,
+) =>
+  queryClient.ensureQueryData({
+    queryKey: Common.UseGetCanvasCommissionByCanvasIdKeyFn(clientOptions),
+    queryFn: () =>
+      getCanvasCommissionByCanvasId({ ...clientOptions }).then((response) => response.data),
   });
 export const ensureUseListInvitationCodesData = (
   queryClient: QueryClient,

--- a/packages/ai-workspace-common/src/queries/prefetch.ts
+++ b/packages/ai-workspace-common/src/queries/prefetch.ts
@@ -9,6 +9,7 @@ import {
   exportDocument,
   getActionResult,
   getAuthConfig,
+  getCanvasCommissionByCanvasId,
   getCanvasData,
   getCanvasDetail,
   getCanvasState,
@@ -75,6 +76,7 @@ import {
   ExportCanvasData,
   ExportDocumentData,
   GetActionResultData,
+  GetCanvasCommissionByCanvasIdData,
   GetCanvasDataData,
   GetCanvasDetailData,
   GetCanvasStateData,
@@ -523,6 +525,15 @@ export const prefetchUseGetCreditUsageByCanvasId = (
   queryClient.prefetchQuery({
     queryKey: Common.UseGetCreditUsageByCanvasIdKeyFn(clientOptions),
     queryFn: () => getCreditUsageByCanvasId({ ...clientOptions }).then((response) => response.data),
+  });
+export const prefetchUseGetCanvasCommissionByCanvasId = (
+  queryClient: QueryClient,
+  clientOptions: Options<GetCanvasCommissionByCanvasIdData, true>,
+) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseGetCanvasCommissionByCanvasIdKeyFn(clientOptions),
+    queryFn: () =>
+      getCanvasCommissionByCanvasId({ ...clientOptions }).then((response) => response.data),
   });
 export const prefetchUseListInvitationCodes = (
   queryClient: QueryClient,

--- a/packages/ai-workspace-common/src/queries/queries.ts
+++ b/packages/ai-workspace-common/src/queries/queries.ts
@@ -72,6 +72,7 @@ import {
   generateMedia,
   getActionResult,
   getAuthConfig,
+  getCanvasCommissionByCanvasId,
   getCanvasData,
   getCanvasDetail,
   getCanvasState,
@@ -308,6 +309,8 @@ import {
   GetActionResultData,
   GetActionResultError,
   GetAuthConfigError,
+  GetCanvasCommissionByCanvasIdData,
+  GetCanvasCommissionByCanvasIdError,
   GetCanvasDataData,
   GetCanvasDataError,
   GetCanvasDetailData,
@@ -1262,6 +1265,23 @@ export const useGetCreditUsageByCanvasId = <
     queryKey: Common.UseGetCreditUsageByCanvasIdKeyFn(clientOptions, queryKey),
     queryFn: () =>
       getCreditUsageByCanvasId({ ...clientOptions }).then(
+        (response) => response.data as TData,
+      ) as TData,
+    ...options,
+  });
+export const useGetCanvasCommissionByCanvasId = <
+  TData = Common.GetCanvasCommissionByCanvasIdDefaultResponse,
+  TError = GetCanvasCommissionByCanvasIdError,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  clientOptions: Options<GetCanvasCommissionByCanvasIdData, true>,
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, 'queryKey' | 'queryFn'>,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseGetCanvasCommissionByCanvasIdKeyFn(clientOptions, queryKey),
+    queryFn: () =>
+      getCanvasCommissionByCanvasId({ ...clientOptions }).then(
         (response) => response.data as TData,
       ) as TData,
     ...options,

--- a/packages/ai-workspace-common/src/queries/suspense.ts
+++ b/packages/ai-workspace-common/src/queries/suspense.ts
@@ -9,6 +9,7 @@ import {
   exportDocument,
   getActionResult,
   getAuthConfig,
+  getCanvasCommissionByCanvasId,
   getCanvasData,
   getCanvasDetail,
   getCanvasState,
@@ -81,6 +82,8 @@ import {
   GetActionResultData,
   GetActionResultError,
   GetAuthConfigError,
+  GetCanvasCommissionByCanvasIdData,
+  GetCanvasCommissionByCanvasIdError,
   GetCanvasDataData,
   GetCanvasDataError,
   GetCanvasDetailData,
@@ -955,6 +958,23 @@ export const useGetCreditUsageByCanvasIdSuspense = <
     queryKey: Common.UseGetCreditUsageByCanvasIdKeyFn(clientOptions, queryKey),
     queryFn: () =>
       getCreditUsageByCanvasId({ ...clientOptions }).then(
+        (response) => response.data as TData,
+      ) as TData,
+    ...options,
+  });
+export const useGetCanvasCommissionByCanvasIdSuspense = <
+  TData = Common.GetCanvasCommissionByCanvasIdDefaultResponse,
+  TError = GetCanvasCommissionByCanvasIdError,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  clientOptions: Options<GetCanvasCommissionByCanvasIdData, true>,
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, 'queryKey' | 'queryFn'>,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseGetCanvasCommissionByCanvasIdKeyFn(clientOptions, queryKey),
+    queryFn: () =>
+      getCanvasCommissionByCanvasId({ ...clientOptions }).then(
         (response) => response.data as TData,
       ) as TData,
     ...options,

--- a/packages/ai-workspace-common/src/requests/services.gen.ts
+++ b/packages/ai-workspace-common/src/requests/services.gen.ts
@@ -391,6 +391,9 @@ import type {
   GetCreditUsageByCanvasIdData,
   GetCreditUsageByCanvasIdError,
   GetCreditUsageByCanvasIdResponse2,
+  GetCanvasCommissionByCanvasIdData,
+  GetCanvasCommissionByCanvasIdError,
+  GetCanvasCommissionByCanvasIdResponse2,
   ListInvitationCodesError,
   ListInvitationCodesResponse2,
   ActivateInvitationCodeData,
@@ -2600,6 +2603,23 @@ export const getCreditUsageByCanvasId = <ThrowOnError extends boolean = false>(
   >({
     ...options,
     url: '/credit/canvas',
+  });
+};
+
+/**
+ * Get canvas commission by canvas ID
+ * Get canvas commission (credit usage with commission rate) by canvas ID
+ */
+export const getCanvasCommissionByCanvasId = <ThrowOnError extends boolean = false>(
+  options: Options<GetCanvasCommissionByCanvasIdData, ThrowOnError>,
+) => {
+  return (options?.client ?? client).get<
+    GetCanvasCommissionByCanvasIdResponse2,
+    GetCanvasCommissionByCanvasIdError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/credit/commission',
   });
 };
 

--- a/packages/ai-workspace-common/src/requests/types.gen.ts
+++ b/packages/ai-workspace-common/src/requests/types.gen.ts
@@ -5214,6 +5214,18 @@ export type GetCreditUsageByCanvasIdResponse = BaseResponse & {
   };
 };
 
+export type GetCanvasCommissionByCanvasIdResponse = BaseResponse & {
+  /**
+   * Canvas commission by canvas ID
+   */
+  data?: {
+    /**
+     * Total canvas commission by canvas ID
+     */
+    total?: number;
+  };
+};
+
 export type InvitationCode = {
   /**
    * Invitation code
@@ -10342,6 +10354,19 @@ export type GetCreditUsageByCanvasIdData = {
 export type GetCreditUsageByCanvasIdResponse2 = GetCreditUsageByCanvasIdResponse;
 
 export type GetCreditUsageByCanvasIdError = unknown;
+
+export type GetCanvasCommissionByCanvasIdData = {
+  query: {
+    /**
+     * Canvas ID
+     */
+    canvasId: string;
+  };
+};
+
+export type GetCanvasCommissionByCanvasIdResponse2 = GetCanvasCommissionByCanvasIdResponse;
+
+export type GetCanvasCommissionByCanvasIdError = unknown;
 
 export type ListInvitationCodesResponse2 = ListInvitationCodesResponse;
 

--- a/packages/ai-workspace-common/src/utils/download-node-data.ts
+++ b/packages/ai-workspace-common/src/utils/download-node-data.ts
@@ -176,7 +176,11 @@ export const hasDownloadableData = (nodeData: NodeData): boolean => {
 };
 
 // Main download function for different node types
-export const downloadNodeData = async (nodeData: NodeData, t: TFunction): Promise<void> => {
+export const downloadNodeData = async (
+  nodeData: NodeData,
+  t: TFunction,
+  options?: { usePublicFileUrl?: boolean },
+): Promise<void> => {
   const { nodeType, entityId, title = '', metadata = {} } = nodeData;
   const fileName = getSanitizedFileName(title, nodeType, metadata);
 
@@ -204,7 +208,7 @@ export const downloadNodeData = async (nodeData: NodeData, t: TFunction): Promis
         updatedAt: metadata?.updatedAt,
       };
 
-      const { fileUrl } = getDriveFileUrl(driveFile, isSharePage, false);
+      const { fileUrl } = getDriveFileUrl(driveFile, isSharePage, options?.usePublicFileUrl, false);
       if (!fileUrl) {
         message.error(t('canvas.resourceLibrary.download.invalidUrl'));
         return;

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -3225,6 +3225,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetCreditUsageByCanvasIdResponse'
+  /credit/commission:
+    get:
+      tags:
+        - credit
+      summary: Get canvas commission by canvas ID
+      description: Get canvas commission (credit usage with commission rate) by canvas ID
+      operationId: getCanvasCommissionByCanvasId
+      parameters:
+        - name: canvasId
+          in: query
+          description: Canvas ID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetCanvasCommissionByCanvasIdResponse'
   /invitation/list:
     get:
       tags:
@@ -9243,6 +9264,18 @@ components:
                   description: Credit usage list by canvas ID
                   items:
                     $ref: '#/components/schemas/CreditUsage'
+    GetCanvasCommissionByCanvasIdResponse:
+      allOf:
+        - $ref: '#/components/schemas/BaseResponse'
+        - type: object
+          properties:
+            data:
+              type: object
+              description: Canvas commission by canvas ID
+              properties:
+                total:
+                  type: number
+                  description: Total canvas commission by canvas ID
     InvitationCode:
       type: object
       properties:

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -7329,6 +7329,29 @@ export const GetCreditUsageByCanvasIdResponseSchema = {
   ],
 } as const;
 
+export const GetCanvasCommissionByCanvasIdResponseSchema = {
+  allOf: [
+    {
+      $ref: '#/components/schemas/BaseResponse',
+    },
+    {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'object',
+          description: 'Canvas commission by canvas ID',
+          properties: {
+            total: {
+              type: 'number',
+              description: 'Total canvas commission by canvas ID',
+            },
+          },
+        },
+      },
+    },
+  ],
+} as const;
+
 export const InvitationCodeSchema = {
   type: 'object',
   properties: {

--- a/packages/openapi-schema/src/services.gen.ts
+++ b/packages/openapi-schema/src/services.gen.ts
@@ -391,6 +391,9 @@ import type {
   GetCreditUsageByCanvasIdData,
   GetCreditUsageByCanvasIdError,
   GetCreditUsageByCanvasIdResponse2,
+  GetCanvasCommissionByCanvasIdData,
+  GetCanvasCommissionByCanvasIdError,
+  GetCanvasCommissionByCanvasIdResponse2,
   ListInvitationCodesError,
   ListInvitationCodesResponse2,
   ActivateInvitationCodeData,
@@ -2600,6 +2603,23 @@ export const getCreditUsageByCanvasId = <ThrowOnError extends boolean = false>(
   >({
     ...options,
     url: '/credit/canvas',
+  });
+};
+
+/**
+ * Get canvas commission by canvas ID
+ * Get canvas commission (credit usage with commission rate) by canvas ID
+ */
+export const getCanvasCommissionByCanvasId = <ThrowOnError extends boolean = false>(
+  options: Options<GetCanvasCommissionByCanvasIdData, ThrowOnError>,
+) => {
+  return (options?.client ?? client).get<
+    GetCanvasCommissionByCanvasIdResponse2,
+    GetCanvasCommissionByCanvasIdError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/credit/commission',
   });
 };
 

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -5214,6 +5214,18 @@ export type GetCreditUsageByCanvasIdResponse = BaseResponse & {
   };
 };
 
+export type GetCanvasCommissionByCanvasIdResponse = BaseResponse & {
+  /**
+   * Canvas commission by canvas ID
+   */
+  data?: {
+    /**
+     * Total canvas commission by canvas ID
+     */
+    total?: number;
+  };
+};
+
 export type InvitationCode = {
   /**
    * Invitation code
@@ -10342,6 +10354,19 @@ export type GetCreditUsageByCanvasIdData = {
 export type GetCreditUsageByCanvasIdResponse2 = GetCreditUsageByCanvasIdResponse;
 
 export type GetCreditUsageByCanvasIdError = unknown;
+
+export type GetCanvasCommissionByCanvasIdData = {
+  query: {
+    /**
+     * Canvas ID
+     */
+    canvasId: string;
+  };
+};
+
+export type GetCanvasCommissionByCanvasIdResponse2 = GetCanvasCommissionByCanvasIdResponse;
+
+export type GetCanvasCommissionByCanvasIdError = unknown;
 
 export type ListInvitationCodesResponse2 = ListInvitationCodesResponse;
 

--- a/packages/request/src/queries/common.ts
+++ b/packages/request/src/queries/common.ts
@@ -71,6 +71,7 @@ import {
   generateMedia,
   getActionResult,
   getAuthConfig,
+  getCanvasCommissionByCanvasId,
   getCanvasData,
   getCanvasDetail,
   getCanvasState,
@@ -720,6 +721,18 @@ export const UseGetCreditUsageByCanvasIdKeyFn = (
   clientOptions: Options<unknown, true>,
   queryKey?: Array<unknown>,
 ) => [useGetCreditUsageByCanvasIdKey, ...(queryKey ?? [clientOptions])];
+export type GetCanvasCommissionByCanvasIdDefaultResponse = Awaited<
+  ReturnType<typeof getCanvasCommissionByCanvasId>
+>['data'];
+export type GetCanvasCommissionByCanvasIdQueryResult<
+  TData = GetCanvasCommissionByCanvasIdDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useGetCanvasCommissionByCanvasIdKey = 'GetCanvasCommissionByCanvasId';
+export const UseGetCanvasCommissionByCanvasIdKeyFn = (
+  clientOptions: Options<unknown, true>,
+  queryKey?: Array<unknown>,
+) => [useGetCanvasCommissionByCanvasIdKey, ...(queryKey ?? [clientOptions])];
 export type ListInvitationCodesDefaultResponse = Awaited<
   ReturnType<typeof listInvitationCodes>
 >['data'];

--- a/packages/request/src/queries/ensureQueryData.ts
+++ b/packages/request/src/queries/ensureQueryData.ts
@@ -9,6 +9,7 @@ import {
   exportDocument,
   getActionResult,
   getAuthConfig,
+  getCanvasCommissionByCanvasId,
   getCanvasData,
   getCanvasDetail,
   getCanvasState,
@@ -75,6 +76,7 @@ import {
   ExportCanvasData,
   ExportDocumentData,
   GetActionResultData,
+  GetCanvasCommissionByCanvasIdData,
   GetCanvasDataData,
   GetCanvasDetailData,
   GetCanvasStateData,
@@ -523,6 +525,15 @@ export const ensureUseGetCreditUsageByCanvasIdData = (
   queryClient.ensureQueryData({
     queryKey: Common.UseGetCreditUsageByCanvasIdKeyFn(clientOptions),
     queryFn: () => getCreditUsageByCanvasId({ ...clientOptions }).then((response) => response.data),
+  });
+export const ensureUseGetCanvasCommissionByCanvasIdData = (
+  queryClient: QueryClient,
+  clientOptions: Options<GetCanvasCommissionByCanvasIdData, true>,
+) =>
+  queryClient.ensureQueryData({
+    queryKey: Common.UseGetCanvasCommissionByCanvasIdKeyFn(clientOptions),
+    queryFn: () =>
+      getCanvasCommissionByCanvasId({ ...clientOptions }).then((response) => response.data),
   });
 export const ensureUseListInvitationCodesData = (
   queryClient: QueryClient,

--- a/packages/request/src/queries/prefetch.ts
+++ b/packages/request/src/queries/prefetch.ts
@@ -9,6 +9,7 @@ import {
   exportDocument,
   getActionResult,
   getAuthConfig,
+  getCanvasCommissionByCanvasId,
   getCanvasData,
   getCanvasDetail,
   getCanvasState,
@@ -75,6 +76,7 @@ import {
   ExportCanvasData,
   ExportDocumentData,
   GetActionResultData,
+  GetCanvasCommissionByCanvasIdData,
   GetCanvasDataData,
   GetCanvasDetailData,
   GetCanvasStateData,
@@ -523,6 +525,15 @@ export const prefetchUseGetCreditUsageByCanvasId = (
   queryClient.prefetchQuery({
     queryKey: Common.UseGetCreditUsageByCanvasIdKeyFn(clientOptions),
     queryFn: () => getCreditUsageByCanvasId({ ...clientOptions }).then((response) => response.data),
+  });
+export const prefetchUseGetCanvasCommissionByCanvasId = (
+  queryClient: QueryClient,
+  clientOptions: Options<GetCanvasCommissionByCanvasIdData, true>,
+) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseGetCanvasCommissionByCanvasIdKeyFn(clientOptions),
+    queryFn: () =>
+      getCanvasCommissionByCanvasId({ ...clientOptions }).then((response) => response.data),
   });
 export const prefetchUseListInvitationCodes = (
   queryClient: QueryClient,

--- a/packages/request/src/queries/queries.ts
+++ b/packages/request/src/queries/queries.ts
@@ -71,6 +71,7 @@ import {
   generateMedia,
   getActionResult,
   getAuthConfig,
+  getCanvasCommissionByCanvasId,
   getCanvasData,
   getCanvasDetail,
   getCanvasState,
@@ -307,6 +308,8 @@ import {
   GetActionResultData,
   GetActionResultError,
   GetAuthConfigError,
+  GetCanvasCommissionByCanvasIdData,
+  GetCanvasCommissionByCanvasIdError,
   GetCanvasDataData,
   GetCanvasDataError,
   GetCanvasDetailData,
@@ -1261,6 +1264,23 @@ export const useGetCreditUsageByCanvasId = <
     queryKey: Common.UseGetCreditUsageByCanvasIdKeyFn(clientOptions, queryKey),
     queryFn: () =>
       getCreditUsageByCanvasId({ ...clientOptions }).then(
+        (response) => response.data as TData,
+      ) as TData,
+    ...options,
+  });
+export const useGetCanvasCommissionByCanvasId = <
+  TData = Common.GetCanvasCommissionByCanvasIdDefaultResponse,
+  TError = GetCanvasCommissionByCanvasIdError,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  clientOptions: Options<GetCanvasCommissionByCanvasIdData, true>,
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, 'queryKey' | 'queryFn'>,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseGetCanvasCommissionByCanvasIdKeyFn(clientOptions, queryKey),
+    queryFn: () =>
+      getCanvasCommissionByCanvasId({ ...clientOptions }).then(
         (response) => response.data as TData,
       ) as TData,
     ...options,

--- a/packages/request/src/queries/suspense.ts
+++ b/packages/request/src/queries/suspense.ts
@@ -9,6 +9,7 @@ import {
   exportDocument,
   getActionResult,
   getAuthConfig,
+  getCanvasCommissionByCanvasId,
   getCanvasData,
   getCanvasDetail,
   getCanvasState,
@@ -81,6 +82,8 @@ import {
   GetActionResultData,
   GetActionResultError,
   GetAuthConfigError,
+  GetCanvasCommissionByCanvasIdData,
+  GetCanvasCommissionByCanvasIdError,
   GetCanvasDataData,
   GetCanvasDataError,
   GetCanvasDetailData,
@@ -955,6 +958,23 @@ export const useGetCreditUsageByCanvasIdSuspense = <
     queryKey: Common.UseGetCreditUsageByCanvasIdKeyFn(clientOptions, queryKey),
     queryFn: () =>
       getCreditUsageByCanvasId({ ...clientOptions }).then(
+        (response) => response.data as TData,
+      ) as TData,
+    ...options,
+  });
+export const useGetCanvasCommissionByCanvasIdSuspense = <
+  TData = Common.GetCanvasCommissionByCanvasIdDefaultResponse,
+  TError = GetCanvasCommissionByCanvasIdError,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  clientOptions: Options<GetCanvasCommissionByCanvasIdData, true>,
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, 'queryKey' | 'queryFn'>,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseGetCanvasCommissionByCanvasIdKeyFn(clientOptions, queryKey),
+    queryFn: () =>
+      getCanvasCommissionByCanvasId({ ...clientOptions }).then(
         (response) => response.data as TData,
       ) as TData,
     ...options,

--- a/packages/request/src/requests/services.gen.ts
+++ b/packages/request/src/requests/services.gen.ts
@@ -391,6 +391,9 @@ import type {
   GetCreditUsageByCanvasIdData,
   GetCreditUsageByCanvasIdError,
   GetCreditUsageByCanvasIdResponse2,
+  GetCanvasCommissionByCanvasIdData,
+  GetCanvasCommissionByCanvasIdError,
+  GetCanvasCommissionByCanvasIdResponse2,
   ListInvitationCodesError,
   ListInvitationCodesResponse2,
   ActivateInvitationCodeData,
@@ -2600,6 +2603,23 @@ export const getCreditUsageByCanvasId = <ThrowOnError extends boolean = false>(
   >({
     ...options,
     url: '/credit/canvas',
+  });
+};
+
+/**
+ * Get canvas commission by canvas ID
+ * Get canvas commission (credit usage with commission rate) by canvas ID
+ */
+export const getCanvasCommissionByCanvasId = <ThrowOnError extends boolean = false>(
+  options: Options<GetCanvasCommissionByCanvasIdData, ThrowOnError>,
+) => {
+  return (options?.client ?? client).get<
+    GetCanvasCommissionByCanvasIdResponse2,
+    GetCanvasCommissionByCanvasIdError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/credit/commission',
   });
 };
 

--- a/packages/request/src/requests/types.gen.ts
+++ b/packages/request/src/requests/types.gen.ts
@@ -5214,6 +5214,18 @@ export type GetCreditUsageByCanvasIdResponse = BaseResponse & {
   };
 };
 
+export type GetCanvasCommissionByCanvasIdResponse = BaseResponse & {
+  /**
+   * Canvas commission by canvas ID
+   */
+  data?: {
+    /**
+     * Total canvas commission by canvas ID
+     */
+    total?: number;
+  };
+};
+
 export type InvitationCode = {
   /**
    * Invitation code
@@ -10306,6 +10318,10 @@ export type GetCreditUsageByResultIdData = {
      * Result ID
      */
     resultId: string;
+    /**
+     * Version number (optional, returns latest version if not specified)
+     */
+    version?: string;
   };
 };
 
@@ -10338,6 +10354,19 @@ export type GetCreditUsageByCanvasIdData = {
 export type GetCreditUsageByCanvasIdResponse2 = GetCreditUsageByCanvasIdResponse;
 
 export type GetCreditUsageByCanvasIdError = unknown;
+
+export type GetCanvasCommissionByCanvasIdData = {
+  query: {
+    /**
+     * Canvas ID
+     */
+    canvasId: string;
+  };
+};
+
+export type GetCanvasCommissionByCanvasIdResponse2 = GetCanvasCommissionByCanvasIdResponse;
+
+export type GetCanvasCommissionByCanvasIdError = unknown;
 
 export type ListInvitationCodesResponse2 = ListInvitationCodesResponse;
 

--- a/packages/stores/src/stores/action-result.ts
+++ b/packages/stores/src/stores/action-result.ts
@@ -22,6 +22,7 @@ interface ActionResultState {
   streamResults: Record<string, ActionResult>;
   traceIdMap: Record<string, string>; // key: resultId, value: traceId
   currentFile: DriveFile | null;
+  currentFileUsePublicFileUrl?: boolean;
 
   // Stream result actions
   addStreamResult: (resultId: string, result: ActionResult) => void;
@@ -55,7 +56,7 @@ interface ActionResultState {
   cleanupOldResults: () => void;
 
   // Current file management
-  setCurrentFile: (file: DriveFile | null) => void;
+  setCurrentFile: (file: DriveFile | null, options?: { usePublicFileUrl?: boolean }) => void;
 }
 
 export const defaultState = {
@@ -66,6 +67,7 @@ export const defaultState = {
   streamResults: {},
   traceIdMap: {},
   currentFile: null,
+  currentFileUsePublicFileUrl: undefined,
 };
 
 const POLLING_STATE_INITIAL: PollingState = {
@@ -424,10 +426,11 @@ export const useActionResultStore = create<ActionResultState>()(
       },
 
       // Current file management methods
-      setCurrentFile: (file: DriveFile | null) => {
+      setCurrentFile: (file: DriveFile | null, options?: { usePublicFileUrl?: boolean }) => {
         set((state) => ({
           ...state,
           currentFile: file,
+          currentFileUsePublicFileUrl: file ? options?.usePublicFileUrl : undefined,
         }));
       },
     }),

--- a/packages/utils/src/drive-file-mapper.ts
+++ b/packages/utils/src/drive-file-mapper.ts
@@ -137,7 +137,7 @@ export function mapDriveFileToWorkflowNodeExecution(
         metadata,
       },
     }),
-    entityId: file.fileId,
+    entityId: file.resultId,
   } as WorkflowNodeExecution;
 }
 


### PR DESCRIPTION
# Summary
  - add a PublicFileUrlProvider context + selection modal scoping so workflow previews/tool-call product cards inherit the correct drive-file visibility without prop drilling, and store the resolved flag in the action-result
  store for cross-tree previews
  - keep drive-file share creation idempotent by checking whether the `share/<id>.json` payload actually exists (static table or OSS) before reusing a record, and add logging around drive-file shares as well as external file
  streaming
  - expose MiscService.fileStorageExists and sprinkle tracing logs so backend diagnostics show when shares/files are reused, written, or missing

  # Impact Areas

  Please check the areas this PR affects:

  - [ ] Multi-threaded Dialogues
  - [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
  - [ ] Context Memory & References
  - [ ] Knowledge Base Integration & RAG
  - [ ] Quotes & Citations
  - [ ] AI Document Editing & WYSIWYG
  - [x] Free-form Canvas Interface
  | Before | After |
  | ------ | ----- |
  | N/A    | N/A   |

  # Checklist
  - [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added canvas commission data retrieval endpoint
  * Introduced file storage existence verification
  * Enabled share reuse across users with ownership validation
  * Implemented public file URL context for consistent file preview handling

* **Bug Fixes**
  * Corrected drive file product filtering and entity identification logic

* **Refactoring**
  * Streamlined import paths for node type modules
  * Optimized share creation workflow for improved data consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->