### PR TITLE
  feat: add dual file URL placeholders for emails and improve HTTP cache validation with OSS lastModified

### DIFF
--- a/apps/api/src/modules/skill/skill-engine.service.ts
+++ b/apps/api/src/modules/skill/skill-engine.service.ts
@@ -254,8 +254,9 @@ export class SkillEngineService implements OnModuleInit {
         );
 
         const url = `${this.config.get('origin')}/share/file/${shareRecord.shareId}`;
+        const contentUrl = `${this.config.get('origin')}/v1/drive/file/public/${fileId}`;
 
-        return { url, shareId: shareRecord.shareId, driveFile };
+        return { url, contentUrl, shareId: shareRecord.shareId, driveFile };
       },
       genImageID: async () => {
         return genImageID();

--- a/packages/agent-tools/src/builtin/interface.ts
+++ b/packages/agent-tools/src/builtin/interface.ts
@@ -141,7 +141,12 @@ export interface ReflyService {
   createShareForDriveFile: (
     user: User,
     fileId: string,
-  ) => Promise<{ url: string; shareId: string; driveFile: DriveFile }>;
+  ) => Promise<{
+    url: string; // Share page URL (for links/previews)
+    contentUrl: string; // Direct file content URL (for <img src="">)
+    shareId: string;
+    driveFile: DriveFile;
+  }>;
 
   getUserMediaConfig(
     user: User,


### PR DESCRIPTION
# Summary

  This PR introduces two improvements:

  1. **Dual file URL placeholder support for LLM-generated HTML emails**
     - `file://df-xxx` → Share preview page URL (for clickable links like `<a href="">`)
     - `file-content://df-xxx` → Direct file content URL (for embedded media like `<img src="">`, `<video src="">`)

     This allows LLM to choose the appropriate URL type based on the use case, fixing the issue where `<img src="">` tags were receiving share page URLs instead of direct content URLs.

  2. **HTTP cache validation using OSS lastModified**
     - Changed cache validation to use the more recent timestamp between OSS `lastModified` and DB `updatedAt`
     - Returns 404 if file doesn't exist in OSS storage
     - Prevents browser from caching stale content when files are being migrated from internal to external OSS

  # Impact Areas

  - [x] Other

  # Screenshots/Videos

  N/A - Backend changes only

  # Checklist

  - [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
  - [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
  - [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - [x] I've updated the documentation accordingly.
  - [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

  ## Files Changed

  ### File URL Placeholder Support
  - `packages/agent-tools/src/builtin/index.ts` - Added `file-content://` placeholder support, updated tool description
  - `packages/agent-tools/src/builtin/interface.ts` - Added `contentUrl` to `createShareForDriveFile` return type
  - `apps/api/src/modules/skill/skill-engine.service.ts` - Return both `url` and `contentUrl`

  ### HTTP Cache Validation
  - `apps/api/src/modules/drive/drive.service.ts` - `getDriveFileMetadata` and `getPublicFileMetadata` now use OSS lastModified
  - `apps/api/src/modules/misc/misc.service.ts` - `getInternalFileMetadata` and `getExternalFileMetadata` now use OSS lastModified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `contentUrl` field for enhanced file sharing capabilities.
  * Expanded email file embedding to support dual placeholder formats: shareable links and direct content URLs for media elements.

* **Bug Fixes**
  * Improved accuracy of file modification timestamps by synchronizing storage and database records.
  * Enhanced validation to detect missing files in object storage and provide clearer error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->