### PR TITLE
fix: prevent workspace tab switching from triggering login status check

### DIFF
--- a/packages/ai-workspace-common/src/hooks/use-get-user-settings.ts
+++ b/packages/ai-workspace-common/src/hooks/use-get-user-settings.ts
@@ -1,11 +1,7 @@
 import { useEffect } from 'react';
 import { useCookie } from 'react-use';
 import { useTranslation } from 'react-i18next';
-import {
-  useLocation,
-  useNavigate,
-  useSearchParams,
-} from '@refly-packages/ai-workspace-common/utils/router';
+import { useNavigate, useSearchParams } from '@refly-packages/ai-workspace-common/utils/router';
 
 import getClient from '@refly-packages/ai-workspace-common/requests/proxiedRequest';
 import { LocalSettings, useUserStoreShallow } from '@refly/stores';
@@ -33,7 +29,6 @@ export const useGetUserSettings = () => {
   }));
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const location = useLocation();
 
   const [uid] = useCookie(UID_COOKIE);
 
@@ -61,10 +56,10 @@ export const useGetUserSettings = () => {
       userStore.setUserProfile(undefined);
       userStore.setIsLogin(false);
 
-      // Use location.pathname from useLocation hook to get current route
+      // Use window.location.pathname to get current route (always latest, no dependency needed)
       // We use isPublicAccessPageByPath (extracted from usePublicAccessPage) to check
       // This ensures we get the latest route value even in async context
-      const isPublicPage = isPublicAccessPageByPath(location.pathname);
+      const isPublicPage = isPublicAccessPageByPath(window.location.pathname);
 
       if (!isPublicPage) {
         navigate(`/?${searchParams.toString()}`); // Extension should navigate to home
@@ -158,5 +153,5 @@ export const useGetUserSettings = () => {
 
   useEffect(() => {
     getLoginStatus();
-  }, [hasLoginCredentials, location.pathname]);
+  }, [hasLoginCredentials]);
 };


### PR DESCRIPTION
- Remove location.pathname from useEffect dependencies to prevent unnecessary re-checks
- Use window.location.pathname in getLoginStatus for latest route value
- Fixes issue where switching tabs in /workspace caused full-screen loading

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal path tracking logic for improved performance and reduced unnecessary re-renders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->