### PR TITLE
fix: Remove duplicate token credit usage

### DIFF
--- a/apps/api/src/modules/skill/skill-invoker.service.ts
+++ b/apps/api/src/modules/skill/skill-invoker.service.ts
@@ -1064,13 +1064,6 @@ export class SkillInvokerService {
                 };
                 await this.usageReportQueue.add(`usage_report:${resultId}`, tokenUsage);
               }
-              // Process credit billing for all steps after skill completion
-              // Bill credits for successful completions and user aborts (partial usage should be charged)
-              const shouldBillCredits = !result.errors.length || result.errorType === 'userAbort';
-
-              if (shouldBillCredits) {
-                await this.processCreditUsageReport(user, resultId, version, resultAggregator);
-              }
             }
             break;
         }


### PR DESCRIPTION
## Summary

This PR fixes a bug where Auto-routed agent node executions created duplicate credit usage records - one with the Auto model name and another with the actual model name (e.g., Claude Opus 4.5).

The issue was introduced in commit `838a679` when credit billing was added to the `on_chat_model_end` callback for early validation, but the existing billing logic at skill completion was not removed, causing the same execution to be billed twice.

## Changes

- Remove duplicate credit billing trigger in `on_chat_model_end` event handler
- Keep credit billing at skill completion stage where routing metadata is properly available
- Ensure each `action_result_id` generates only one `credit_usages` record with correct Auto model billing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modified the automatic credit billing process following skill execution to streamline the credit management workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->