### PR TITLE
[REF-866] feat: update nextVersion calculation in SkillResponse components

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/index.tsx
@@ -155,7 +155,8 @@ const SkillResponseNodePreviewComponent = ({
     });
 
     // Update node status immediately to show "waiting" state
-    const nextVersion = (node.data?.metadata?.version || 0) + 1;
+    const nextVersion =
+      node.data?.metadata?.status === 'init' ? 0 : (node.data?.metadata?.version || 0) + 1;
     setNodeData(node.id, {
       metadata: {
         status: 'waiting',

--- a/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/skill-response.tsx
@@ -483,7 +483,8 @@ export const SkillResponseNode = memo(
         resetFailedState(entityId);
       }
 
-      const nextVersion = (data?.metadata?.version || 0) + 1;
+      const nextVersion =
+        data?.metadata?.status === 'init' ? 0 : (data?.metadata?.version ?? 0) + 1;
 
       setNodeData(id, {
         contentPreview: '',


### PR DESCRIPTION
- Modified the nextVersion calculation to reset to 0 when the node's status is 'init', ensuring correct versioning behavior.
- Ensured compliance with coding standards, including the use of optional chaining and nullish coalescing for safer property access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version tracking for skill responses. Initial executions now consistently start at version 0, while subsequent reruns properly increment from the previous version for accurate execution history.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->