### PR TITLE
feat: implement tool-based auto model routing

### DIFF
--- a/apps/api/src/modules/skill/skill.service.ts
+++ b/apps/api/src/modules/skill/skill.service.ts
@@ -487,6 +487,8 @@ export class SkillService implements OnModuleInit {
     const routerContext = {
       llmItems,
       userId: user.uid,
+      scene: param.mode,
+      toolsets: param.toolsets,
     };
     const autoModelRouter = new AutoModelRouter(routerContext);
 

--- a/apps/api/src/modules/workflow/workflow.service.ts
+++ b/apps/api/src/modules/workflow/workflow.service.ts
@@ -335,6 +335,7 @@ export class WorkflowService {
         entityType: 'canvas' as const,
         entityId: canvasId,
       },
+      mode: 'node_agent',
       modelName: modelInfo?.name,
       modelItemId: modelInfo?.providerItemId,
       context,

--- a/packages/utils/src/auto-model.ts
+++ b/packages/utils/src/auto-model.ts
@@ -48,6 +48,43 @@ export const selectAutoModel = (): string | null => {
 };
 
 /**
+ * Tool-based routing configuration
+ */
+export interface ToolBasedRoutingConfig {
+  enabled: boolean;
+  targetTools: string[];
+  matchedModelId: string | null;
+  unmatchedModelId: string | null;
+}
+
+/**
+ * Get tool-based routing configuration from environment variables
+ * @returns Tool-based routing configuration
+ */
+export const getToolBasedRoutingConfig = (): ToolBasedRoutingConfig => {
+  const enabled = process.env.AUTO_MODEL_ROUTING_TOOL_BASED_ENABLED === 'true';
+
+  const targetToolsStr = process.env.AUTO_MODEL_ROUTING_TOOL_BASED_TARGET_TOOLS;
+  const targetTools = targetToolsStr
+    ? targetToolsStr
+        .split(',')
+        .map((tool) => tool.trim())
+        .filter((tool) => tool.length > 0)
+    : [];
+
+  const matchedModelId = process.env.AUTO_MODEL_ROUTING_TOOL_BASED_MATCHED_MODEL_ID?.trim() || null;
+  const unmatchedModelId =
+    process.env.AUTO_MODEL_ROUTING_TOOL_BASED_UNMATCHED_MODEL_ID?.trim() || null;
+
+  return {
+    enabled,
+    targetTools,
+    matchedModelId,
+    unmatchedModelId,
+  };
+};
+
+/**
  * Check if the given provider item config is the Auto model
  * @param config The provider item config (string or ProviderItemConfig)
  * @returns True if this is the Auto model


### PR DESCRIPTION
## Summary

This PR adds tool-based auto model routing for the Auto model. When running in `node_agent` mode, the router now checks which tools are being used and routes to different models based on whether target tools are present. This allows us to use specific models for certain tool combinations.

## Changes

- Added tool-based routing logic to `AutoModelRouter` that checks for target tools and routes to matched/unmatched models
- Extended `RouterContext` with `scene` and `toolsets` fields to support routing decisions
- Added `getToolBasedRoutingConfig()` utility to read routing config from environment variables
- Updated `SkillService` to pass scene and toolsets to the router
- Updated `WorkflowService` to set `mode: 'node_agent'` when invoking skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool-based routing: models can be selected automatically based on required tools and scene context.
* **Improvements**
  * Routing context now includes scene and toolset information for smarter selection.
  * Tool-based routing is configurable and logs routing decisions and fallbacks for better visibility.
  * Invoke-skill requests now include a new mode ("node_agent") in their payload.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->