### PR TITLE
fix: update default subscription interval to yearly

### DIFF
--- a/packages/ai-workspace-common/src/components/settings/subscribe-modal/priceContent.tsx
+++ b/packages/ai-workspace-common/src/components/settings/subscribe-modal/priceContent.tsx
@@ -239,7 +239,7 @@ const PlanItem = memo((props: PlanItemProps) => {
     voucher,
     voucherValidDays,
   } = props;
-  const [interval, setInterval] = useState<SubscriptionInterval>('monthly');
+  const [interval, setInterval] = useState<SubscriptionInterval>('yearly');
   const navigate = useNavigate();
 
   const { isLogin, userProfile } = useUserStoreShallow((state) => ({


### PR DESCRIPTION
…monthly to yearly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default subscription interval selection from monthly to yearly in the pricing interface, affecting the initial price option displayed to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->