### PR TITLE
feat: Support multi-region for Bedrock provider

### DIFF
--- a/packages/providers/src/llm/index.ts
+++ b/packages/providers/src/llm/index.ts
@@ -15,6 +15,35 @@ interface BedrockApiKeyConfig {
   secretAccessKey: string;
 }
 
+interface BedrockExtraParams {
+  region?: string;
+  regions?: string[];
+}
+
+/**
+ * Select region for Bedrock provider with the following priority:
+ * 1. If `region` is specified, use it directly (backward compatible)
+ * 2. Otherwise, randomly select from `regions` array (load balancing)
+ * 3. If neither is specified, throw an error
+ */
+const selectBedrockRegion = (extraParams: BedrockExtraParams): string => {
+  // Priority 1: Use fixed region if specified
+  if (extraParams.region) {
+    return extraParams.region;
+  }
+
+  // Priority 2: Randomly select from regions array
+  if (extraParams.regions && extraParams.regions.length > 0) {
+    const randomIndex = Math.floor(Math.random() * extraParams.regions.length);
+    return extraParams.regions[randomIndex];
+  }
+
+  // Neither region nor regions is specified
+  throw new ProviderMisconfigurationError(
+    'Region is required for Bedrock provider. Specify either "region" (single) or "regions" (array) in extraParams.',
+  );
+};
+
 export const getChatModel = (
   provider: BaseProvider,
   config: LLMModelConfig,
@@ -72,19 +101,19 @@ export const getChatModel = (
         ...commonParams,
       });
       break;
-    case 'bedrock':
-      if (!extraParams.region) {
-        throw new ProviderMisconfigurationError('Region is required for Bedrock provider');
-      }
+    case 'bedrock': {
+      const selectedRegion = selectBedrockRegion(extraParams as BedrockExtraParams);
+      // Exclude region/regions from commonParams to prevent overriding selectedRegion
+      const { region: _region, regions: _regions, ...bedrockCommonParams } = commonParams;
 
       try {
         const apiKeyConfig = JSON.parse(provider.apiKey) as BedrockApiKeyConfig;
         model = new ChatBedrockConverse({
           model: config.modelId,
-          region: extraParams.region,
+          region: selectedRegion,
           credentials: apiKeyConfig,
           maxTokens: config?.maxOutput,
-          ...commonParams,
+          ...bedrockCommonParams,
           ...(config?.capabilities?.reasoning
             ? {
                 additionalModelRequestFields: {
@@ -101,6 +130,7 @@ export const getChatModel = (
         throw new ProviderMisconfigurationError(`Invalid bedrock api key config: ${error}`);
       }
       break;
+    }
     case 'vertex': {
       model = new ChatVertexAI({
         model: config.modelId,


### PR DESCRIPTION
# Summary

Add support for multi-region configuration in Bedrock provider to enable region-based load balancing.

## Changes

- Add `BedrockExtraParams` interface with `region` and `regions` fields
- Implement `selectBedrockRegion` helper function with the following priority:
  1. Use `region` if specified (backward compatible)
  2. Randomly select from `regions` array (load balancing)
  3. Throw error if neither is specified
- Update `getChatModel` to use the new region selection logic

## Benefits

- Distribute requests across multiple AWS regions
- Reduce rate limit issues by load balancing
- Maintain backward compatibility with existing `region` configuration

# Impact Areas

Please check the areas this PR affects:

- [ ] Multi-threaded Dialogues
- [x] AI-Powered Capabilities (Web Search, Knowledge Base Search, Question Recommendations)
- [ ] Context Memory & References
- [ ] Knowledge Base Integration & RAG
- [ ] Quotes & Citations
- [ ] AI Document Editing & WYSIWYG
- [ ] Free-form Canvas Interface
- [x] Other

# Screenshots/Videos

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Refly Documentation](https://github.com/langgenius/refly-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bedrock provider now auto-selects an operating region with priority for a fixed region and fallback to a random region from a provided list.

* **Bug Fixes**
  * Improved validation and clearer error messages when region configuration is missing or invalid.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->