### PR TITLE
  fix: disable file preview truncation for shared files and update resultId mapping on canvas duplication                                                                            

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/file-preview/code.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/file-preview/code.tsx
@@ -11,7 +11,15 @@ const MAX_CARD_CHARS = 2000;
 const MAX_PREVIEW_LINES = 2000;
 const MAX_PREVIEW_CHARS = 100000;
 
-const truncateContent = (content: string, maxLines: number, maxChars: number) => {
+const truncateContent = (
+  content: string,
+  maxLines: number,
+  maxChars: number,
+  disableTruncation = false,
+) => {
+  if (disableTruncation) {
+    return { content, isTruncated: false };
+  }
   const lines = content.split('\n');
   if (lines.length <= maxLines && content.length <= maxChars) {
     return { content, isTruncated: false };
@@ -34,63 +42,72 @@ interface CodeRendererProps extends SourceRendererProps {
 }
 
 // Card mode: truncated content with SyntaxHighlighter
-const CardRenderer = memo(({ source, fileContent, file, language }: CodeRendererProps) => {
-  const rawContent = new TextDecoder().decode(fileContent.data);
-  const detectedLanguage = language || getCodeLanguage(file.name) || 'text';
+const CardRenderer = memo(
+  ({ source, fileContent, file, language, disableTruncation }: CodeRendererProps) => {
+    const rawContent = new TextDecoder().decode(fileContent.data);
+    const detectedLanguage = language || getCodeLanguage(file.name) || 'text';
 
-  // Use different truncation limits based on source
-  const isPreview = source === 'preview';
-  const maxLines = isPreview ? MAX_PREVIEW_LINES : MAX_CARD_LINES;
-  const maxChars = isPreview ? MAX_PREVIEW_CHARS : MAX_CARD_CHARS;
+    // Use different truncation limits based on source
+    const isPreview = source === 'preview';
+    const maxLines = isPreview ? MAX_PREVIEW_LINES : MAX_CARD_LINES;
+    const maxChars = isPreview ? MAX_PREVIEW_CHARS : MAX_CARD_CHARS;
 
-  const { content: truncatedContent, isTruncated } = useMemo(
-    () => truncateContent(rawContent, maxLines, maxChars),
-    [rawContent, maxLines, maxChars],
-  );
+    const { content: truncatedContent, isTruncated } = useMemo(
+      () => truncateContent(rawContent, maxLines, maxChars, disableTruncation),
+      [rawContent, maxLines, maxChars, disableTruncation],
+    );
 
-  // Preview mode: use CodeViewer (Monaco Editor has virtualization)
-  if (isPreview) {
-    return (
-      <div className="h-full flex flex-col">
-        {isTruncated && <TruncationNotice maxLines={maxLines} />}
-        <div className="flex-1 min-h-0">
-          <CodeViewer
-            code={truncatedContent}
-            language={detectedLanguage}
-            title={file.name}
-            entityId={file.fileId}
-            isGenerating={false}
-            activeTab="code"
-            onTabChange={() => {}}
-            onClose={() => {}}
-            onRequestFix={() => {}}
-            readOnly={true}
-            type="text/plain"
-            showActions={false}
-            purePreview={true}
-          />
+    // Preview mode: use CodeViewer (Monaco Editor has virtualization)
+    if (isPreview) {
+      return (
+        <div className="h-full flex flex-col">
+          {isTruncated && <TruncationNotice maxLines={maxLines} />}
+          <div className="flex-1 min-h-0">
+            <CodeViewer
+              code={truncatedContent}
+              language={detectedLanguage}
+              title={file.name}
+              entityId={file.fileId}
+              isGenerating={false}
+              activeTab="code"
+              onTabChange={() => {}}
+              onClose={() => {}}
+              onRequestFix={() => {}}
+              readOnly={true}
+              type="text/plain"
+              showActions={false}
+              purePreview={true}
+            />
+          </div>
         </div>
+      );
+    }
+
+    return (
+      <div className="h-full overflow-y-auto">
+        <SyntaxHighlighter code={truncatedContent} language={detectedLanguage} />
       </div>
     );
-  }
-
-  return (
-    <div className="h-full overflow-y-auto">
-      <SyntaxHighlighter code={truncatedContent} language={detectedLanguage} />
-    </div>
-  );
-});
+  },
+);
 
 // Preview mode: with Monaco Editor (virtualized) but still truncated for very large files
 const PreviewRenderer = memo(
-  ({ fileContent, file, language, activeTab, onTabChange }: CodeRendererProps) => {
+  ({
+    fileContent,
+    file,
+    language,
+    activeTab,
+    onTabChange,
+    disableTruncation,
+  }: CodeRendererProps) => {
     const rawContent = new TextDecoder().decode(fileContent.data);
     const detectedLanguage = language || getCodeLanguage(file.name) || 'text';
     const [tab, setTab] = useState<'code' | 'preview'>(activeTab || 'code');
 
     const { content: textContent, isTruncated } = useMemo(
-      () => truncateContent(rawContent, MAX_PREVIEW_LINES, MAX_PREVIEW_CHARS),
-      [rawContent],
+      () => truncateContent(rawContent, MAX_PREVIEW_LINES, MAX_PREVIEW_CHARS, disableTruncation),
+      [rawContent, disableTruncation],
     );
 
     const handleTabChange = (v: 'code' | 'preview') => {
@@ -127,14 +144,28 @@ const PreviewRenderer = memo(
 const PREVIEWABLE_LANGUAGES = new Set(['html', 'markdown', 'mermaid', 'svg']);
 
 export const CodeRenderer = memo(
-  ({ source = 'card', fileContent, file, language, activeTab, onTabChange }: CodeRendererProps) => {
+  ({
+    source = 'card',
+    fileContent,
+    file,
+    language,
+    activeTab,
+    onTabChange,
+    disableTruncation,
+  }: CodeRendererProps) => {
     const detectedLanguage = language || getCodeLanguage(file.name) || 'text';
     const supportsPreview = PREVIEWABLE_LANGUAGES.has(detectedLanguage.toLowerCase());
 
     // Use CardRenderer for non-previewable languages
     if (!supportsPreview) {
       return (
-        <CardRenderer source={source} fileContent={fileContent} file={file} language={language} />
+        <CardRenderer
+          source={source}
+          fileContent={fileContent}
+          file={file}
+          language={language}
+          disableTruncation={disableTruncation}
+        />
       );
     }
 
@@ -147,36 +178,39 @@ export const CodeRenderer = memo(
         language={language}
         activeTab={activeTab}
         onTabChange={onTabChange}
+        disableTruncation={disableTruncation}
       />
     );
   },
 );
 
-export const JsonRenderer = memo(({ fileContent, source = 'card' }: SourceRendererProps) => {
-  const textContent = new TextDecoder().decode(fileContent.data);
-  const { content: displayContent, isTruncated } = useMemo(
-    () =>
-      source === 'card'
-        ? truncateContent(textContent, MAX_CARD_LINES, MAX_CARD_CHARS)
-        : truncateContent(textContent, MAX_PREVIEW_LINES, MAX_PREVIEW_CHARS),
-    [textContent, source],
-  );
+export const JsonRenderer = memo(
+  ({ fileContent, source = 'card', disableTruncation }: SourceRendererProps) => {
+    const textContent = new TextDecoder().decode(fileContent.data);
+    const { content: displayContent, isTruncated } = useMemo(
+      () =>
+        source === 'card'
+          ? truncateContent(textContent, MAX_CARD_LINES, MAX_CARD_CHARS, disableTruncation)
+          : truncateContent(textContent, MAX_PREVIEW_LINES, MAX_PREVIEW_CHARS, disableTruncation),
+      [textContent, source, disableTruncation],
+    );
 
-  // Card mode: no truncation notice
-  if (source === 'card') {
+    // Card mode: no truncation notice
+    if (source === 'card') {
+      return (
+        <div className="h-full overflow-y-auto">
+          <SyntaxHighlighter code={displayContent} language="json" />
+        </div>
+      );
+    }
+
     return (
-      <div className="h-full overflow-y-auto">
-        <SyntaxHighlighter code={displayContent} language="json" />
+      <div className="h-full flex flex-col">
+        {isTruncated && <TruncationNotice maxLines={MAX_PREVIEW_LINES} />}
+        <div className="flex-1 overflow-y-auto min-h-0">
+          <SyntaxHighlighter code={displayContent} language="json" />
+        </div>
       </div>
     );
-  }
-
-  return (
-    <div className="h-full flex flex-col">
-      {isTruncated && <TruncationNotice maxLines={MAX_PREVIEW_LINES} />}
-      <div className="flex-1 overflow-y-auto min-h-0">
-        <SyntaxHighlighter code={displayContent} language="json" />
-      </div>
-    </div>
-  );
-});
+  },
+);

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/file-preview/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/file-preview/index.tsx
@@ -6,7 +6,6 @@ import { getCodeLanguage } from '@refly-packages/ai-workspace-common/utils/file-
 import { useDriveFileUrl } from '@refly-packages/ai-workspace-common/hooks/canvas/use-drive-file-url';
 import { useDownloadFile } from '@refly-packages/ai-workspace-common/hooks/canvas/use-download-file';
 import { cn } from '@refly/utils/cn';
-import { useMatch } from 'react-router-dom';
 
 // Import renderer components
 import type { FileContent } from './types';
@@ -80,17 +79,20 @@ interface FilePreviewProps {
   file: DriveFile;
   markdownClassName?: string;
   source?: 'card' | 'preview';
+  disableTruncation?: boolean;
 }
 
 export const FilePreview = memo(
-  ({ file, markdownClassName = '', source = 'card' }: FilePreviewProps) => {
+  ({
+    file,
+    markdownClassName = '',
+    source = 'card',
+    disableTruncation = false,
+  }: FilePreviewProps) => {
     const [fileContent, setFileContent] = useState<FileContent | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [activeTab, setActiveTab] = useState<'code' | 'preview'>('preview');
-
-    // Check if current page is a share page
-    const isShareFile = useMatch('/share/file/:shareId');
 
     // useFileUrl now automatically fetches publicURL if needed in share pages
     const { fileUrl, isLoading: isLoadingUrl } = useDriveFileUrl({ file });
@@ -169,9 +171,8 @@ export const FilePreview = memo(
       if (!fileContent) return null;
 
       const { category, language } = extractContentCategory(fileContent.contentType, file.name);
-      const isCardMode = source === 'card' || !!isShareFile;
 
-      const rendererSource = isCardMode ? 'card' : 'preview';
+      const rendererSource = source;
 
       switch (category) {
         case 'svg':
@@ -186,6 +187,7 @@ export const FilePreview = memo(
               file={file}
               activeTab={activeTab}
               onTabChange={handleTabChange}
+              disableTruncation={disableTruncation}
             />
           );
         case 'markdown':
@@ -197,6 +199,7 @@ export const FilePreview = memo(
               className={markdownClassName}
               activeTab={activeTab}
               onTabChange={handleTabChange}
+              disableTruncation={disableTruncation}
             />
           );
         case 'code':
@@ -208,6 +211,7 @@ export const FilePreview = memo(
               language={language!}
               activeTab={activeTab}
               onTabChange={handleTabChange}
+              disableTruncation={disableTruncation}
             />
           );
         case 'text':
@@ -217,12 +221,20 @@ export const FilePreview = memo(
               fileContent={fileContent}
               file={file}
               className={markdownClassName}
+              disableTruncation={disableTruncation}
             />
           );
         case 'pdf':
           return <PdfRenderer fileContent={fileContent} file={file} />;
         case 'json':
-          return <JsonRenderer source={rendererSource} fileContent={fileContent} file={file} />;
+          return (
+            <JsonRenderer
+              source={rendererSource}
+              fileContent={fileContent}
+              file={file}
+              disableTruncation={disableTruncation}
+            />
+          );
         case 'video':
           return <VideoRenderer fileContent={fileContent} file={file} />;
         case 'audio':

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/file-preview/markdown.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/file-preview/markdown.tsx
@@ -10,7 +10,15 @@ const MAX_CARD_CHARS = 2000;
 const MAX_PREVIEW_LINES = 2000;
 const MAX_PREVIEW_CHARS = 100000;
 
-const truncateContent = (content: string, maxLines: number, maxChars: number) => {
+const truncateContent = (
+  content: string,
+  maxLines: number,
+  maxChars: number,
+  disableTruncation = false,
+) => {
+  if (disableTruncation) {
+    return { content, isTruncated: false };
+  }
   const lines = content.split('\n');
   if (lines.length <= maxLines && content.length <= maxChars) {
     return { content, isTruncated: false };
@@ -28,11 +36,11 @@ const TruncationNotice = memo(({ maxLines }: { maxLines: number }) => {
   );
 });
 
-const Card = memo(({ fileContent, className }: SourceRendererProps) => {
+const Card = memo(({ fileContent, className, disableTruncation }: SourceRendererProps) => {
   const textContent = new TextDecoder().decode(fileContent.data);
   const { content: truncatedContent } = useMemo(
-    () => truncateContent(textContent, MAX_CARD_LINES, MAX_CARD_CHARS),
-    [textContent],
+    () => truncateContent(textContent, MAX_CARD_LINES, MAX_CARD_CHARS, disableTruncation),
+    [textContent, disableTruncation],
   );
 
   return (
@@ -42,42 +50,60 @@ const Card = memo(({ fileContent, className }: SourceRendererProps) => {
   );
 });
 
-const Preview = memo(({ fileContent, file, activeTab, onTabChange }: SourceRendererProps) => {
-  const rawContent = new TextDecoder().decode(fileContent.data);
+const Preview = memo(
+  ({ fileContent, file, activeTab, onTabChange, disableTruncation }: SourceRendererProps) => {
+    const rawContent = new TextDecoder().decode(fileContent.data);
 
-  const { content: textContent, isTruncated } = useMemo(
-    () => truncateContent(rawContent, MAX_PREVIEW_LINES, MAX_PREVIEW_CHARS),
-    [rawContent],
-  );
+    const { content: textContent, isTruncated } = useMemo(
+      () => truncateContent(rawContent, MAX_PREVIEW_LINES, MAX_PREVIEW_CHARS, disableTruncation),
+      [rawContent, disableTruncation],
+    );
 
-  return (
-    <div className="h-full flex flex-col">
-      {isTruncated && <TruncationNotice maxLines={MAX_PREVIEW_LINES} />}
-      <div className="flex-1 min-h-0">
-        <CodeViewer
-          code={textContent}
-          language="markdown"
-          title={file.name}
-          entityId={file.fileId}
-          isGenerating={false}
-          activeTab={activeTab!}
-          onTabChange={onTabChange!}
-          onClose={() => {}}
-          onRequestFix={() => {}}
-          readOnly={true}
-          type="text/markdown"
-          showActions={false}
-          purePreview={false}
-        />
+    return (
+      <div className="h-full flex flex-col">
+        {isTruncated && <TruncationNotice maxLines={MAX_PREVIEW_LINES} />}
+        <div className="flex-1 min-h-0">
+          <CodeViewer
+            code={textContent}
+            language="markdown"
+            title={file.name}
+            entityId={file.fileId}
+            isGenerating={false}
+            activeTab={activeTab!}
+            onTabChange={onTabChange!}
+            onClose={() => {}}
+            onRequestFix={() => {}}
+            readOnly={true}
+            type="text/markdown"
+            showActions={false}
+            purePreview={false}
+          />
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);
 
 export const MarkdownRenderer = memo(
-  ({ source, fileContent, file, className, activeTab, onTabChange }: SourceRendererProps) => {
+  ({
+    source,
+    fileContent,
+    file,
+    className,
+    activeTab,
+    onTabChange,
+    disableTruncation,
+  }: SourceRendererProps) => {
     if (source === 'card') {
-      return <Card source={source} fileContent={fileContent} file={file} className={className} />;
+      return (
+        <Card
+          source={source}
+          fileContent={fileContent}
+          file={file}
+          className={className}
+          disableTruncation={disableTruncation}
+        />
+      );
     }
     return (
       <Preview
@@ -86,6 +112,7 @@ export const MarkdownRenderer = memo(
         file={file}
         activeTab={activeTab}
         onTabChange={onTabChange}
+        disableTruncation={disableTruncation}
       />
     );
   },

--- a/packages/ai-workspace-common/src/components/canvas/canvas-resources/file-preview/types.ts
+++ b/packages/ai-workspace-common/src/components/canvas/canvas-resources/file-preview/types.ts
@@ -18,4 +18,5 @@ export interface SourceRendererProps extends FileRendererProps {
   className?: string;
   activeTab?: 'code' | 'preview';
   onTabChange?: (tab: 'code' | 'preview') => void;
+  disableTruncation?: boolean;
 }

--- a/packages/web-core/src/pages/drive-file-share/index.tsx
+++ b/packages/web-core/src/pages/drive-file-share/index.tsx
@@ -72,7 +72,7 @@ const DriveFileSharePage = () => {
           )}
 
           <div className={`flex-grow h-full ${isHtmlFile ? '' : 'pb-16'}`}>
-            <FilePreview file={file} source="preview" />
+            <FilePreview file={file} source="preview" disableTruncation />
           </div>
         </div>
       </div>


### PR DESCRIPTION
 # Summary                                                                                                                                                                          
                                                                                                                                                                                     
  Fix file preview truncation on share pages and correct resultId mapping when duplicating canvas drive files.                                                                       
                                                                                                                                                                                     
  **File Preview (Frontend):**                                                                                                                                                       
  - Added `disableTruncation` prop to `FilePreview`, `CodeRenderer`, `MarkdownRenderer`, and `JsonRenderer`                                                                          
  - Share file pages now display full file content without 20-line truncation limit                                                                                                  
  - Card mode still uses truncation (20 lines), preview mode uses extended limit (2000 lines)                                                                                        
                                                                                                                                                                                     
  **Canvas Duplication (Backend):**                                                                                                                                                  
  - Fixed duplicated DriveFiles retaining old `resultId` instead of mapped new `resultId`                                                                                            
  - Added post-duplication update step to replace `resultId` using `replaceEntityMap`                                                                                                
                                                                                                                                                                                     
  # Impact Areas                                                                                                                                                                     
                                                                                                                                                                                     
  - [x] Free-form Canvas Interface                                                                                                                                                   
  - [x] Other (Share Pages, Canvas Duplication)                                                                                                                                      
                                                                                                                                                                                     
  # Checklist                                                                                                                                                                        
                                                                                                                                                                                     
  - [x] I understand that this PR may be closed in case there was no previous discussion or issues.                                                                                  
  - [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.                                                       
  - [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional control to disable content truncation in file previews for code, JSON, and markdown files.

* **Chores**
  * Improved file duplication process with enhanced record mapping updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->