### PR TITLE
fix: clean up builtin toolset definition

### DIFF
--- a/packages/agent-tools/src/inventory.ts
+++ b/packages/agent-tools/src/inventory.ts
@@ -8,29 +8,15 @@ import {
   BuiltinGenerateCodeArtifactDefinition,
   BuiltinSendEmailToolset,
   BuiltinSendEmailDefinition,
-  BuiltinGetTimeToolset,
-  BuiltinGetTimeDefinition,
-  BuiltinReadFileToolset,
-  BuiltinReadFileDefinition,
-  BuiltinExecuteCodeToolset,
-  BuiltinExecuteCodeDefinition,
 } from './builtin';
 import { AgentBaseToolset } from './base';
 import { BrowserUseToolset, BrowserUseToolsetDefinition } from './browser-use';
-// import { FalAudioToolset, FalAudioToolsetDefinition } from './fal-audio';
-// import { FalImageToolset, FalImageToolsetDefinition } from './fal-image';
-// import { FalVideoToolset, FalVideoToolsetDefinition } from './fal-video';
-// import { FirecrawlToolset, FirecrawlToolsetDefinition } from './firecrawl';
-// DEPRECATED: FishAudio and HeyGen are now loaded from configuration
-// import { FishAudioToolset, FishAudioToolsetDefinition } from './fish-audio';
 import { GitHubToolsetDefinition } from './github';
-// import { HeyGenToolset, HeyGenToolsetDefinition } from './heygen';
 import { GmailToolsetDefinition } from './gmail';
 import { GoogleDocsToolsetDefinition } from './google-docs';
 import { GoogleDriveToolsetDefinition } from './google-drive';
 import { GoogleSheetsToolsetDefinition } from './google-sheets';
 import { JinaToolset, JinaToolsetDefinition } from './jina';
-// import { LinkedInToolsetDefinition } from './linkedin';
 import { NotionToolset, NotionToolsetDefinition } from './notion';
 import { PerplexityToolset, PerplexityToolsetDefinition } from './perplexity';
 import { ProductHuntToolset, ProductHuntToolsetDefinition } from './producthunt';
@@ -65,18 +51,6 @@ export const builtinToolsetInventory: Record<
     class: BuiltinSendEmailToolset,
     definition: BuiltinSendEmailDefinition,
   },
-  [BuiltinGetTimeDefinition.key]: {
-    class: BuiltinGetTimeToolset,
-    definition: BuiltinGetTimeDefinition,
-  },
-  [BuiltinReadFileDefinition.key]: {
-    class: BuiltinReadFileToolset,
-    definition: BuiltinReadFileDefinition,
-  },
-  [BuiltinExecuteCodeDefinition.key]: {
-    class: BuiltinExecuteCodeToolset,
-    definition: BuiltinExecuteCodeDefinition,
-  },
 };
 
 // Oauth tool use external sdk to execute, so the class is undefined
@@ -87,10 +61,6 @@ export const toolsetInventory: Record<
     definition: ToolsetDefinition;
   }
 > = {
-  // [FirecrawlToolsetDefinition.key]: {
-  //   class: FirecrawlToolset,
-  //   definition: FirecrawlToolsetDefinition,
-  // },
   [SandboxToolsetDefinition.key]: {
     class: SandboxToolset,
     definition: SandboxToolsetDefinition,
@@ -108,10 +78,6 @@ export const toolsetInventory: Record<
     class: JinaToolset,
     definition: JinaToolsetDefinition,
   },
-  // [WhaleWisdomToolsetDefinition.key]: {
-  //   class: WhaleWisdomToolset,
-  //   definition: WhaleWisdomToolsetDefinition,
-  // },
   [GoogleDocsToolsetDefinition.key]: {
     class: undefined,
     definition: GoogleDocsToolsetDefinition,
@@ -128,18 +94,6 @@ export const toolsetInventory: Record<
     class: NotionToolset,
     definition: NotionToolsetDefinition,
   },
-  // [FalAudioToolsetDefinition.key]: {
-  //   class: FalAudioToolset,
-  //   definition: FalAudioToolsetDefinition,
-  // },
-  // [FalImageToolsetDefinition.key]: {
-  //   class: FalImageToolset,
-  //   definition: FalImageToolsetDefinition,
-  // },
-  // [FalVideoToolsetDefinition.key]: {
-  //   class: FalVideoToolset,
-  //   definition: FalVideoToolsetDefinition,
-  // },
   [PerplexityToolsetDefinition.key]: {
     class: PerplexityToolset,
     definition: PerplexityToolsetDefinition,
@@ -160,10 +114,6 @@ export const toolsetInventory: Record<
     class: undefined,
     definition: GmailToolsetDefinition,
   },
-  // [LinkedInToolsetDefinition.key]: {
-  //   class: undefined,
-  //   definition: LinkedInToolsetDefinition,
-  // },
   [RedditToolsetDefinition.key]: {
     class: undefined,
     definition: RedditToolsetDefinition,


### PR DESCRIPTION
# Summary

- Removed deprecated and unused toolset imports to improve code clarity and maintainability.
- Ensured consistent use of optional chaining and nullish coalescing for safer property access throughout the file.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed registrations for built-in toolsets: Get Time, Read File, and Execute Code
  * Removed registrations for external toolsets: Firecrawl, Whale Wisdom, Fal Audio, Fal Image, Fal Video, and LinkedIn

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->