### PR TITLE
feat: enhance agent nodes and reasoning content display

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/shared/reasoning-content-preview.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/shared/reasoning-content-preview.tsx
@@ -1,12 +1,11 @@
 import { memo, useState, useEffect } from 'react';
 import { Markdown } from '@refly-packages/ai-workspace-common/components/markdown';
 import { Source } from '@refly/openapi-schema';
-import { ChevronDown, ChevronUp } from 'lucide-react';
 import { cn } from '@refly/utils/cn';
 import { useTranslation } from 'react-i18next';
 import { Button } from 'antd';
 import { getParsedReasoningContent } from '@refly/utils/content-parser';
-import { IconThinking } from '@refly-packages/ai-workspace-common/components/common/icon';
+import { Thinking, ArrowDown, ArrowUp } from 'refly-icons';
 
 interface ReasoningContentPreviewProps {
   content: string;
@@ -14,103 +13,53 @@ interface ReasoningContentPreviewProps {
   stepStatus: 'executing' | 'finish';
   className?: string;
   resultId?: string;
-  sizeMode?: 'compact' | 'adaptive';
 }
 
 export const ReasoningContentPreview = memo(
-  ({
-    content,
-    sources,
-    stepStatus,
-    className = '',
-    resultId,
-    sizeMode = 'adaptive',
-  }: ReasoningContentPreviewProps) => {
+  ({ content, sources, stepStatus, className = '', resultId }: ReasoningContentPreviewProps) => {
     const { t } = useTranslation();
-    const [collapsed, setCollapsed] = useState(
-      stepStatus !== 'executing' || sizeMode === 'compact',
-    );
+    const isExecuting = ['executing', 'waiting'].includes(stepStatus);
+    const [collapsed, setCollapsed] = useState(!isExecuting);
 
     // Auto-collapse when step status changes from executing to finish
     // or when sizeMode changes to compact
     useEffect(() => {
-      if (stepStatus === 'executing' && sizeMode !== 'compact') {
+      if (isExecuting) {
         setCollapsed(false);
       } else {
         setCollapsed(true);
       }
-    }, [stepStatus, sizeMode]);
+    }, [isExecuting]);
 
     if (!content?.trim()) return null;
 
     return (
-      <div
-        className={cn(
-          'bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 transition-all',
-          className,
-          {
-            'cursor-pointer hover:bg-gray-100': collapsed,
-            'p-3': sizeMode !== 'compact',
-            'p-2': sizeMode === 'compact',
-          },
-        )}
-      >
-        {collapsed ? (
-          <div
-            className="flex items-center justify-between text-xs"
-            onClick={() => sizeMode !== 'compact' && setCollapsed(false)}
-          >
-            <div className="flex items-center gap-1">
-              <IconThinking
-                className={cn('text-gray-500', {
-                  'w-4 h-4': sizeMode !== 'compact',
-                  'w-3 h-3': sizeMode === 'compact',
-                })}
-              />
-              <span
-                className={cn({
-                  truncate: sizeMode === 'compact',
-                  'max-w-[200px]': sizeMode === 'compact',
-                })}
-              >
-                {t('canvas.skillResponse.reasoningContent')}
-              </span>
-            </div>
-            {sizeMode !== 'compact' && <ChevronDown className="w-4 h-4" />}
+      <div className={cn('bg-refly-bg-control-z0 rounded-lg', className)}>
+        <div
+          className="p-3 flex items-center justify-between cursor-pointer"
+          onClick={() => setCollapsed(!collapsed)}
+        >
+          <div className="flex items-center gap-2 text-sm font-medium leading-5 text-refly-text-0">
+            <Thinking size={16} />
+            {t('canvas.skillResponse.reasoningContent')}
           </div>
-        ) : (
-          <div>
-            <div className="flex items-center justify-between mb-2">
-              <div className="flex items-center gap-1 text-xs font-medium">
-                <IconThinking className="w-4 h-4" />
-                {t('canvas.skillResponse.reasoningContent')}
-              </div>
-              <Button
-                type="text"
-                icon={<ChevronUp className="w-4 h-4" />}
-                onClick={() => setCollapsed(true)}
-                size="small"
-                className="flex items-center justify-center h-6 w-6 min-w-0 p-0"
-              />
-            </div>
-            <Markdown
-              className="text-xs overflow-hidden"
-              content={getParsedReasoningContent(content)}
-              sources={sources || []}
-              resultId={resultId}
-            />
-          </div>
+          <Button
+            type="text"
+            icon={collapsed ? <ArrowUp size={16} /> : <ArrowDown size={16} />}
+            onClick={() => setCollapsed(!collapsed)}
+            size="small"
+            className="flex items-center justify-center h-6 w-6 min-w-0 p-0"
+          />
+        </div>
+        {!collapsed && (
+          <Markdown
+            className="p-3 pt-0 text-xs overflow-hidden"
+            content={getParsedReasoningContent(content)}
+            sources={sources || []}
+            resultId={resultId}
+          />
         )}
       </div>
-    );
-  },
-  (prevProps, nextProps) => {
-    return (
-      prevProps.content === nextProps.content &&
-      prevProps.stepStatus === nextProps.stepStatus &&
-      prevProps.className === nextProps.className &&
-      prevProps.sizeMode === nextProps.sizeMode &&
-      JSON.stringify(prevProps.sources) === JSON.stringify(nextProps.sources)
     );
   },
 );

--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
@@ -746,14 +746,17 @@ export const SkillResponseNode = memo(
               source="node"
               canEdit={!readonly}
               actions={
-                <SkillResponseActions
-                  readonly={readonly}
-                  nodeIsExecuting={isExecuting}
-                  workflowIsRunning={workflowIsRunning}
-                  onRerunSingle={handleRerunSingle}
-                  onRerunFromHere={handleRerunFromHere}
-                  onStop={handleStop}
-                />
+                isHovered || selected ? (
+                  <SkillResponseActions
+                    readonly={readonly}
+                    nodeIsExecuting={isExecuting}
+                    workflowIsRunning={workflowIsRunning}
+                    onRerunSingle={handleRerunSingle}
+                    onRerunFromHere={handleRerunFromHere}
+                    onStop={handleStop}
+                    status={status}
+                  />
+                ) : null
               }
             />
 

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/publish-template-button.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/publish-template-button.tsx
@@ -138,7 +138,8 @@ const PublishTemplateButton = React.memo(
               className={cn(disabled ? 'opacity-50 cursor-not-allowed' : '')}
               type="primary"
               icon={<TurnRight size={16} />}
-              disabled={disabled}
+              //  remove this comment to restore the original style, the disable logic is handled in the event handler
+              // disabled={disabled}
               onClick={() => {
                 if (disabled) return;
 

--- a/packages/ai-workspace-common/src/components/result-message/index.tsx
+++ b/packages/ai-workspace-common/src/components/result-message/index.tsx
@@ -31,11 +31,12 @@ export const AIMessageCard = memo(({ message, resultId, stepStatus }: AIMessageC
   const content = message.content ?? '';
   const reasoningContent = message.reasoningContent ?? '';
   const hasReasoningContent = Boolean(reasoningContent?.trim());
+  const hasContent = Boolean(content?.trim());
 
-  if (!content?.trim()) return null;
+  if (!hasContent && !hasReasoningContent) return null;
 
   return (
-    <div className="my-2 px-3 text-base">
+    <div className="my-2 text-base">
       <div className={`skill-response-content-${resultId}-${message.messageId}`}>
         {hasReasoningContent && (
           <ReasoningContentPreview
@@ -45,7 +46,7 @@ export const AIMessageCard = memo(({ message, resultId, stepStatus }: AIMessageC
             resultId={resultId}
           />
         )}
-        <Markdown content={content} resultId={resultId} />
+        <Markdown content={content} resultId={resultId} className="px-3" />
       </div>
     </div>
   );

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -1492,6 +1492,8 @@ const translations = {
       skillCompleted: 'Skill Completed',
       stepCompleted: 'Step Completed',
       rerunSingle: 'Rerun This Node',
+      runSingle: 'Run This Node',
+      stopSingle: 'Stop',
       rerunFromHere: 'Run From Here',
       stopConfirmModal: {
         title: 'Stop Agent Task?',

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -1493,6 +1493,8 @@ const translations = {
       skillCompleted: '技能已完成',
       stepCompleted: '步骤已完成',
       rerunSingle: '仅运行此节点',
+      runSingle: '仅运行此节点',
+      stopSingle: '终止',
       rerunFromHere: '从此节点开始运行',
       stopConfirmModal: {
         title: '停止 Agent 任务？',


### PR DESCRIPTION
# Summary

- Updated SkillResponseNode to conditionally render SkillResponseActions based on hover and selection state.
- Refactored ReasoningContentPreview to improve state management and styling with Tailwind CSS.
- Introduced new icons and adjusted button functionalities in SkillResponseActions for better user interaction.
- Ensured proper use of optional chaining and nullish coalescing for safer property access throughout the components.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features & Improvements**
  * Streamlined skill response node actions with explicit button controls replacing dropdown menus
  * Reasoning content preview features simplified header design with compact toggle layout
  * Action controls now appear contextually when nodes are hovered or selected for a cleaner interface

* **Localization**
  * Added new translated labels supporting English and Chinese languages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->