### PR TITLE
feat: Add `endpoint` configuration and use it for public file content…

### DIFF
--- a/apps/api/src/modules/config/app.config.ts
+++ b/apps/api/src/modules/config/app.config.ts
@@ -4,6 +4,7 @@ export default () => ({
   port: Number.parseInt(process.env.PORT) || 5800,
   wsPort: Number.parseInt(process.env.WS_PORT) || 5801,
   origin: process.env.ORIGIN || 'http://localhost:5700',
+  endpoint: process.env.ENDPOINT || 'http://localhost:5800',
   static: {
     public: {
       endpoint: process.env.STATIC_PUBLIC_ENDPOINT || 'http://localhost:5800/v1/misc/public',

--- a/apps/api/src/modules/skill/skill-engine.service.ts
+++ b/apps/api/src/modules/skill/skill-engine.service.ts
@@ -262,7 +262,7 @@ export class SkillEngineService implements OnModuleInit {
         );
 
         const url = `${this.config.get('origin')}/share/file/${shareRecord.shareId}`;
-        const contentUrl = `${this.config.get('origin')}/v1/drive/file/public/${fileId}`;
+        const contentUrl = `${this.config.get('endpoint')}/v1/drive/file/public/${fileId}`;
 
         return { url, contentUrl, shareId: shareRecord.shareId, driveFile };
       },


### PR DESCRIPTION
… URLs in the skill engine.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [ ] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [ ] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable endpoint setting for API operations (defaults to http://localhost:5800).

* **Bug Fixes**
  * Updated public file sharing URL generation to use configured endpoint instead of origin.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->