### PR TITLE
fix: update default value for publishToCommunity in CreateWorkflowApp…

### DIFF
--- a/packages/ai-workspace-common/src/components/workflow-app/create-modal.tsx
+++ b/packages/ai-workspace-common/src/components/workflow-app/create-modal.tsx
@@ -597,7 +597,7 @@ export const CreateWorkflowAppModal = ({
           title,
           description: '',
           remixEnabled: false, // Default to false (remix disabled)
-          publishToCommunity: false, // Default to false (not published to community)
+          publishToCommunity: true, // Default to true (published to community)
         });
         setCoverFileList([]);
         setCoverStorageKey(undefined);
@@ -675,7 +675,7 @@ export const CreateWorkflowAppModal = ({
           ?.map((node) => node.id) ?? [];
 
       setInitialFormData({
-        publishToCommunity: formValues.publishToCommunity ?? false,
+        publishToCommunity: formValues.publishToCommunity ?? true,
         title: formValues.title ?? title,
         description: formValues.description ?? '',
         selectedResults: [...validNodeIds].sort(),


### PR DESCRIPTION
…Modal

- Changed the default value of publishToCommunity from false to true to ensure workflows are published to the community by default.
- Updated the initial form data to reflect this change, ensuring consistency in the modal's behavior.
- Ensured compliance with coding standards, including the use of optional chaining and nullish coalescing for safer property access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly created workflow apps now default to being published to the community.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->