### PR TITLE
feat: add currentPlan and source fields to checkout session models an…

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1560,6 +1560,10 @@ model CheckoutSession {
   invoiceId      String?  @map("invoice_id")
   /// Stripe customer ID
   customerId     String?  @map("customer_id")
+  /// Current plan
+  currentPlan    String?  @map("current_plan")
+  /// Source (canvas, template, pricing, etc.)
+  source         String?  @map("source")
   /// Create timestamp
   createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz()
   /// Update timestamp

--- a/apps/api/src/modules/subscription/subscription.service.ts
+++ b/apps/api/src/modules/subscription/subscription.service.ts
@@ -5,7 +5,12 @@ import { PrismaService } from '../common/prisma.service';
 import { CreditService } from '../credit/credit.service';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
-import { CreateCheckoutSessionRequest, SubscriptionUsageData, User } from '@refly/openapi-schema';
+import {
+  CreateCheckoutSessionRequest,
+  CreateCreditPackCheckoutSessionRequest,
+  SubscriptionUsageData,
+  User,
+} from '@refly/openapi-schema';
 import { genTokenUsageMeterID, genStorageUsageMeterID, safeParseJSON } from '@refly/utils';
 import {
   CreateSubscriptionParam,
@@ -224,6 +229,8 @@ export class SubscriptionService implements OnModuleInit {
           uid,
           sessionId: session.id,
           lookupKey,
+          currentPlan: param.currentPlan,
+          source: param.source,
         },
       }),
       // Only update if customer ID changed
@@ -240,7 +247,7 @@ export class SubscriptionService implements OnModuleInit {
     return session;
   }
 
-  async createCreditPackCheckoutSession(user: User, param: { packId: string }) {
+  async createCreditPackCheckoutSession(user: User, param: CreateCreditPackCheckoutSessionRequest) {
     const { uid } = user;
     const userPo = await this.prisma.user.findUnique({ where: { uid } });
 
@@ -307,6 +314,8 @@ export class SubscriptionService implements OnModuleInit {
         uid,
         sessionId: session?.id ?? '',
         lookupKey,
+        currentPlan: param.currentPlan,
+        source: param.source,
       },
     });
 

--- a/apps/api/src/modules/subscription/subscription.webhook.ts
+++ b/apps/api/src/modules/subscription/subscription.webhook.ts
@@ -6,6 +6,7 @@ import { PrismaService } from '../common/prisma.service';
 import { CreditService } from '../credit/credit.service';
 import { SubscriptionService } from './subscription.service';
 import { Prisma } from '@prisma/client';
+import { logEvent } from '@refly/telemetry-node';
 
 @Injectable()
 export class SubscriptionWebhooks {
@@ -59,7 +60,7 @@ export class SubscriptionWebhooks {
     // Check if customerId is already associated with this user
     const user = await this.prisma.user.findUnique({
       where: { uid },
-      select: { customerId: true },
+      select: { uid: true, customerId: true, email: true },
     });
 
     // Update user's customerId if it's missing or different
@@ -93,6 +94,11 @@ export class SubscriptionWebhooks {
         `Credit pack purchase: ${packPlan.name}`,
       );
 
+      logEvent(user, `purchase_${packPlan.packId}_success`, null, {
+        user_plan: checkoutSession.currentPlan,
+        source: checkoutSession.source,
+      });
+
       this.logger.log(
         `Successfully processed credit pack purchase checkout session ${session.id} for user ${uid}`,
       );
@@ -114,6 +120,11 @@ export class SubscriptionWebhooks {
       status: 'active',
       subscriptionId,
       customerId,
+    });
+
+    logEvent(user, 'purchase_plus_success', null, {
+      user_plan: checkoutSession.currentPlan,
+      source: checkoutSession.source,
     });
 
     this.logger.log(`Successfully processed checkout session ${session.id} for user ${uid}`);

--- a/packages/ai-workspace-common/src/components/settings/subscribe-modal/priceContent.tsx
+++ b/packages/ai-workspace-common/src/components/settings/subscribe-modal/priceContent.tsx
@@ -505,6 +505,8 @@ export const PriceContent = memo((props: { source: PriceSource }) => {
           body: {
             planType,
             interval: interval,
+            currentPlan,
+            source: 'pricing',
           },
         });
         if (res.data?.data?.url) {

--- a/packages/ai-workspace-common/src/components/subscription/credit-insufficient-modal.tsx
+++ b/packages/ai-workspace-common/src/components/subscription/credit-insufficient-modal.tsx
@@ -483,6 +483,8 @@ export const CreditInsufficientModal = memo(() => {
           body: {
             planType: 'plus' as SubscriptionPlanType,
             interval: interval,
+            currentPlan,
+            source: creditInsufficientTriggeredFrom,
           },
         });
         if (res.data?.data?.url) {
@@ -497,6 +499,8 @@ export const CreditInsufficientModal = memo(() => {
         const res = await getClient().createCreditPackCheckoutSession({
           body: {
             packId: selectedId,
+            currentPlan,
+            source: creditInsufficientTriggeredFrom,
           },
         });
         if (res.data?.data?.url) {

--- a/packages/ai-workspace-common/src/requests/types.gen.ts
+++ b/packages/ai-workspace-common/src/requests/types.gen.ts
@@ -5066,6 +5066,14 @@ export type CreateCheckoutSessionRequest = {
    * Subscription billing interval
    */
   interval?: SubscriptionInterval;
+  /**
+   * Current plan
+   */
+  currentPlan?: string;
+  /**
+   * Source
+   */
+  source?: string;
 };
 
 export type CreateCreditPackCheckoutSessionRequest = {
@@ -5073,6 +5081,14 @@ export type CreateCreditPackCheckoutSessionRequest = {
    * Credit pack identifier
    */
   packId: string;
+  /**
+   * Current plan
+   */
+  currentPlan?: string;
+  /**
+   * Source
+   */
+  source?: string;
 };
 
 export type CreateCheckoutSessionResponse = BaseResponse & {
@@ -7584,6 +7600,10 @@ export type DriveFile = {
    * Drive file update timestamp
    */
   updatedAt?: string;
+  /**
+   * Private access URL for the file (requires authentication)
+   */
+  url?: string;
 };
 
 export type ListDriveFilesResponse = BaseResponse & {

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -9198,6 +9198,12 @@ components:
         interval:
           description: Subscription billing interval
           $ref: '#/components/schemas/SubscriptionInterval'
+        currentPlan:
+          type: string
+          description: Current plan
+        source:
+          type: string
+          description: Source
     CreateCreditPackCheckoutSessionRequest:
       type: object
       required: 
@@ -9206,6 +9212,12 @@ components:
         packId:
           type: string
           description: Credit pack identifier
+        currentPlan:
+          type: string
+          description: Current plan
+        source:
+          type: string
+          description: Source
     CreateCheckoutSessionResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -7096,6 +7096,14 @@ export const CreateCheckoutSessionRequestSchema = {
       description: 'Subscription billing interval',
       $ref: '#/components/schemas/SubscriptionInterval',
     },
+    currentPlan: {
+      type: 'string',
+      description: 'Current plan',
+    },
+    source: {
+      type: 'string',
+      description: 'Source',
+    },
   },
 } as const;
 
@@ -7106,6 +7114,14 @@ export const CreateCreditPackCheckoutSessionRequestSchema = {
     packId: {
       type: 'string',
       description: 'Credit pack identifier',
+    },
+    currentPlan: {
+      type: 'string',
+      description: 'Current plan',
+    },
+    source: {
+      type: 'string',
+      description: 'Source',
     },
   },
 } as const;

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -5066,6 +5066,14 @@ export type CreateCheckoutSessionRequest = {
    * Subscription billing interval
    */
   interval?: SubscriptionInterval;
+  /**
+   * Current plan
+   */
+  currentPlan?: string;
+  /**
+   * Source
+   */
+  source?: string;
 };
 
 export type CreateCreditPackCheckoutSessionRequest = {
@@ -5073,6 +5081,14 @@ export type CreateCreditPackCheckoutSessionRequest = {
    * Credit pack identifier
    */
   packId: string;
+  /**
+   * Current plan
+   */
+  currentPlan?: string;
+  /**
+   * Source
+   */
+  source?: string;
 };
 
 export type CreateCheckoutSessionResponse = BaseResponse & {

--- a/packages/request/src/requests/types.gen.ts
+++ b/packages/request/src/requests/types.gen.ts
@@ -5066,6 +5066,14 @@ export type CreateCheckoutSessionRequest = {
    * Subscription billing interval
    */
   interval?: SubscriptionInterval;
+  /**
+   * Current plan
+   */
+  currentPlan?: string;
+  /**
+   * Source
+   */
+  source?: string;
 };
 
 export type CreateCreditPackCheckoutSessionRequest = {
@@ -5073,6 +5081,14 @@ export type CreateCreditPackCheckoutSessionRequest = {
    * Credit pack identifier
    */
   packId: string;
+  /**
+   * Current plan
+   */
+  currentPlan?: string;
+  /**
+   * Source
+   */
+  source?: string;
 };
 
 export type CreateCheckoutSessionResponse = BaseResponse & {
@@ -7584,6 +7600,10 @@ export type DriveFile = {
    * Drive file update timestamp
    */
   updatedAt?: string;
+  /**
+   * Private access URL for the file (requires authentication)
+   */
+  url?: string;
 };
 
 export type ListDriveFilesResponse = BaseResponse & {


### PR DESCRIPTION
…d requests

- Introduced currentPlan and source fields in the CheckoutSession model for better tracking of subscription details.
- Updated CreateCheckoutSessionRequest and CreateCreditPackCheckoutSessionRequest types to include currentPlan and source.
- Enhanced subscription service and webhook logic to utilize new fields for improved telemetry logging and user experience.
- Refactored related components to pass currentPlan and source during checkout session creation.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods
