### PR TITLE
fix: Keep auto model when appending nodes

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
@@ -604,7 +604,8 @@ export const SkillResponseNode = memo(
         dragCreateInfo?: NodeDragCreateInfo;
       }) => {
         const { metadata } = data;
-        const { selectedSkill, actionMeta, modelInfo } = metadata;
+        // Do not pass modelInfo to the new node. The new node should use the Auto model.
+        const { selectedSkill, actionMeta, modelInfo: _ignored, ...restMetadata } = metadata;
 
         const currentSkill = actionMeta || selectedSkill;
 
@@ -644,11 +645,10 @@ export const SkillResponseNode = memo(
                 title: '',
                 entityId: genNodeEntityId('skillResponse') as string,
                 metadata: {
-                  ...metadata,
+                  ...restMetadata,
                   query: '',
                   contextItems: mergedContextItems,
                   selectedSkill: currentSkill,
-                  modelInfo,
                   status: 'init',
                 },
               },


### PR DESCRIPTION
# Summary

This PR fixes an issue where follow-up skill nodes incorrectly inherited the model configuration from their parent nodes. Now, when creating a follow-up node from a skill response, the `modelInfo` is intentionally excluded so that the new node can use the Auto model instead.

The change ensures that follow-up nodes don't carry over the specific model selection from the previous node, allowing them to automatically select the appropriate model based on the context.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [x] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [x] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where AI skill response nodes would inherit previous model configurations instead of automatically defaulting to the Auto model selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->