### PR TITLE
feat: Support credit billing for cached tokens

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -426,33 +426,37 @@ enum ActionStatus {
 
 model TokenUsage {
   /// Primary key
-  pk              BigInt   @id @default(autoincrement())
+  pk               BigInt   @id @default(autoincrement())
   /// UID
-  uid             String   @map("uid")
+  uid              String   @map("uid")
   /// Action result id
-  resultId        String?  @map("result_id")
+  resultId         String?  @map("result_id")
   /// Model tier
-  tier            String   @map("tier")
+  tier             String   @map("tier")
   /// Model provider
-  modelProvider   String   @default("") @map("model_provider")
+  modelProvider    String   @default("") @map("model_provider")
   /// Model name
-  modelName       String   @default("") @map("model_name")
+  modelName        String   @default("") @map("model_name")
   /// Model label
-  modelLabel      String   @default("") @map("model_label")
+  modelLabel       String   @default("") @map("model_label")
   /// Provider item id
-  providerItemId  String?  @map("provider_item_id")
+  providerItemId   String?  @map("provider_item_id")
   /// Original model ID before routing (e.g., 'auto')
-  originalModelId String?  @map("original_model_id")
+  originalModelId  String?  @map("original_model_id")
   /// Model routing metadata (JSON)
-  modelRoutedData String?  @map("model_routed_data")
+  modelRoutedData  String?  @map("model_routed_data")
   /// Input tokens
-  inputTokens     Int      @default(0) @map("input_tokens")
+  inputTokens      Int      @default(0) @map("input_tokens")
   /// Output tokens
-  outputTokens    Int      @default(0) @map("output_tokens")
+  outputTokens     Int      @default(0) @map("output_tokens")
+  /// Cache read tokens (from prompt caching)
+  cacheReadTokens  Int      @default(0) @map("cache_read_tokens")
+  /// Cache write tokens (from prompt caching)
+  cacheWriteTokens Int      @default(0) @map("cache_write_tokens")
   /// Create timestamp
-  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz()
   /// Update timestamp
-  updatedAt       DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz()
+  updatedAt        DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz()
 
   @@index([uid, createdAt])
   @@index([originalModelId, createdAt])

--- a/apps/api/src/modules/credit/credit.dto.ts
+++ b/apps/api/src/modules/credit/credit.dto.ts
@@ -42,6 +42,8 @@ export interface ModelUsageDetail {
   actualModelName?: string;
   inputTokens: number;
   outputTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
   creditCost: number;
 }
 

--- a/apps/api/src/modules/credit/credit.service.ts
+++ b/apps/api/src/modules/credit/credit.service.ts
@@ -988,6 +988,8 @@ export class CreditService {
 
       const inputTokens = usage.inputTokens || 0;
       const outputTokens = usage.outputTokens || 0;
+      const cacheReadTokens = usage.cacheReadTokens || 0;
+      const cacheWriteTokens = usage.cacheWriteTokens || 0;
 
       // Calculate credit cost for this usage
       let creditCost = 0;
@@ -995,15 +997,29 @@ export class CreditService {
         if (creditBilling.unit === '5k_tokens') {
           const perInputUnit = creditBilling.inputCost || 0;
           const perOutputUnit = creditBilling.outputCost || 0;
-          creditCost = Math.ceil(
-            (inputTokens / 5000) * perInputUnit + (outputTokens / 5000) * perOutputUnit,
-          );
+          // Fallback: use inputCost for both cache read and cache write (cache operations are on input side)
+          const perCacheReadUnit = creditBilling.cacheReadCost ?? perInputUnit;
+          const perCacheWriteUnit = creditBilling.cacheWriteCost ?? perInputUnit;
+
+          const inputCost = (inputTokens / 5000) * perInputUnit;
+          const outputCost = (outputTokens / 5000) * perOutputUnit;
+          const cacheReadCost = (cacheReadTokens / 5000) * perCacheReadUnit;
+          const cacheWriteCost = (cacheWriteTokens / 5000) * perCacheWriteUnit;
+
+          creditCost = Math.ceil(inputCost + outputCost + cacheReadCost + cacheWriteCost);
         } else if (creditBilling.unit === '1m_tokens') {
           const perInputUnit = creditBilling.inputCost || 0;
           const perOutputUnit = creditBilling.outputCost || 0;
-          creditCost = Math.ceil(
-            (inputTokens / 1000000) * perInputUnit + (outputTokens / 1000000) * perOutputUnit,
-          );
+          // Fallback: use inputCost for both cache read and cache write (cache operations are on input side)
+          const perCacheReadUnit = creditBilling.cacheReadCost ?? perInputUnit;
+          const perCacheWriteUnit = creditBilling.cacheWriteCost ?? perInputUnit;
+
+          const inputCost = (inputTokens / 1000000) * perInputUnit;
+          const outputCost = (outputTokens / 1000000) * perOutputUnit;
+          const cacheReadCost = (cacheReadTokens / 1000000) * perCacheReadUnit;
+          const cacheWriteCost = (cacheWriteTokens / 1000000) * perCacheWriteUnit;
+
+          creditCost = Math.ceil(inputCost + outputCost + cacheReadCost + cacheWriteCost);
         } else {
           creditCost = Math.max(creditBilling.inputCost, creditBilling.outputCost);
         }
@@ -1030,6 +1046,8 @@ export class CreditService {
         actualModelName: usage.modelName,
         inputTokens,
         outputTokens,
+        cacheReadTokens,
+        cacheWriteTokens,
         creditCost: creditCost,
       });
     }

--- a/apps/api/src/modules/skill/skill-invoker.service.ts
+++ b/apps/api/src/modules/skill/skill-invoker.service.ts
@@ -1626,6 +1626,8 @@ export class SkillInvokerService {
               modelName: providerItem?.name,
               inputTokens: tokenUsage.inputTokens || 0,
               outputTokens: tokenUsage.outputTokens || 0,
+              cacheReadTokens: tokenUsage.cacheReadTokens || 0,
+              cacheWriteTokens: tokenUsage.cacheWriteTokens || 0,
             };
 
             // billingModelName: model name used for billing (Auto or direct model)

--- a/apps/api/src/modules/subscription/subscription.service.ts
+++ b/apps/api/src/modules/subscription/subscription.service.ts
@@ -1136,6 +1136,8 @@ export class SubscriptionService implements OnModuleInit {
           tier: usage.tier ?? '',
           originalModelId: usage.originalModelId ?? null,
           modelRoutedData: usage.modelRoutedData ? JSON.stringify(usage.modelRoutedData) : null,
+          cacheReadTokens: usage.cacheReadTokens ?? 0,
+          cacheWriteTokens: usage.cacheWriteTokens ?? 0,
         },
       }),
       ...(usage.tier !== 'free'

--- a/apps/api/src/utils/credit-billing.ts
+++ b/apps/api/src/utils/credit-billing.ts
@@ -37,10 +37,15 @@ export const normalizeCreditBilling = (raw: unknown): CreditBilling | undefined 
     outputCost = half;
   }
 
+  const cacheReadCost = parseNumber(legacy.cacheReadCost);
+  const cacheWriteCost = parseNumber(legacy.cacheWriteCost);
+
   const normalized: CreditBilling = {
     unit: typeof legacy.unit === 'string' ? legacy.unit : 'request',
     inputCost,
     outputCost,
+    cacheReadCost,
+    cacheWriteCost,
     minCharge: parseNumber(legacy.minCharge) ?? 0,
   };
 

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -10395,6 +10395,14 @@ components:
           type: number
           description: Credit consumption per unit for output tokens
           minimum: 0
+        cacheReadCost:
+          type: number
+          description: Credit consumption per unit for cache read tokens (typically 10% of input cost)
+          minimum: 0
+        cacheWriteCost:
+          type: number
+          description: Credit consumption per unit for cache write tokens (typically higher than input cost)
+          minimum: 0
         minCharge:
           type: number
           description: Minimum credit charge per request

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -8611,6 +8611,18 @@ export const CreditBillingSchema = {
       description: 'Credit consumption per unit for output tokens',
       minimum: 0,
     },
+    cacheReadCost: {
+      type: 'number',
+      description:
+        'Credit consumption per unit for cache read tokens (typically 10% of input cost)',
+      minimum: 0,
+    },
+    cacheWriteCost: {
+      type: 'number',
+      description:
+        'Credit consumption per unit for cache write tokens (typically higher than input cost)',
+      minimum: 0,
+    },
     minCharge: {
       type: 'number',
       description: 'Minimum credit charge per request',

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -6098,6 +6098,14 @@ export type CreditBilling = {
    */
   outputCost: number;
   /**
+   * Credit consumption per unit for cache read tokens (typically 10% of input cost)
+   */
+  cacheReadCost?: number;
+  /**
+   * Credit consumption per unit for cache write tokens (typically higher than input cost)
+   */
+  cacheWriteCost?: number;
+  /**
    * Minimum credit charge per request
    */
   minCharge: number;

--- a/packages/utils/src/models.ts
+++ b/packages/utils/src/models.ts
@@ -16,11 +16,13 @@ export const aggregateTokenUsage = (usageItems: TokenUsageItem[]): TokenUsageIte
         inputTokens: 0,
         outputTokens: 0,
         cacheReadTokens: 0,
+        cacheWriteTokens: 0,
       };
     }
     aggregatedUsage[key].inputTokens += item.inputTokens;
     aggregatedUsage[key].outputTokens += item.outputTokens;
     aggregatedUsage[key].cacheReadTokens += item.cacheReadTokens ?? 0;
+    aggregatedUsage[key].cacheWriteTokens += item.cacheWriteTokens ?? 0;
   }
 
   return Object.entries(aggregatedUsage).map(([key, value]) => {
@@ -34,6 +36,7 @@ export const aggregateTokenUsage = (usageItems: TokenUsageItem[]): TokenUsageIte
         'inputTokens',
         'outputTokens',
         'cacheReadTokens',
+        'cacheWriteTokens',
       ]),
     };
   });


### PR DESCRIPTION
## Summary

This PR adds support for prompt caching billing by tracking cache read and cache write tokens separately. The system now properly calculates credit costs for cached tokens in addition to regular input/output tokens.

## Changes

- Added `cache_read_tokens` and `cache_write_tokens` columns to `token_usages` table
- Updated `CreditBilling` type to include optional `cacheReadCost` and `cacheWriteCost` fields
- Modified credit calculation logic to handle cache token costs with fallback to input cost when not specified
- Updated token usage aggregation to include cache write tokens alongside existing cache read tokens
- Extended API schemas and DTOs to support the new cache token fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token usage reports now include separate tracking for cache read and write tokens, providing granular insights into cache operations.
  * Credit billing now calculates cache read and write costs independently, enabling precise cost attribution for cached queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->