### PR TITLE
feat: Add auto model routing tracking for token usage

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -426,31 +426,36 @@ enum ActionStatus {
 
 model TokenUsage {
   /// Primary key
-  pk             BigInt   @id @default(autoincrement())
+  pk              BigInt   @id @default(autoincrement())
   /// UID
-  uid            String   @map("uid")
+  uid             String   @map("uid")
   /// Action result id
-  resultId       String?  @map("result_id")
+  resultId        String?  @map("result_id")
   /// Model tier
-  tier           String   @map("tier")
+  tier            String   @map("tier")
   /// Model provider
-  modelProvider  String   @default("") @map("model_provider")
+  modelProvider   String   @default("") @map("model_provider")
   /// Model name
-  modelName      String   @default("") @map("model_name")
+  modelName       String   @default("") @map("model_name")
   /// Model label
-  modelLabel     String   @default("") @map("model_label")
+  modelLabel      String   @default("") @map("model_label")
   /// Provider item id
-  providerItemId String?  @map("provider_item_id")
+  providerItemId  String?  @map("provider_item_id")
+  /// Original model ID before routing (e.g., 'auto')
+  originalModelId String?  @map("original_model_id")
+  /// Model routing metadata (JSON)
+  modelRoutedData String?  @map("model_routed_data")
   /// Input tokens
-  inputTokens    Int      @default(0) @map("input_tokens")
+  inputTokens     Int      @default(0) @map("input_tokens")
   /// Output tokens
-  outputTokens   Int      @default(0) @map("output_tokens")
+  outputTokens    Int      @default(0) @map("output_tokens")
   /// Create timestamp
-  createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz()
   /// Update timestamp
-  updatedAt      DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz()
+  updatedAt       DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz()
 
   @@index([uid, createdAt])
+  @@index([originalModelId, createdAt])
   @@map("token_usages")
 }
 

--- a/apps/api/src/modules/skill/skill-invoker.service.ts
+++ b/apps/api/src/modules/skill/skill-invoker.service.ts
@@ -901,12 +901,22 @@ export class SkillInvokerService {
               if (!providerItem) {
                 this.logger.error(`model not found: ${String(runMeta.ls_model_name)}`);
               }
+
+              // Extract routing data if model was routed (e.g., from Auto model)
+              const config =
+                typeof data.providerItem?.config === 'string'
+                  ? safeParseJSON(data.providerItem?.config)
+                  : data.providerItem?.config;
+              const routedData = config?.routedData;
+
               const usage: TokenUsageItem = {
                 tier: providerItem?.tier,
                 modelProvider: providerItem?.provider?.name,
                 modelName: String(runMeta.ls_model_name),
                 modelLabel: providerItem?.name,
                 providerItemId: providerItem?.itemId,
+                originalModelId: routedData?.originalModelId,
+                modelRoutedData: routedData,
                 inputTokens:
                   (chunk.usage_metadata?.input_tokens ?? 0) -
                   (chunk.usage_metadata?.input_token_details?.cache_read ?? 0),

--- a/apps/api/src/modules/subscription/subscription.service.ts
+++ b/apps/api/src/modules/subscription/subscription.service.ts
@@ -1003,6 +1003,8 @@ export class SubscriptionService implements OnModuleInit {
             'outputTokens',
           ]),
           tier: usage.tier ?? '',
+          originalModelId: usage.originalModelId ?? null,
+          modelRoutedData: usage.modelRoutedData ? JSON.stringify(usage.modelRoutedData) : null,
         },
       }),
       ...(usage.tier !== 'free'

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -5621,6 +5621,35 @@ components:
           type: string
           description: Model tier
           deprecated: true
+        originalModelId:
+          type: string
+          description: Original model ID before routing (e.g., 'auto')
+        modelRoutedData:
+          type: object
+          description: Complete model routing metadata (JSON)
+          properties:
+            isRouted:
+              type: boolean
+              description: Whether this request was routed
+            originalItemId:
+              type: string
+              description: Original provider item ID before routing
+            originalModelId:
+              type: string
+              description: Original model ID (e.g., 'auto')
+            originalProvider:
+              type: string
+              description: Original model provider name
+            originalModelName:
+              type: string
+              description: Original model name/label for display
+            routedAt:
+              type: string
+              format: date-time
+              description: Routing timestamp
+            routingStrategy:
+              type: string
+              description: Routing strategy used (e.g., 'auto', 'load_balance', 'region')
     ActionStatus:
       type: string
       description: Action status

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -2057,6 +2057,45 @@ export const TokenUsageItemSchema = {
       description: 'Model tier',
       deprecated: true,
     },
+    originalModelId: {
+      type: 'string',
+      description: "Original model ID before routing (e.g., 'auto')",
+    },
+    modelRoutedData: {
+      type: 'object',
+      description: 'Complete model routing metadata (JSON)',
+      properties: {
+        isRouted: {
+          type: 'boolean',
+          description: 'Whether this request was routed',
+        },
+        originalItemId: {
+          type: 'string',
+          description: 'Original provider item ID before routing',
+        },
+        originalModelId: {
+          type: 'string',
+          description: "Original model ID (e.g., 'auto')",
+        },
+        originalProvider: {
+          type: 'string',
+          description: 'Original model provider name',
+        },
+        originalModelName: {
+          type: 'string',
+          description: 'Original model name/label for display',
+        },
+        routedAt: {
+          type: 'string',
+          format: 'date-time',
+          description: 'Routing timestamp',
+        },
+        routingStrategy: {
+          type: 'string',
+          description: "Routing strategy used (e.g., 'auto', 'load_balance', 'region')",
+        },
+      },
+    },
   },
 } as const;
 

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -1568,6 +1568,43 @@ export type TokenUsageItem = {
    * @deprecated
    */
   tier?: string;
+  /**
+   * Original model ID before routing (e.g., 'auto')
+   */
+  originalModelId?: string;
+  /**
+   * Complete model routing metadata (JSON)
+   */
+  modelRoutedData?: {
+    /**
+     * Whether this request was routed
+     */
+    isRouted?: boolean;
+    /**
+     * Original provider item ID before routing
+     */
+    originalItemId?: string;
+    /**
+     * Original model ID (e.g., 'auto')
+     */
+    originalModelId?: string;
+    /**
+     * Original model provider name
+     */
+    originalProvider?: string;
+    /**
+     * Original model name/label for display
+     */
+    originalModelName?: string;
+    /**
+     * Routing timestamp
+     */
+    routedAt?: string;
+    /**
+     * Routing strategy used (e.g., 'auto', 'load_balance', 'region')
+     */
+    routingStrategy?: string;
+  };
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR adds tracking support for auto model routing in token usage records. When the system routes requests to different models (e.g., using the 'auto' model), the token usage now captures both the original and routed model information for better analytics and debugging.

## Changes

- Added `originalModelId` and `modelRoutedData` fields to `TokenUsage` schema to track routing history
- Updated skill invoker service to extract routing metadata from provider config when recording token usage
- Modified subscription service to persist routing data when creating token usage records
- Extended OpenAPI schema with routing metadata structure including strategy, timestamps, and original model info
- Added database index on `originalModelId` for efficient querying of auto-routed requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token usage records now include enhanced routing metadata, capturing the original model identifier and comprehensive routing information—including provider details, routing strategy, and timestamp—to provide full transparency into model routing and substitution decisions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->