### PR TITLE
  fix: Remove file type restrictions from FileInput in mixed-text-editor                                                                                             

### DIFF
--- a/packages/ai-workspace-common/src/components/workflow-app/mixed-text-editor/mixed-text-editor.tsx
+++ b/packages/ai-workspace-common/src/components/workflow-app/mixed-text-editor/mixed-text-editor.tsx
@@ -168,22 +168,6 @@ const MixedTextEditor: React.FC<MixedTextEditorProps> = memo(
             if (segment.variable?.variableType === 'resource') {
               const currentFile = segment.variable.value?.[0]?.resource;
 
-              // Map resourceTypes to proper MIME types
-              const getAcceptTypes = (resourceTypes: string[] | undefined) => {
-                if (!resourceTypes || resourceTypes.length === 0) return '*';
-
-                const typeMap: Record<string, string> = {
-                  image: 'image/*',
-                  document: '.pdf,.doc,.docx,.txt,.rtf,.md,.json,.xml,.csv,.xlsx,.xls',
-                  audio: 'audio/*',
-                  video: 'video/*',
-                };
-
-                return resourceTypes.map((type) => typeMap[type] || `.${type}`).join(',');
-              };
-
-              const acceptTypes = getAcceptTypes(segment.variable.resourceTypes);
-
               return (
                 <FileInput
                   key={`${segment.id}-${index}`}
@@ -192,7 +176,6 @@ const MixedTextEditor: React.FC<MixedTextEditorProps> = memo(
                   placeholder={segment.variable?.name || segment.placeholder}
                   onChange={(value) => handleVariableChange(segment.id || '', value)}
                   disabled={disabled}
-                  accept={acceptTypes}
                   isDefaultValue={segment.isDefaultValue}
                   isModified={segment.isModified}
                 />


### PR DESCRIPTION
 # Summary                                                                                                                                                          
                                                                                                                                                                     
  Remove explicit `accept` prop and MIME type mapping from `FileInput` component in mixed-text-editor.                                                               
                                                                                                                                                                     
  **Changes:**                                                                                                                                                       
  - Removed `getAcceptTypes` function that mapped resourceTypes to MIME types                                                                                        
  - Removed `accept` prop from FileInput, allowing all file types to be uploaded                                                                                     
                                                                                                                                                                     
  # Impact Areas                                                                                                                                                     
                                                                                                                                                                     
  - [x] Workflow Variables (File Upload)                                                                                                                             
                                                                                                                                                                     
  # Checklist                                                                                                                                                        
                                                                                                                                                                     
  - [x] I understand that this PR may be closed in case there was no previous discussion or issues.                                                                  
  - [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.                                       
  - [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods