### PR TITLE
  feat: remove file type restrictions and fix unsupported file download                                                                                                             

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/file-preview/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/file-preview/index.tsx
@@ -4,6 +4,7 @@ import { DriveFile } from '@refly/openapi-schema';
 import { File } from 'refly-icons';
 import { getCodeLanguage } from '@refly-packages/ai-workspace-common/utils/file-type';
 import { useDriveFileUrl } from '@refly-packages/ai-workspace-common/hooks/canvas/use-drive-file-url';
+import { useDownloadFile } from '@refly-packages/ai-workspace-common/hooks/canvas/use-download-file';
 import { cn } from '@refly/utils/cn';
 import { useMatch } from 'react-router-dom';
 
@@ -19,19 +20,6 @@ import { AudioRenderer } from './audio';
 import { UnsupportedRenderer } from './unsupported';
 import { HtmlRenderer } from './html';
 import { MarkdownRenderer } from './markdown';
-
-const useHandleDownload = (url: string | undefined, fileName: string) => {
-  return useCallback(() => {
-    if (!url) return;
-
-    const link = document.createElement('a');
-    link.href = `${url}?download=1`;
-    link.download = fileName;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  }, [url, fileName]);
-};
 
 interface ContentCategoryResult {
   category: string;
@@ -164,7 +152,11 @@ export const FilePreview = memo(
       };
     }, [fetchFileContent]);
 
-    const handleDownload = useHandleDownload(fileContent?.url, file.name);
+    const contentType = (file?.type ?? '') as string;
+    const { handleDownload: downloadFile, isDownloading } = useDownloadFile();
+    const handleDownload = useCallback(() => {
+      downloadFile({ currentFile: file, contentType });
+    }, [downloadFile, file, contentType]);
 
     const handleTabChange = useCallback((tab: 'code' | 'preview') => {
       setActiveTab(tab);
@@ -231,6 +223,7 @@ export const FilePreview = memo(
               fileContent={fileContent}
               file={file}
               onDownload={handleDownload}
+              isDownloading={isDownloading}
             />
           );
       }

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/file-preview/unsupported.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/file-preview/unsupported.tsx
@@ -5,10 +5,11 @@ import type { FileRendererProps } from './types';
 
 interface UnsupportedRendererProps extends FileRendererProps {
   onDownload: () => void;
+  isDownloading?: boolean;
 }
 
 export const UnsupportedRenderer = memo(
-  ({ fileContent, file, onDownload }: UnsupportedRendererProps) => {
+  ({ fileContent, file, onDownload, isDownloading }: UnsupportedRendererProps) => {
     const { contentType } = fileContent;
 
     return (
@@ -19,7 +20,13 @@ export const UnsupportedRenderer = memo(
           <div className="text-sm text-gray-500 mb-4">File type: {contentType}</div>
           <div className="text-sm text-gray-400">Preview not available for this file type</div>
         </div>
-        <Button type="primary" icon={<Download className="w-4 h-4" />} onClick={onDownload}>
+        <Button
+          type="primary"
+          icon={<Download className="w-4 h-4" />}
+          onClick={onDownload}
+          loading={isDownloading}
+          disabled={isDownloading}
+        >
           Download File
         </Button>
       </div>

--- a/packages/ai-workspace-common/src/components/canvas/workflow-variables/resource-type-form.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/workflow-variables/resource-type-form.tsx
@@ -1,25 +1,15 @@
-import React, { useCallback, useMemo, useEffect } from 'react';
-import { Form, Upload, Button, message, Select, Tooltip } from 'antd';
+import React, { useCallback } from 'react';
+import { Form, Upload, Button, message, Tooltip } from 'antd';
 import { useTranslation } from 'react-i18next';
-import { Refresh, Delete, Close } from 'refly-icons';
+import { Refresh, Delete } from 'refly-icons';
 import type { UploadFile } from 'antd/es/upload/interface';
 import { Spin } from '@refly-packages/ai-workspace-common/components/common/spin';
 import {
   FileIcon,
   defaultStyles,
 } from '@refly-packages/ai-workspace-common/components/common/resource-icon';
-import {
-  RESOURCE_TYPE,
-  ACCEPT_FILE_EXTENSIONS,
-  IMAGE_FILE_EXTENSIONS,
-  DOCUMENT_FILE_EXTENSIONS,
-  AUDIO_FILE_EXTENSIONS,
-  VIDEO_FILE_EXTENSIONS,
-} from './constants';
+import { IMAGE_FILE_EXTENSIONS } from './constants';
 import { getFileExtension } from './utils';
-import { NodeIcon } from '@refly-packages/ai-workspace-common/components/canvas/nodes/shared/node-icon';
-
-const { useWatch } = Form;
 
 interface ResourceTypeFormProps {
   fileList: UploadFile[];
@@ -31,69 +21,8 @@ interface ResourceTypeFormProps {
 }
 
 export const ResourceTypeForm: React.FC<ResourceTypeFormProps> = React.memo(
-  ({ fileList, uploading, onFileUpload, onFileRemove, onRefreshFile, form }) => {
+  ({ fileList, uploading, onFileUpload, onFileRemove, onRefreshFile }) => {
     const { t } = useTranslation();
-
-    const selectedResourceTypes = useWatch('resourceTypes', form);
-
-    const acceptedFileExtensions = useMemo(() => {
-      try {
-        if (!selectedResourceTypes || selectedResourceTypes.length === 0) {
-          return ACCEPT_FILE_EXTENSIONS;
-        }
-
-        const extensions: string[] = [];
-        for (const type of selectedResourceTypes) {
-          switch (type) {
-            case 'document':
-              extensions.push(...DOCUMENT_FILE_EXTENSIONS);
-              break;
-            case 'image':
-              extensions.push(...IMAGE_FILE_EXTENSIONS);
-              break;
-            case 'audio':
-              extensions.push(...AUDIO_FILE_EXTENSIONS);
-              break;
-            case 'video':
-              extensions.push(...VIDEO_FILE_EXTENSIONS);
-              break;
-            default:
-              extensions.push(...ACCEPT_FILE_EXTENSIONS);
-              break;
-          }
-        }
-
-        return extensions.length > 0 ? extensions : ACCEPT_FILE_EXTENSIONS;
-      } catch (error) {
-        console.error('Error calculating accepted file extensions:', error);
-        return ACCEPT_FILE_EXTENSIONS;
-      }
-    }, [selectedResourceTypes]);
-
-    const options = useMemo(() => {
-      return RESOURCE_TYPE.map((type) => ({
-        label: t(`canvas.workflow.variables.resourceType.${type}`),
-        value: type,
-      }));
-    }, [t]);
-
-    useEffect(() => {
-      if (!fileList?.length) {
-        return;
-      }
-
-      const incompatibleFiles = fileList.filter((file) => {
-        if (!file.name) return false;
-        const fileExtension = getFileExtension(file.name);
-        return !acceptedFileExtensions.includes(fileExtension);
-      });
-
-      if (incompatibleFiles.length > 0) {
-        for (const file of incompatibleFiles) {
-          onFileRemove(file);
-        }
-      }
-    }, [acceptedFileExtensions, fileList, onFileRemove]);
 
     const handleUpload = useCallback(
       async (file: File) => {
@@ -120,68 +49,16 @@ export const ResourceTypeForm: React.FC<ResourceTypeFormProps> = React.memo(
       }
     }, []);
 
-    const getFileIconType = useCallback(
-      (name: string) => {
-        const extension = getFileExtension(name);
-        if (IMAGE_FILE_EXTENSIONS.includes(extension)) {
-          return 'image';
-        }
-        return extension;
-      },
-      [getFileExtension],
-    );
-
-    const tagRender = (props: any) => {
-      const { label, value, closable, onClose } = props;
-      const onPreventMouseDown = (event: React.MouseEvent<HTMLSpanElement>) => {
-        event.preventDefault();
-        event.stopPropagation();
-      };
-      return (
-        <div
-          className="h-5 box-border flex items-center px-1 py-0.5 border-[1px] border-solid border-refly-Card-Border rounded-[4px] text-xs leading-4 bg-refly-tertiary-default cursor-pointer mr-1"
-          onMouseDown={onPreventMouseDown}
-        >
-          <NodeIcon type={value} filled={false} iconSize={16} small className="w-4 h-4" />
-          <span className="text-refly-text-1">{label}</span>
-          {closable && (
-            <Close
-              onClick={onClose}
-              size={12}
-              color="var(--refly-text-1)"
-              className="ml-1 hover:bg-refly-tertiary-hover rounded-full"
-            />
-          )}
-        </div>
-      );
-    };
+    const getFileIconType = useCallback((name: string) => {
+      const extension = getFileExtension(name);
+      if (IMAGE_FILE_EXTENSIONS.includes(extension)) {
+        return 'image';
+      }
+      return extension;
+    }, []);
 
     return (
       <>
-        <Form.Item
-          label={t('canvas.workflow.variables.resourceAcceptType') || 'Accept Types'}
-          name="resourceTypes"
-          initialValue={RESOURCE_TYPE}
-          rules={[
-            {
-              required: true,
-              message:
-                t('canvas.workflow.variables.resourceTypesRequired') ||
-                'Resource types are required',
-            },
-          ]}
-        >
-          <Select
-            showSearch={false}
-            mode="multiple"
-            placeholder={
-              t('canvas.workflow.variables.selectResourceTypes') || 'Select resource types'
-            }
-            className="w-full resource-type-select"
-            options={options}
-            tagRender={tagRender}
-          />
-        </Form.Item>
         <Form.Item
           required
           label={t('canvas.workflow.variables.value') || 'Variable Value'}
@@ -201,7 +78,6 @@ export const ResourceTypeForm: React.FC<ResourceTypeFormProps> = React.memo(
             onRemove={handleRemove}
             onChange={handleChange}
             multiple={false}
-            accept={acceptedFileExtensions.map((ext) => `.${ext}`).join(',')}
             listType="text"
             disabled={uploading}
             maxCount={1}

--- a/packages/ai-workspace-common/src/components/import-resource/index.tsx
+++ b/packages/ai-workspace-common/src/components/import-resource/index.tsx
@@ -45,7 +45,13 @@ export const ImportResourceModal = memo(() => {
   const [currentProjectId, setCurrentProjectId] = useState<string | undefined>(projectId);
 
   const disableSave = useMemo(() => {
-    return saveLoading || waitingList.length === 0 || waitingList.length > canImportCount;
+    const hasUploadingFiles = waitingList.some((item) => item.file?.status === 'uploading');
+    return (
+      saveLoading ||
+      waitingList.length === 0 ||
+      waitingList.length > canImportCount ||
+      hasUploadingFiles
+    );
   }, [waitingList, canImportCount, saveLoading]);
 
   useEffect(() => {


### PR DESCRIPTION
# Summary                                                                                                                                                                         
                                                                                                                                                                                    
  Remove file type restrictions for workflow variables and fix file download issues.                                                                                                
                                                                                                                                                                                    
  **File Type Restrictions Removed:**                                                                                                                                               
  - Removed resource type selector from `ResourceTypeForm`, defaulting to all types                                                                                                 
  - Allow any file type upload without extension restrictions                                                                                                                       
  - File-to-variable conversion now accepts all file types with default `resourceTypes: ['document', 'image', 'audio', 'video']`                                                    
                                                                                                                                                                                    
  **Download Fix:**                                                                                                                                                                 
  - Fixed empty file download in unsupported file preview by using `useDownloadFile` hook                                                                                           
  - Added loading state for download button                                                                                                                                         
                                                                                                                                                                                    
  **Import Modal:**                                                                                                                                                                 
  - Disabled import button while files are uploading                                                                                                                                
                                                                                                                                                                                    
  # Impact Areas                                                                                                                                                                    
                                                                                                                                                                                    
  - [x] Free-form Canvas Interface                                                                                                                                                  
  - [x] Workflow Variables                                                                                                                                                          
  - [x] Resource Library                                                                                                                                                            
                                                                                                                                                                                    
  # Checklist                                                                                                                                                                       
                                                                                                                                                                                    
  - [x] I understand that this PR may be closed in case there was no previous discussion or issues.                                                                                 
  - [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.                                                      
  - [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods                                                                            
                                                                                                                