### PR TITLE
  feat: Add invite page to public access pages whitelist

### DIFF
--- a/packages/ai-workspace-common/src/hooks/use-is-share-page.ts
+++ b/packages/ai-workspace-common/src/hooks/use-is-share-page.ts
@@ -13,6 +13,7 @@ export const isPublicAccessPageByPath = (pathname: string): boolean => {
   const isWorkflowTemplatePage = pathname?.startsWith('/workflow-template/') ?? false;
   const isLoginPage = (pathname ?? '') === '/login';
   const isPricingPage = pathname === '/pricing';
+  const isInvitePage = pathname === '/invite';
   return (
     isPreviewPage ||
     isSharePage ||
@@ -21,7 +22,8 @@ export const isPublicAccessPageByPath = (pathname: string): boolean => {
     isAppPage ||
     isWorkflowTemplatePage ||
     isLoginPage ||
-    isPricingPage
+    isPricingPage ||
+    isInvitePage
   );
 };
 


### PR DESCRIPTION
# Summary

  Add `/invite` page to `isPublicAccessPageByPath` function, allowing unauthenticated users to access the invite page.

  # Impact Areas

  - [x] Other (Authentication / Routing)

  # Checklist

  - [x] I understand that this PR may be closed in case there was no previous discussion or issues.
  - [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The invite page is now publicly accessible, allowing users to access invitations without requiring login.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->