### PR TITLE
[REF-954]fix: prevent duplicate entries in action message creation

### DIFF
--- a/apps/api/src/modules/drive/drive.service.ts
+++ b/apps/api/src/modules/drive/drive.service.ts
@@ -154,7 +154,7 @@ export class DriveService implements OnModuleInit {
     while (attempts < 100) {
       // Prevent infinite loop
       const randomSuffix = Math.random().toString(36).substring(2, 7); // 5-character random string
-      const newName = `${nameWithoutExt}-${randomSuffix}${extension}`;
+      const newName = `${nameWithoutExt}-${Date.now()}-${randomSuffix}${extension}`;
 
       if (!existingNames.has(newName)) {
         return newName;
@@ -374,124 +374,117 @@ export class DriveService implements OnModuleInit {
     },
   ): Promise<ProcessedUpsertDriveFileResult[]> {
     // Acquire lock to prevent concurrent file processing for the same canvas
-    const lockKey = `drive:canvas:${canvasId}`;
-    const releaseLock = await this.redis.waitLock(lockKey);
+    // const lockKey = `drive:canvas:${canvasId}`;
+    // const releaseLock = await this.redis.waitLock(lockKey);
+    const presentFiles = await this.prisma.driveFile.findMany({
+      select: { name: true },
+      where: { canvasId, scope: 'present', deletedAt: null },
+    });
 
-    try {
-      const presentFiles = await this.prisma.driveFile.findMany({
-        select: { name: true },
-        where: { canvasId, scope: 'present', deletedAt: null },
-      });
+    // Create a set of existing filenames for quick lookup
+    const existingFileNames = new Set(presentFiles.map((file) => file.name));
 
-      // Create a set of existing filenames for quick lookup
-      const existingFileNames = new Set(presentFiles.map((file) => file.name));
+    const results: ProcessedUpsertDriveFileResult[] = [];
 
-      const results: ProcessedUpsertDriveFileResult[] = [];
+    // Process each request in the batch
+    for (const request of requests) {
+      const { canvasId, name, content, storageKey, externalUrl, buffer, type } = request;
 
-      // Process each request in the batch
-      for (const request of requests) {
-        const { canvasId, name, content, storageKey, externalUrl, buffer, type } = request;
+      // Generate unique filename to avoid conflicts
+      const uniqueName = this.generateUniqueFileName(name, existingFileNames);
+      existingFileNames.add(uniqueName); // Add to set to prevent future conflicts in this batch
 
-        // Generate unique filename to avoid conflicts
-        const uniqueName = this.generateUniqueFileName(name, existingFileNames);
-        existingFileNames.add(uniqueName); // Add to set to prevent future conflicts in this batch
-
-        // Skip requests that don't have content to process
-        if (content === undefined && !storageKey && !externalUrl && !buffer) {
-          continue;
-        }
-
-        let source = request.source;
-        if (request.variableId) {
-          source = 'variable';
-        } else if (request.resultId) {
-          source = 'agent';
-        }
-
-        // Generate drive storage path
-        const driveStorageKey = this.generateStorageKey(user, {
-          canvasId,
-          name: uniqueName,
-          source,
-          scope: 'present',
-        });
-
-        let rawData: Buffer;
-        let size: bigint;
-
-        if (buffer) {
-          // Case 0: Buffer upload
-          rawData = buffer;
-          size = BigInt(rawData.length);
-        } else if (content !== undefined) {
-          // Case 1: Direct content upload
-          rawData = Buffer.from(content, 'utf8');
-          size = BigInt(rawData.length);
-          // Infer MIME type from filename, fallback to text/plain
-          request.type =
-            getSafeMimeType(name, mime.getType(name) ?? type ?? undefined) || 'text/plain';
-        } else if (storageKey) {
-          // Case 2: Transfer from existing storage key
-          let objectInfo = await this.internalOss.statObject(storageKey);
-          if (!objectInfo) {
-            throw new ParamsError(`Source file not found: ${storageKey}`);
-          }
-
-          if (storageKey !== driveStorageKey) {
-            objectInfo = await this.internalOss.duplicateFile(storageKey, driveStorageKey);
-          }
-
-          size = BigInt(objectInfo?.size ?? 0);
-          request.type =
-            objectInfo?.metaData?.['Content-Type'] ??
-            getSafeMimeType(name, mime.getType(name) ?? undefined);
-        } else if (externalUrl) {
-          // Case 3: Download from external URL
-          rawData = await this.downloadFileFromUrl(externalUrl);
-          size = BigInt(rawData.length);
-
-          // Determine content type based on file extension or default to binary
-          request.type = getSafeMimeType(name, mime.getType(name) ?? undefined);
-        }
-
-        if (options?.archiveFiles) {
-          if (request.variableId) {
-            await this.archiveFiles(user, canvasId, {
-              source: 'variable',
-              variableId: request.variableId,
-            });
-          } else if (request.resultId) {
-            await this.archiveFiles(user, canvasId, {
-              source: 'agent',
-              resultId: request.resultId,
-            });
-          }
-        }
-
-        if (rawData) {
-          const headers: Record<string, string> = {};
-          const formattedContentType = this.appendUtf8CharsetIfNeeded(request.type);
-          if (formattedContentType) {
-            headers['Content-Type'] = formattedContentType;
-          }
-          await this.internalOss.putObject(driveStorageKey, rawData, headers);
-        }
-
-        results.push({
-          ...request,
-          name: uniqueName,
-          driveStorageKey,
-          size,
-          source,
-          category: getFileCategory(request.type),
-        });
+      // Skip requests that don't have content to process
+      if (content === undefined && !storageKey && !externalUrl && !buffer) {
+        continue;
       }
 
-      return results;
-    } finally {
-      // Always release the lock
-      await releaseLock();
+      let source = request.source;
+      if (request.variableId) {
+        source = 'variable';
+      } else if (request.resultId) {
+        source = 'agent';
+      }
+
+      // Generate drive storage path
+      const driveStorageKey = this.generateStorageKey(user, {
+        canvasId,
+        name: uniqueName,
+        source,
+        scope: 'present',
+      });
+
+      let rawData: Buffer;
+      let size: bigint;
+
+      if (buffer) {
+        // Case 0: Buffer upload
+        rawData = buffer;
+        size = BigInt(rawData.length);
+      } else if (content !== undefined) {
+        // Case 1: Direct content upload
+        rawData = Buffer.from(content, 'utf8');
+        size = BigInt(rawData.length);
+        // Infer MIME type from filename, fallback to text/plain
+        request.type =
+          getSafeMimeType(name, mime.getType(name) ?? type ?? undefined) || 'text/plain';
+      } else if (storageKey) {
+        // Case 2: Transfer from existing storage key
+        let objectInfo = await this.internalOss.statObject(storageKey);
+        if (!objectInfo) {
+          throw new ParamsError(`Source file not found: ${storageKey}`);
+        }
+
+        if (storageKey !== driveStorageKey) {
+          objectInfo = await this.internalOss.duplicateFile(storageKey, driveStorageKey);
+        }
+
+        size = BigInt(objectInfo?.size ?? 0);
+        request.type =
+          objectInfo?.metaData?.['Content-Type'] ??
+          getSafeMimeType(name, mime.getType(name) ?? undefined);
+      } else if (externalUrl) {
+        // Case 3: Download from external URL
+        rawData = await this.downloadFileFromUrl(externalUrl);
+        size = BigInt(rawData.length);
+
+        // Determine content type based on file extension or default to binary
+        request.type = getSafeMimeType(name, mime.getType(name) ?? undefined);
+      }
+
+      if (options?.archiveFiles) {
+        if (request.variableId) {
+          await this.archiveFiles(user, canvasId, {
+            source: 'variable',
+            variableId: request.variableId,
+          });
+        } else if (request.resultId) {
+          await this.archiveFiles(user, canvasId, {
+            source: 'agent',
+            resultId: request.resultId,
+          });
+        }
+      }
+
+      if (rawData) {
+        const headers: Record<string, string> = {};
+        const formattedContentType = this.appendUtf8CharsetIfNeeded(request.type);
+        if (formattedContentType) {
+          headers['Content-Type'] = formattedContentType;
+        }
+        await this.internalOss.putObject(driveStorageKey, rawData, headers);
+      }
+
+      results.push({
+        ...request,
+        name: uniqueName,
+        driveStorageKey,
+        size,
+        source,
+        category: getFileCategory(request.type),
+      });
     }
+    return results;
   }
 
   /**

--- a/apps/api/src/utils/message-aggregator.ts
+++ b/apps/api/src/utils/message-aggregator.ts
@@ -115,7 +115,7 @@ export class MessageAggregator {
       // Create new messages
       if (newMessages.length > 0) {
         const createData = newMessages.map((msg) => this.toPrismaInput(msg));
-        await this.prisma.actionMessage.createMany({ data: createData });
+        await this.prisma.actionMessage.createMany({ data: createData, skipDuplicates: true });
 
         // Mark as persisted
         for (const msg of newMessages) {


### PR DESCRIPTION
This pull request includes several improvements to file handling and message aggregation logic, primarily focusing on enhancing filename uniqueness, preventing duplicate database entries, and modifying the locking mechanism during file processing.

File handling and concurrency:

* Improved filename uniqueness by including a timestamp in generated filenames to further reduce the chance of collisions.
* Removed the Redis-based locking mechanism for processing files associated with the same canvas, simplifying the code and potentially improving performance. [[1]](diffhunk://#diff-3aa1e7d7be6c3fe907a11f6ec552d01e30fcb3556182cd066560c92a0adfeb18L377-R378) [[2]](diffhunk://#diff-3aa1e7d7be6c3fe907a11f6ec552d01e30fcb3556182cd066560c92a0adfeb18L489-L494)

Database operations:

* Updated the message aggregation logic to use the `skipDuplicates: true` option with `createMany`, preventing duplicate messages from being inserted into the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filename generation for file uploads to reduce collision risks with enhanced uniqueness handling
  * Enhanced message persistence to gracefully handle duplicate entries without processing errors

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->