### PR TITLE
feat: restore canvas duplication for new system

### DIFF
--- a/apps/api/src/modules/share/share.module.ts
+++ b/apps/api/src/modules/share/share.module.ts
@@ -17,6 +17,7 @@ import { ShareCreationService } from './share-creation.service';
 import { ShareDuplicationService } from './share-duplication.service';
 import { ShareRateLimitService } from './share-rate-limit.service';
 import { ToolModule } from '../tool/tool.module';
+import { ToolCallModule } from '../tool-call/tool-call.module';
 import { CanvasSyncModule } from '../canvas-sync/canvas-sync.module';
 import { CreditModule } from '../credit/credit.module';
 import { ConfigModule } from '@nestjs/config';
@@ -32,6 +33,7 @@ import { ProviderModule } from '../provider/provider.module';
     RAGModule,
     MiscModule,
     ToolModule,
+    ToolCallModule,
     ActionModule,
     CodeArtifactModule,
     SubscriptionModule,

--- a/packages/ai-workspace-common/src/components/canvas-template/template-card.tsx
+++ b/packages/ai-workspace-common/src/components/canvas-template/template-card.tsx
@@ -17,7 +17,6 @@ interface TemplateCardProps {
 }
 
 export const TemplateCard = ({ template, className, showUser = true }: TemplateCardProps) => {
-  const showRemix = false;
   const { t } = useTranslation();
   const { setVisible: setModalVisible } = useCanvasTemplateModal((state) => ({
     setVisible: state.setVisible,
@@ -213,7 +212,7 @@ export const TemplateCard = ({ template, className, showUser = true }: TemplateC
 
           {/* Action buttons section */}
           <div className="flex items-center justify-between gap-3 mt-3">
-            {showRemix && (
+            {
               <Button
                 loading={duplicating}
                 type="primary"
@@ -222,7 +221,7 @@ export const TemplateCard = ({ template, className, showUser = true }: TemplateC
               >
                 {t('template.use')}
               </Button>
-            )}
+            }
 
             {template.shareId && (
               <Button type="primary" className="flex-1 min-w-20 px-2" onClick={handlePreview}>

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/actions-in-canvas-dropdown.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/actions-in-canvas-dropdown.tsx
@@ -169,17 +169,17 @@ export const ActionsInCanvasDropdown = memo((props: ActionsInCanvasDropdownProps
         label: <MenuItemLabel text={t('canvas.toolbar.rename')} handleClick={handleRename} />,
         key: 'rename',
       },
-      // {
-      //   label: (
-      //     <MenuItemLabel
-      //       text={t('canvas.toolbar.tooltip.duplicateWorkflow')}
-      //       handleClick={handleDuplicate}
-      //       loading={duplicateLoading}
-      //     />
-      //   ),
-      //   key: 'duplicate',
-      //   disabled: duplicateLoading,
-      // },
+      {
+        label: (
+          <MenuItemLabel
+            text={t('canvas.toolbar.tooltip.duplicateWorkflow')}
+            handleClick={handleDuplicate}
+            loading={duplicateLoading}
+          />
+        ),
+        key: 'duplicate',
+        disabled: duplicateLoading,
+      },
       {
         label: (
           <div

--- a/packages/ai-workspace-common/src/components/workflow-app/create-modal.tsx
+++ b/packages/ai-workspace-common/src/components/workflow-app/create-modal.tsx
@@ -132,7 +132,6 @@ export const CreateWorkflowAppModal = ({
   const [form] = Form.useForm();
   const [messageApi, contextHolder] = message.useMessage();
   const [confirmLoading, setConfirmLoading] = useState(false);
-  const showRemix = false;
 
   // Cover image upload state
   const [coverFileList, setCoverFileList] = useState<UploadFile[]>([]);
@@ -573,7 +572,7 @@ export const CreateWorkflowAppModal = ({
         ...values,
         title: values.title,
         description: values.description ?? '',
-        remixEnabled: showRemix ? (values.remixEnabled ?? false) : false,
+        remixEnabled: values.remixEnabled ?? false,
         publishToCommunity: values.publishToCommunity ?? false,
       });
     } catch (error) {
@@ -1073,7 +1072,7 @@ export const CreateWorkflowAppModal = ({
                   </div>
                 </div>
                 {/* Remix Settings */}
-                {showRemix && (
+                {
                   <div className="flex flex-col gap-2 mt-5">
                     <div className="flex items-center justify-between">
                       <label
@@ -1088,7 +1087,7 @@ export const CreateWorkflowAppModal = ({
                     </div>
                     <div className="text-xs text-refly-text-2">{t('workflowApp.remixHint')}</div>
                   </div>
-                )}
+                }
 
                 {/* Cover Image Upload */}
                 <div className="flex flex-col gap-2 mt-5">

--- a/packages/ai-workspace-common/src/components/workflow-list/workflowActionDropdown.tsx
+++ b/packages/ai-workspace-common/src/components/workflow-list/workflowActionDropdown.tsx
@@ -17,7 +17,6 @@ interface WorkflowActionDropdown {
 }
 
 export const WorkflowActionDropdown = memo((props: WorkflowActionDropdown) => {
-  const showRemix = false;
   const { workflow, children, onRenameSuccess, onDeleteSuccess } = props;
   const { t } = useTranslation();
   const [popupVisible, setPopupVisible] = useState(false);
@@ -111,48 +110,46 @@ export const WorkflowActionDropdown = memo((props: WorkflowActionDropdown) => {
       ),
       key: 'rename',
     },
-    ...(showRemix
-      ? [
-          {
-            label: (
-              <div
-                className="flex items-center gap-1 min-w-28"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleDuplicate();
-                }}
-              >
-                {t('canvas.toolbar.duplicate')}
-                <Spin spinning={duplicateLoading} size="small" className="text-refly-text-3" />
-              </div>
-            ),
-            key: 'duplicate',
-            disabled: duplicateLoading,
-          },
-          {
-            label: (
-              <Tooltip
-                title={!isShared ? t('workflowList.copyLinkTooltip') : undefined}
-                placement="right"
-              >
-                <div
-                  className={`flex items-center gap-1 min-w-28 ${!isShared ? 'opacity-50 cursor-not-allowed' : ''}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (!isShared) return;
-                    handleCopyLink();
-                  }}
-                >
-                  <Spin spinning={copyLinkLoading} size="small" className="text-refly-text-3" />
-                  {t('workflowList.copyLink')}
-                </div>
-              </Tooltip>
-            ),
-            key: 'copyLink',
-            disabled: !isShared || copyLinkLoading,
-          },
-        ]
-      : []),
+    ...[
+      {
+        label: (
+          <div
+            className="flex items-center gap-1 min-w-28"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleDuplicate();
+            }}
+          >
+            {t('canvas.toolbar.duplicate')}
+            <Spin spinning={duplicateLoading} size="small" className="text-refly-text-3" />
+          </div>
+        ),
+        key: 'duplicate',
+        disabled: duplicateLoading,
+      },
+      {
+        label: (
+          <Tooltip
+            title={!isShared ? t('workflowList.copyLinkTooltip') : undefined}
+            placement="right"
+          >
+            <div
+              className={`flex items-center gap-1 min-w-28 ${!isShared ? 'opacity-50 cursor-not-allowed' : ''}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!isShared) return;
+                handleCopyLink();
+              }}
+            >
+              <Spin spinning={copyLinkLoading} size="small" className="text-refly-text-3" />
+              {t('workflowList.copyLink')}
+            </div>
+          </Tooltip>
+        ),
+        key: 'copyLink',
+        disabled: !isShared || copyLinkLoading,
+      },
+    ],
 
     {
       label: (

--- a/packages/ai-workspace-common/src/components/workspace/canvas-list-modal/canvasActionDropdown.tsx
+++ b/packages/ai-workspace-common/src/components/workspace/canvas-list-modal/canvasActionDropdown.tsx
@@ -42,7 +42,6 @@ export const CanvasActionDropdown = memo((props: CanvasActionDropdown) => {
     openRenameModal: state.openRenameModal,
     openDeleteModal: state.openDeleteModal,
   }));
-  const showRemix = false;
 
   const { duplicateCanvas, loading: duplicateLoading } = useDuplicateCanvas();
 
@@ -87,27 +86,25 @@ export const CanvasActionDropdown = memo((props: CanvasActionDropdown) => {
       ),
       key: 'rename',
     },
-    ...(showRemix
-      ? [
-          {
-            label: (
-              <div
-                className="flex items-center gap-1"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleDuplicate();
-                }}
-              >
-                <Copy size={18} />
-                {t('canvas.toolbar.duplicate')}
-                <Spin spinning={duplicateLoading} size="small" className="text-refly-text-3" />
-              </div>
-            ),
-            key: 'duplicate',
-            disabled: duplicateLoading,
-          },
-        ]
-      : []),
+    ...[
+      {
+        label: (
+          <div
+            className="flex items-center gap-1"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleDuplicate();
+            }}
+          >
+            <Copy size={18} />
+            {t('canvas.toolbar.duplicate')}
+            <Spin spinning={duplicateLoading} size="small" className="text-refly-text-3" />
+          </div>
+        ),
+        key: 'duplicate',
+        disabled: duplicateLoading,
+      },
+    ],
     handleRemoveFromProject && {
       label: (
         <div

--- a/packages/web-core/src/pages/workflow-app/workflow-app-form.tsx
+++ b/packages/web-core/src/pages/workflow-app/workflow-app-form.tsx
@@ -100,7 +100,6 @@ export const WorkflowAPPForm = ({
   templateContent,
   workflowApp,
 }: WorkflowAPPFormProps) => {
-  const showRemix = false;
   const { t } = useTranslation();
   const { isLogin } = useUserStoreShallow((state) => ({
     isLogin: state.isLogin,
@@ -1032,7 +1031,7 @@ export const WorkflowAPPForm = ({
                   </Button>
                   {/* Remix Button */}
                   {/* hide for temporary */}
-                  {/* {onCopyWorkflow && workflowApp?.remixEnabled && (
+                  {onCopyWorkflow && workflowApp?.remixEnabled && (
                     <Button
                       className="h-10 w-[94px] flex items-center justify-center px-0 rounded-[12px] bg-[#fff] dark:bg-[#232323] border-[0.5px] border-solid border-[rgba(28,31,35,0.3)] text-[#1C1F23] dark:text-white hover:bg-[#eaeaea] shadow-none font-semibold font-roboto text-[16px] leading-[1.25em] gap-0"
                       type="default"
@@ -1041,7 +1040,7 @@ export const WorkflowAPPForm = ({
                     >
                       <span className="">{t('canvas.workflow.run.remix')}</span>
                     </Button>
-                  )} */}
+                  )}
                   {/* Share Icon Button */}
                   {onCopyShareLink && (
                     <Button
@@ -1177,7 +1176,7 @@ export const WorkflowAPPForm = ({
                     </span>
                   </Button>
                   {/* Remix Button */}
-                  {showRemix && onCopyWorkflow && workflowApp?.remixEnabled && (
+                  {onCopyWorkflow && workflowApp?.remixEnabled && (
                     <Button
                       className="h-10 w-[94px] flex items-center justify-center px-0 rounded-[12px] bg-[#F6F6F6] dark:bg-[#232323] border-[0.5px] border-solid border-[rgba(28,31,35,0.3)] text-[#1C1F23] dark:text-white hover:bg-[#eaeaea] shadow-none font-semibold font-roboto text-[16px] leading-[1.25em] gap-0"
                       type="default"


### PR DESCRIPTION
# Summary

  Enhance canvas duplication to properly copy ActionMessage and ToolCallResult records with correct ID mappings.

  **ActionMessage & ToolCallResult Duplication:**
  - Added `duplicateActionMessages()` and `duplicateToolCallResults()` methods to `ActionService`
  - Copy ActionMessage and ToolCallResult records during canvas/workflow duplication (previously not copied)
  - Build `callIdMap` to maintain toolCallId references between ActionMessage and ToolCallResult
  - Changed from parallel to sequential execution (tool calls first, then messages with callIdMap)

  **File ID Reference Updates:**
  - Use `fileIdMap` to update fileId references in workflow resource variables
  - Update file references in ActionResult.context using combined replace map

  **CallId Format Consistency:**
  - Fixed callId format to use `{resultId}:{version}:{toolsetId}:{toolName}:{uuid}` instead of simple `tc-xxx`
  - Both `ActionService` and `ShareDuplicationService` now use `toolCallService.getOrCreateToolCallId()`
  - Removed unused `genToolCallID()` function and `TOOL_CALL` prefix from utils

  **Bug Fixes:**
  - Fixed `resultHistory.map is not a function` error caused by double-stringification of context/history fields
  - Fixed workflow app queue timing issue where `generate` queue was added before `shareRecord` creation

  # Impact Areas

  - [x] Canvas Duplication
  - [x] Workflow App Template Duplication
  - [x] Share Duplication

  # Checklist

  - [x] I understand that this PR may be closed in case there was no previous discussion or issues.
  - [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

  ## Summary by CodeRabbit

  * **New Features**
    * Canvas duplication now copies ActionMessage and ToolCallResult records with proper ID mappings
    * Workflow variables with file references are correctly updated during duplication
    * Shared workflow app duplication maintains complete action history including tool calls

  * **Bug Fixes**
    * Fixed double-stringification issue with ActionResult context/history fields
    * Fixed queue timing issue in workflow app template creation
    * Fixed callId format consistency across duplication services

  * **Refactoring**
    * Removed unused `genToolCallID()` utility function
    * Consolidated callId generation to use `ToolCallService.getOrCreateToolCallId()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled duplicate workflow functionality across the application interface.

* **Enhancements**
  * Improved workflow duplication to better preserve and remap IDs for related entities, including tool calls and action messages.
  * Enhanced file ID mapping during duplication operations for more accurate asset references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->