### PR TITLE
hotfix: credit pricing page

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas-template/template-list.tsx
+++ b/packages/ai-workspace-common/src/components/canvas-template/template-list.tsx
@@ -10,7 +10,7 @@ import { TemplateCardSkeleton } from './template-card-skeleton';
 import cn from 'classnames';
 
 // Marketplace link
-const MARKETPLACE_LINK = `${window.location.origin}`;
+const MARKETPLACE_LINK = `${window.location.origin}/marketplace`;
 
 // Custom EndMessage component for template list
 const EndMessage = memo(() => {

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -888,7 +888,7 @@ const translations = {
       endMessage: {
         title: "Didn't find the workflow automation template you need?",
         subtitle: "Join our Discord and tell us what you're looking for",
-        goToMarketplace: 'Go to Marketplace',
+        goToMarketplace: 'Explore More Templates',
       },
     },
     agentInputPlaceholder: 'Enter task description, Agent will generate reusable workflows',
@@ -2704,7 +2704,7 @@ const translations = {
       getStarted: 'Get Started',
       subscribeNow: 'Subscribe Now',
       manage: 'Manage Subscription',
-      currentPlan: 'Current Plan',
+      currentPlan: 'Your Current Plan',
       t1Requests: 'T1 Requests',
       t1RequestsDescription:
         'T1 models include Claude 3.7 Sonnet (Thinking), DeepSeek R1, o3 Mini, GPT-4o and others. Each successful skill call to T1 models counts as one request.',
@@ -3591,7 +3591,7 @@ const translations = {
     },
   },
   subscription: {
-    modalTitle: 'Upgrade to Get More Credits',
+    modalTitle: 'Upgrade Your Plan to Get More Credits',
     cancelAnytime: "Cancel anytime. By subscribing, you agree to Refly's",
     privacy: 'Privacy',
     terms: 'Terms',
@@ -3621,14 +3621,15 @@ const translations = {
       priceMonthly: '{{price}}/month',
       priceYearly: '{{price}}/month',
       priceYearlyTotal: '{{price}}/year Save 20%',
-      upgrade: 'Upgrade to {{planType}}',
+      upgrade: 'Get {{planType}}',
       cannotChangeTo: 'Cannot change to {{planType}}',
-      currentPlan: 'Current Plan',
+      currentPlan: 'Your Current Plan',
       cannotSwitchTo:
         "Legacy plans can't be switched to Plus directly.Please contact support@refly.ai",
+      memberBenefits: 'Member Benefits',
       free: {
-        title: 'Free Plan',
-        description: 'A welcoming gateway to explore the power of AI—completely free',
+        title: 'Free',
+        description: 'Ideal for beginners exploring workflow automation',
         price: 'Free forever',
         buttonText: 'Continue for free',
         buttonTextDowngrade: 'Downgrade to Free',
@@ -3644,9 +3645,9 @@ const translations = {
         features: [
           'Daily new credits\n300 credits',
           'Monthly credits\n2,000 credits',
-          'New subscribers receive an extra\n2,000 bonus credits',
+          //'New subscribers receive an extra\n2,000 bonus credits',
           'Access to a vast library of tools',
-          {
+          /*{
             name: 'Credit-free tools',
             type: 'pointFreeTools',
             items: [
@@ -3660,7 +3661,7 @@ const translations = {
               'X',
             ],
             duration: '365 DAYS',
-          },
+          },*/
           'Service support\nHigh priority support',
         ],
       },
@@ -3825,7 +3826,7 @@ const translations = {
     storageFullModal: {
       free: {
         title: 'Free Plan',
-        titleCn: 'Current Plan',
+        titleCn: 'Your Current Plan',
         description: 'A welcoming gateway to explore the power of AI—completely free',
         price: 'Free forever',
         buttonText: 'Continue for free',
@@ -3880,7 +3881,7 @@ const translations = {
           'More enterprise features coming soon',
         ],
       },
-      currentPlan: 'Current Plan',
+      currentPlan: 'Your Current Plan',
     },
   },
   onboarding: {

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -138,9 +138,9 @@ const translations = {
         features: [
           '每日可获取新积分\n100点',
           '每月积分\n2000点',
-          '首次订阅额外赠送\n2000点',
+          //'首次订阅额外赠送\n2000点',
           '访问丰富的工具库',
-          {
+          /*{
             name: '免积分使用工具',
             type: 'pointFreeTools',
             items: [
@@ -154,7 +154,7 @@ const translations = {
               'X',
             ],
             duration: '365 DAYS',
-          },
+          },*/
           '服务支持\n高优邮件支持',
         ],
       },
@@ -968,7 +968,7 @@ const translations = {
       endMessage: {
         title: '没有找到你需要的工作流自动化模板？',
         subtitle: '加入我们的 Discord 社区，告诉我们你想要什么',
-        goToMarketplace: '前往 Marketplace',
+        goToMarketplace: '探索更多模板',
       },
     },
     agentInputPlaceholder: '输入任务描述，Agent 将生成可复用的工作流',


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plans simplified to Free and Plus; Free now displays a $0/month price block; Plus supports per-feature styling and grouped tool entries.

* **UI Updates**
  * Pricing cards refreshed: explicit selected borders, hover gradient for paid plans, rounded yearly badge, subscription and lightning icons, upgraded button icon (size/color) and visual tweaks across cards.

* **Messaging**
  * Updated subscription and plan wording; "Go to Marketplace" → "Explore More Templates" (EN/ZH).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->