### PR TITLE
fix: Set correct copilot model name in action result

### DIFF
--- a/apps/api/src/modules/skill/skill.dto.ts
+++ b/apps/api/src/modules/skill/skill.dto.ts
@@ -17,22 +17,24 @@ import {
 import { pick } from '../../utils';
 import { safeParseJSON } from '@refly/utils';
 
+export type ModelConfigMap = {
+  chat?: LLMModelConfig;
+  copilot?: LLMModelConfig;
+  agent?: LLMModelConfig;
+  queryAnalysis?: LLMModelConfig;
+  titleGeneration?: LLMModelConfig;
+  image?: MediaGenerationModelConfig;
+  video?: MediaGenerationModelConfig;
+  audio?: MediaGenerationModelConfig;
+};
+
 export interface InvokeSkillJobData extends InvokeSkillRequest {
   uid: string;
   rawParam: string;
   result?: ActionResult;
   provider?: Provider;
   providerItem?: ProviderItem;
-  modelConfigMap?: {
-    chat?: LLMModelConfig;
-    copilot?: LLMModelConfig;
-    agent?: LLMModelConfig;
-    queryAnalysis?: LLMModelConfig;
-    titleGeneration?: LLMModelConfig;
-    image?: MediaGenerationModelConfig;
-    video?: MediaGenerationModelConfig;
-    audio?: MediaGenerationModelConfig;
-  };
+  modelConfigMap?: ModelConfigMap;
 }
 
 export function skillInstancePO2DTO(skill: SkillInstanceModel): SkillInstance {


### PR DESCRIPTION
## Summary

This PR fixes an issue where action results always recorded the chat model name regardless of the actual execution mode. Now the system correctly records:
- Copilot model name when running in `copilot_agent` mode
- Agent model name when running in `node_agent` mode  
- Chat model name as fallback for other modes

## Changes

- Extracted `ModelConfigMap` as a standalone type for better code organization
- Added `getModelNameForMode()` helper function to select the appropriate model name based on execution mode
- Updated action result creation to use the correct model name instead of always using `chat.modelId`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced model selection logic to correctly determine the appropriate AI model based on agent type (copilot, node, or chat mode), ensuring accurate model usage across different agent configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->