### PR TITLE
refactor: update default selected credit pack in CreditInsufficientModal

### DIFF
--- a/packages/ai-workspace-common/src/components/subscription/credit-insufficient-modal.tsx
+++ b/packages/ai-workspace-common/src/components/subscription/credit-insufficient-modal.tsx
@@ -362,19 +362,9 @@ const CreditPacksCard = memo(
     const creditPackOptions: CreditPackOption[] = useMemo(
       () => [
         {
-          id: 'credit_pack_100',
-          price: t('subscription.creditPacks.credit_pack_100.price'),
-          credits: t('subscription.creditPacks.credit_pack_100.credits'),
-        },
-        {
           id: 'credit_pack_1000',
           price: t('subscription.creditPacks.credit_pack_1000.price'),
           credits: t('subscription.creditPacks.credit_pack_1000.credits'),
-        },
-        {
-          id: 'credit_pack_500',
-          price: t('subscription.creditPacks.credit_pack_500.price'),
-          credits: t('subscription.creditPacks.credit_pack_500.credits'),
         },
         {
           id: 'credit_pack_2000',
@@ -525,7 +515,7 @@ export const CreditInsufficientModal = memo(() => {
 
   // Single selection state - can be 'monthly', 'yearly', or a credit pack id
   const [selectedId, setSelectedId] = useState<SelectionId>(
-    hasPaidSubscription && shouldShowCreditPacks ? 'credit_pack_100' : 'yearly',
+    hasPaidSubscription && shouldShowCreditPacks ? 'credit_pack_1000' : 'yearly',
   );
   const [isLoading, setIsLoading] = useState(false);
 
@@ -535,7 +525,7 @@ export const CreditInsufficientModal = memo(() => {
 
     // Only credit packs are shown for paid users (or when Plus card is hidden) — default to the $1 pack.
     if (hasPaidSubscription && shouldShowCreditPacks) {
-      setSelectedId('credit_pack_100');
+      setSelectedId('credit_pack_1000');
       return;
     }
 


### PR DESCRIPTION
* Removed credit pack options for 100 and 500 credits.
* Changed default selected credit pack from 100 to 1000 for users with a paid subscription.
* Ensured consistency in credit pack options displayed for users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Streamlined credit pack options in the subscription modal by removing lower-tier selections
  * Updated the default credit pack selection to a higher-tier option for improved consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->