### PR TITLE
feat: Add APIs to retrieve workflow execution results

### DIFF
--- a/apps/api/src/modules/workflow/workflow.controller.ts
+++ b/apps/api/src/modules/workflow/workflow.controller.ts
@@ -68,4 +68,28 @@ export class WorkflowController {
     const workflowDetail = await this.workflowService.getWorkflowDetail(user, executionId);
     return buildSuccessResponse(workflowExecutionPO2DTO(workflowDetail));
   }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('lastDetail')
+  async getLatestWorkflowDetail(
+    @LoginedUser() user: UserModel,
+    @Query('canvasId') canvasId: string,
+  ): Promise<GetWorkflowDetailResponse> {
+    if (!canvasId) {
+      throw new ParamsError('Canvas ID is required');
+    }
+
+    const workflowDetail = await this.workflowService.getLatestWorkflowDetail(user, canvasId);
+    return buildSuccessResponse(workflowExecutionPO2DTO(workflowDetail));
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('allDetails')
+  async getAllWorkflowDetails(
+    @LoginedUser() user: UserModel,
+    @Query('canvasId') canvasId?: string,
+  ) {
+    const workflowDetails = await this.workflowService.getAllWorkflowDetails(user, canvasId);
+    return buildSuccessResponse(workflowDetails.map(workflowExecutionPO2DTO));
+  }
 }


### PR DESCRIPTION
# Summary

This PR adds two new API endpoints to retrieve workflow execution results:

- **GET /workflow/lastDetail**: Retrieves the latest workflow execution for a specific canvas
- **GET /workflow/allDetails**: Retrieves all workflow executions, with optional canvas filtering

Both endpoints return complete workflow execution details including sorted node executions based on their execution order.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [x] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added two new authenticated endpoints for accessing workflow execution history:
  * Retrieve the latest workflow execution details for a specific canvas
  * Retrieve all workflow execution details for a user, optionally filtered by canvas
  * Both endpoints require authentication and return detailed execution information

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->