### PR TITLE
[REF-1012] feat: improve event tracking for voucher_applied and signup_success

### DIFF
--- a/apps/api/src/modules/subscription/subscription.service.ts
+++ b/apps/api/src/modules/subscription/subscription.service.ts
@@ -171,7 +171,7 @@ export class SubscriptionService implements OnModuleInit {
 
   async createCheckoutSession(user: User, param: CreateCheckoutSessionRequest) {
     const { uid } = user;
-    const { planType, interval, voucherId } = param;
+    const { planType, interval, voucherId, voucherEntryPoint, voucherUserType } = param;
     const userPo = await this.prisma.user.findUnique({ where: { uid } });
 
     const plan = await this.prisma.subscriptionPlan.findFirst({
@@ -193,6 +193,7 @@ export class SubscriptionService implements OnModuleInit {
     // Validate and get voucher promotion code if provided
     let stripePromoCodeId: string | undefined;
     let validatedVoucherId: string | undefined;
+    let voucherDiscountPercent: number | undefined;
     if (voucherId) {
       const voucherValidation = await this.voucherService.validateVoucher(uid, voucherId);
       if (voucherValidation.valid && voucherValidation.voucher) {
@@ -200,6 +201,7 @@ export class SubscriptionService implements OnModuleInit {
         if (voucherValidation.voucher.stripePromoCodeId) {
           stripePromoCodeId = voucherValidation.voucher.stripePromoCodeId;
           validatedVoucherId = voucherId;
+          voucherDiscountPercent = voucherValidation.voucher.discountPercent;
           this.logger.log(
             `Using Stripe promotion code ${stripePromoCodeId} for voucher ${voucherId} (${voucherValidation.voucher.discountPercent}% off)`,
           );
@@ -247,7 +249,14 @@ export class SubscriptionService implements OnModuleInit {
       consent_collection: {
         terms_of_service: 'required',
       },
-      metadata: validatedVoucherId ? { voucherId: validatedVoucherId } : undefined,
+      metadata: validatedVoucherId
+        ? {
+            voucherId: validatedVoucherId,
+            voucherDiscountPercent: voucherDiscountPercent?.toString(),
+            voucherEntryPoint,
+            voucherUserType,
+          }
+        : undefined,
     };
 
     // Apply voucher promotion code or allow promotion codes (not both)

--- a/apps/web/rsbuild.config.ts
+++ b/apps/web/rsbuild.config.ts
@@ -85,6 +85,7 @@ export default defineConfig({
         '../../packages/ai-workspace-common/src',
       ),
       '@refly/utils': path.resolve(__dirname, '../../packages/utils/src'),
+      '@refly/canvas-common': path.resolve(__dirname, '../../packages/canvas-common/src'),
     },
   },
   html: {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -23,13 +23,16 @@
     "paths": {
       "@/*": ["./src/*"],
       "@refly-packages/ai-workspace-common/*": ["../../packages/ai-workspace-common/src/*"],
-      "@refly/utils/*": ["../../packages/utils/src/*"]
+      "@refly/utils/*": ["../../packages/utils/src/*"],
+      "@refly/canvas-common": ["../../packages/canvas-common/src"],
+      "@refly/canvas-common/*": ["../../packages/canvas-common/src/*"]
     }
   },
   "include": ["src"],
   "exclude": ["tailwind-colors.ts"],
   "references": [
     { "path": "../../packages/ai-workspace-common" },
-    { "path": "../../packages/utils" }
+    { "path": "../../packages/utils" },
+    { "path": "../../packages/canvas-common" }
   ]
 }

--- a/packages/ai-workspace-common/src/components/app-manager/app-card.tsx
+++ b/packages/ai-workspace-common/src/components/app-manager/app-card.tsx
@@ -9,6 +9,7 @@ import { memo, useMemo, useCallback } from 'react';
 import defaultAvatar from '@refly-packages/ai-workspace-common/assets/refly_default_avatar.png';
 import { useDuplicateCanvas } from '@refly-packages/ai-workspace-common/hooks/use-duplicate-canvas';
 import { useUserStoreShallow, useAuthStoreShallow } from '@refly/stores';
+import { storeSignupEntryPoint } from '@refly-packages/ai-workspace-common/hooks/use-pending-voucher-claim';
 
 interface AppCardData extends WorkflowApp {
   publishReviewStatus?: string;
@@ -38,6 +39,7 @@ export const AppCard = memo(({ data }: { data: AppCardData; onDelete?: () => voi
       e.stopPropagation();
 
       if (!isLogin) {
+        storeSignupEntryPoint('template_detail');
         setLoginModalOpen(true);
         return;
       }

--- a/packages/ai-workspace-common/src/components/canvas-template/template-card.tsx
+++ b/packages/ai-workspace-common/src/components/canvas-template/template-card.tsx
@@ -9,6 +9,7 @@ import { useCallback, useState, useMemo, useEffect } from 'react';
 import type { SyntheticEvent } from 'react';
 import { AVATAR_PLACEHOLDER_IMAGE, CARD_PLACEHOLDER_IMAGE } from './constants';
 import diamondIcon from '@refly-packages/ai-workspace-common/assets/diamond.svg';
+import { storeSignupEntryPoint } from '@refly-packages/ai-workspace-common/hooks/use-pending-voucher-claim';
 
 interface TemplateCardProps {
   template: CanvasTemplate;
@@ -104,6 +105,7 @@ export const TemplateCard = ({ template, className, showUser = true }: TemplateC
       });
 
       if (!isLogin) {
+        storeSignupEntryPoint('template_detail');
         setLoginModalOpen(true);
         return;
       }

--- a/packages/ai-workspace-common/src/components/canvas/front-page/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/front-page/index.tsx
@@ -129,7 +129,7 @@ export const SettingItem = React.memo(
     const handleSubscriptionClick = useCallback(
       (e: React.MouseEvent) => {
         e.stopPropagation();
-        setSubscribeModalVisible(true);
+        setSubscribeModalVisible(true, 'canvas');
       },
       [setSubscribeModalVisible],
     );

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/failure-notice.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/failure-notice.tsx
@@ -30,7 +30,7 @@ export const FailureNotice = ({ result, handleRetry }: FailureNoticeProps) => {
   const handleSubscriptionClick = useCallback(
     (e?: React.MouseEvent) => {
       e?.stopPropagation();
-      setSubscribeModalVisible(true);
+      setSubscribeModalVisible(true, 'canvas');
 
       logEvent('subscription::upgrade_click', 'skill_invoke');
     },

--- a/packages/ai-workspace-common/src/components/settings/subscribe-modal/index.tsx
+++ b/packages/ai-workspace-common/src/components/settings/subscribe-modal/index.tsx
@@ -12,11 +12,13 @@ export const SubscribeModal = () => {
   const {
     subscribeModalVisible: visible,
     setSubscribeModalVisible: setVisible,
+    subscribeModalSource,
     openedFromSettings,
     setOpenedFromSettings,
   } = useSubscriptionStoreShallow((state) => ({
     subscribeModalVisible: state.subscribeModalVisible,
     setSubscribeModalVisible: state.setSubscribeModalVisible,
+    subscribeModalSource: state.subscribeModalSource,
     openedFromSettings: state.openedFromSettings,
     setOpenedFromSettings: state.setOpenedFromSettings,
   }));
@@ -58,7 +60,7 @@ export const SubscribeModal = () => {
         <div className="font-bold text-2xl m-auto flex items-center gap-2 text-refly-text-0 text-[22px] font-semibold leading-8">
           {t('subscription.modalTitle')}
         </div>
-        <PriceContent source="modal" />
+        <PriceContent source="modal" entryPoint={subscribeModalSource || 'pricing_page'} />
       </div>
     </Modal>
   );

--- a/packages/ai-workspace-common/src/components/settings/subscribe-modal/priceContent.tsx
+++ b/packages/ai-workspace-common/src/components/settings/subscribe-modal/priceContent.tsx
@@ -499,10 +499,10 @@ const PlanItem = memo((props: PlanItemProps) => {
 
 PlanItem.displayName = 'PlanItem';
 
-export const PriceContent = memo((props: { source: PriceSource }) => {
+export const PriceContent = memo((props: { source: PriceSource; entryPoint?: string }) => {
   const { t } = useTranslation('ui');
   const navigate = useNavigate();
-  const { source } = props;
+  const { source, entryPoint } = props;
   const {
     setSubscribeModalVisible: setVisible,
     availableVoucher,
@@ -616,6 +616,8 @@ export const PriceContent = memo((props: { source: PriceSource }) => {
           planType: SubscriptionPlanType;
           interval: SubscriptionInterval;
           voucherId?: string;
+          voucherEntryPoint?: string;
+          voucherUserType?: string;
         } = {
           planType,
           interval: interval,
@@ -629,13 +631,8 @@ export const PriceContent = memo((props: { source: PriceSource }) => {
 
           if (validateRes.data?.data?.valid) {
             body.voucherId = availableVoucher.voucherId;
-
-            // Log voucher applied event
-            logEvent('voucher_applied', null, {
-              voucher_value: Math.round((100 - availableVoucher.discountPercent) / 10),
-              entry_point: 'pricing_page',
-              user_type: userType,
-            });
+            body.voucherEntryPoint = entryPoint || 'pricing_page';
+            body.voucherUserType = userType;
           } else {
             // Voucher is invalid - show message and clear it
             const reason = validateRes.data?.data?.reason || 'Voucher is no longer valid';

--- a/packages/ai-workspace-common/src/components/subscription/credit-insufficient-modal.tsx
+++ b/packages/ai-workspace-common/src/components/subscription/credit-insufficient-modal.tsx
@@ -577,6 +577,8 @@ export const CreditInsufficientModal = memo(() => {
           currentPlan?: string;
           source?: string;
           voucherId?: string;
+          voucherEntryPoint?: string;
+          voucherUserType?: string;
         } = {
           planType: 'plus' as SubscriptionPlanType,
           interval: interval,
@@ -598,13 +600,9 @@ export const CreditInsufficientModal = memo(() => {
 
           if (validateRes.data?.data?.valid) {
             body.voucherId = availableVoucher.voucherId;
+            body.voucherEntryPoint = 'canvas';
+            body.voucherUserType = userType;
             console.log('[CreditInsufficientModal] Voucher added to body:', body.voucherId);
-
-            logEvent('voucher_applied', null, {
-              voucher_value: Math.round((100 - availableVoucher.discountPercent) / 10),
-              entry_point: 'credit_insufficient_modal',
-              user_type: userType,
-            });
           } else {
             const reason = validateRes.data?.data?.reason || 'Voucher is no longer valid';
             message.warning(

--- a/packages/ai-workspace-common/src/components/voucher/voucher-popup.tsx
+++ b/packages/ai-workspace-common/src/components/voucher/voucher-popup.tsx
@@ -128,6 +128,8 @@ export const VoucherPopup = ({
         planType: 'plus';
         interval: 'monthly';
         voucherId?: string;
+        voucherEntryPoint?: string;
+        voucherUserType?: string;
       } = {
         planType: 'plus',
         interval: 'monthly',
@@ -135,13 +137,9 @@ export const VoucherPopup = ({
 
       if (validateRes.data?.data?.valid) {
         body.voucherId = voucher.voucherId;
+        body.voucherEntryPoint = useOnlyMode ? 'share_discount_popup' : 'discount_popup';
+        body.voucherUserType = userType;
         console.log('[voucher-popup] voucher is valid, adding to checkout body');
-
-        logEvent('voucher_applied', null, {
-          voucher_value: voucherValue,
-          entry_point: useOnlyMode ? 'claimed_popup' : 'discount_popup',
-          user_type: userType,
-        });
       } else {
         console.log('[voucher-popup] voucher is NOT valid:', validateRes.data?.data);
         const reason = validateRes.data?.data?.reason || 'Voucher is no longer valid';

--- a/packages/ai-workspace-common/src/hooks/use-pending-voucher-claim.ts
+++ b/packages/ai-workspace-common/src/hooks/use-pending-voucher-claim.ts
@@ -9,6 +9,7 @@ import { useSubscriptionStoreShallow, useUserStoreShallow } from '@refly/stores'
 import type { Voucher } from '@refly/openapi-schema';
 
 const PENDING_VOUCHER_KEY = 'pendingVoucherInviteCode';
+const SIGNUP_ENTRY_POINT_KEY = 'signupEntryPoint';
 
 /**
  * Hook to handle claiming a voucher from URL parameter or localStorage.
@@ -162,9 +163,12 @@ export const usePendingVoucherClaim = () => {
 
 /**
  * Store a voucher invite code for claiming after login
+ * Also stores the signup entry point as voucher_share_link
  */
 export const storePendingVoucherCode = (inviteCode: string) => {
   localStorage.setItem(PENDING_VOUCHER_KEY, inviteCode);
+  // When storing voucher code, set entry point to voucher_share_link
+  localStorage.setItem(SIGNUP_ENTRY_POINT_KEY, 'voucher_share_link');
 };
 
 /**
@@ -179,4 +183,23 @@ export const clearPendingVoucherCode = () => {
  */
 export const getPendingVoucherCode = (): string | null => {
   return localStorage.getItem(PENDING_VOUCHER_KEY);
+};
+
+/**
+ * Store signup entry point for tracking
+ */
+export const storeSignupEntryPoint = (entryPoint: string) => {
+  // Only store if not already set (don't overwrite voucher_share_link)
+  if (!localStorage.getItem(SIGNUP_ENTRY_POINT_KEY)) {
+    localStorage.setItem(SIGNUP_ENTRY_POINT_KEY, entryPoint);
+  }
+};
+
+/**
+ * Get and clear signup entry point
+ */
+export const getAndClearSignupEntryPoint = (): string | null => {
+  const entryPoint = localStorage.getItem(SIGNUP_ENTRY_POINT_KEY);
+  localStorage.removeItem(SIGNUP_ENTRY_POINT_KEY);
+  return entryPoint;
 };

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -9428,6 +9428,12 @@ components:
         voucherId:
           type: string
           description: Optional voucher ID to apply discount
+        voucherEntryPoint:
+          type: string
+          description: Entry point where voucher was applied (e.g., claimed_popup, discount_popup, credit_insufficient_modal, pricing_page)
+        voucherUserType:
+          type: string
+          description: User type when voucher was applied (e.g., new, returning)
         currentPlan:
           type: string
           description: Current plan

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -7164,6 +7164,15 @@ export const CreateCheckoutSessionRequestSchema = {
       type: 'string',
       description: 'Optional voucher ID to apply discount',
     },
+    voucherEntryPoint: {
+      type: 'string',
+      description:
+        'Entry point where voucher was applied (e.g., claimed_popup, discount_popup, credit_insufficient_modal, pricing_page)',
+    },
+    voucherUserType: {
+      type: 'string',
+      description: 'User type when voucher was applied (e.g., new, returning)',
+    },
     currentPlan: {
       type: 'string',
       description: 'Current plan',

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -5137,6 +5137,14 @@ export type CreateCheckoutSessionRequest = {
    */
   voucherId?: string;
   /**
+   * Entry point where voucher was applied (e.g., claimed_popup, discount_popup, credit_insufficient_modal, pricing_page)
+   */
+  voucherEntryPoint?: string;
+  /**
+   * User type when voucher was applied (e.g., new, returning)
+   */
+  voucherUserType?: string;
+  /**
    * Current plan
    */
   currentPlan?: string;

--- a/packages/stores/src/stores/subscription.ts
+++ b/packages/stores/src/stores/subscription.ts
@@ -8,6 +8,7 @@ interface SubscriptionState {
   planType: SubscriptionPlanType;
   userType: string;
   subscribeModalVisible: boolean;
+  subscribeModalSource: string; // Track where the subscribe modal was triggered from (canvas, template_detail, pricing_page, etc.)
   storageExceededModalVisible: boolean;
   creditInsufficientModalVisible: boolean;
   creditInsufficientMembershipLevel: string;
@@ -26,7 +27,7 @@ interface SubscriptionState {
   // method
   setPlanType: (val: SubscriptionPlanType) => void;
   setUserType: (val: string) => void;
-  setSubscribeModalVisible: (val: boolean) => void;
+  setSubscribeModalVisible: (val: boolean, source?: string) => void;
   setStorageExceededModalVisible: (val: boolean) => void;
   setCreditInsufficientModalVisible: (
     val: boolean,
@@ -45,6 +46,7 @@ export const useSubscriptionStore = create<SubscriptionState>()(
     planType: 'free',
     userType: '',
     subscribeModalVisible: false,
+    subscribeModalSource: '',
     storageExceededModalVisible: false,
     creditInsufficientModalVisible: false,
     creditInsufficientMembershipLevel: '',
@@ -58,7 +60,14 @@ export const useSubscriptionStore = create<SubscriptionState>()(
 
     setPlanType: (val: SubscriptionPlanType) => set({ planType: val }),
     setUserType: (val: string) => set({ userType: val }),
-    setSubscribeModalVisible: (val: boolean) => set({ subscribeModalVisible: val }),
+    setSubscribeModalVisible: (val: boolean, source?: string) =>
+      set((state) => ({
+        subscribeModalVisible: val,
+        // Only update source when opening the modal with a source, preserve when closing
+        subscribeModalSource: val
+          ? source || state.subscribeModalSource
+          : state.subscribeModalSource,
+      })),
     setStorageExceededModalVisible: (val: boolean) => set({ storageExceededModalVisible: val }),
     setCreditInsufficientModalVisible: (
       val: boolean,

--- a/packages/web-core/src/components/landing-page-partials/Header.tsx
+++ b/packages/web-core/src/components/landing-page-partials/Header.tsx
@@ -17,6 +17,7 @@ import { Logo } from '@refly-packages/ai-workspace-common/components/common/logo
 import { GithubStar } from '@refly-packages/ai-workspace-common/components/common/github-star';
 import { Language } from 'refly-icons';
 import logoIcon from '@refly-packages/ai-workspace-common/assets/logo.svg';
+import { storeSignupEntryPoint } from '@refly-packages/ai-workspace-common/hooks/use-pending-voucher-claim';
 
 function Header() {
   const navigate = useNavigate();
@@ -125,6 +126,7 @@ function Header() {
   useEffect(() => {
     const shouldOpenLogin = searchParams.get('openLogin');
     if (shouldOpenLogin) {
+      storeSignupEntryPoint('visitor_page');
       setLoginModalOpen(true);
       // Remove the openLogin parameter from URL
       searchParams.delete('openLogin');
@@ -196,7 +198,13 @@ function Header() {
           <span className="font-semibold text-refly-text-0">{t('landingPage.addToChrome')}</span>
         </Button>
 
-        <Button type="primary" onClick={() => setLoginModalOpen(true)}>
+        <Button
+          type="primary"
+          onClick={() => {
+            storeSignupEntryPoint('visitor_page');
+            setLoginModalOpen(true);
+          }}
+        >
           <img
             src={logoIcon}
             className="object-contain shrink-0 self-stretch my-auto w-4 aspect-square"

--- a/packages/web-core/src/components/landing-page-partials/HeroHome.tsx
+++ b/packages/web-core/src/components/landing-page-partials/HeroHome.tsx
@@ -11,6 +11,7 @@ import { Button, Modal } from 'antd';
 import BlurImage from '../../components/common/BlurImage';
 import { useAuthStoreShallow } from '@refly/stores';
 import { useState } from 'react';
+import { storeSignupEntryPoint } from '@refly-packages/ai-workspace-common/hooks/use-pending-voucher-claim';
 
 function HeroHome() {
   const { t, i18n } = useTranslation();
@@ -210,7 +211,10 @@ function HeroHome() {
             {/* Add buttons after the description paragraph */}
             <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row sm:gap-6">
               <Button
-                onClick={() => setLoginModalOpen(true)}
+                onClick={() => {
+                  storeSignupEntryPoint('visitor_page');
+                  setLoginModalOpen(true);
+                }}
                 size="large"
                 type="primary"
                 className="cursor-pointer"

--- a/packages/web-core/src/pages/home-new/index.tsx
+++ b/packages/web-core/src/pages/home-new/index.tsx
@@ -9,7 +9,10 @@ import { canvasTemplateEnabled } from '@refly/ui-kit';
 import Header from '../../components/landing-page-partials/Header';
 import { useSearchParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
-import { storePendingVoucherCode } from '@refly-packages/ai-workspace-common/hooks/use-pending-voucher-claim';
+import {
+  storePendingVoucherCode,
+  storeSignupEntryPoint,
+} from '@refly-packages/ai-workspace-common/hooks/use-pending-voucher-claim';
 
 import cn from 'classnames';
 import { Title } from '@refly-packages/ai-workspace-common/components/canvas/front-page/title';
@@ -39,6 +42,7 @@ const UnsignedFrontPage = memo(() => {
   }));
 
   const handleLogin = useCallback(() => {
+    storeSignupEntryPoint('visitor_page');
     setLoginModalOpen(true);
   }, [setLoginModalOpen]);
 
@@ -46,6 +50,7 @@ const UnsignedFrontPage = memo(() => {
   useEffect(() => {
     const autoLogin = searchParams.get('autoLogin');
     if (autoLogin === 'true') {
+      storeSignupEntryPoint('visitor_page');
       setLoginModalOpen(true);
     }
   }, [searchParams, setLoginModalOpen]);

--- a/packages/web-core/src/pages/workflow-app/workflow-app-form.tsx
+++ b/packages/web-core/src/pages/workflow-app/workflow-app-form.tsx
@@ -27,6 +27,7 @@ import {
 } from '@refly-packages/ai-workspace-common/queries/queries';
 import { extractToolsetsWithNodes, ToolWithNodes } from '@refly/canvas-common';
 import { GenericToolset, UserTool } from '@refly/openapi-schema';
+import { storeSignupEntryPoint } from '@refly-packages/ai-workspace-common/hooks/use-pending-voucher-claim';
 
 /**
  * Check if a toolset is authorized/installed
@@ -536,6 +537,7 @@ export const WorkflowAPPForm = ({
 
     // Check if user is logged in
     if (!isLogin) {
+      storeSignupEntryPoint('template_detail');
       setLoginModalOpen(true);
       return;
     }
@@ -721,6 +723,7 @@ export const WorkflowAPPForm = ({
   const handleRemix = () => {
     // Check if user is logged in
     if (!isLogin) {
+      storeSignupEntryPoint('template_detail');
       setLoginModalOpen(true);
       return;
     }


### PR DESCRIPTION
 ## Summary

  Improve event tracking accuracy for `voucher_applied` and `signup_success` events.

  **voucher_applied Event:**
  - Moved from frontend (on "Use it now" click) to backend (after successful Stripe payment)
  - Added `voucherEntryPoint` and `voucherUserType` fields to checkout session metadata
  - Event now only fires when voucher is actually used in a completed payment

  **signup_success Event:**
  - Added `entry_point` field to track registration source
  - Uses localStorage to persist entry point across page navigations
  - Supported entry points: `visitor_page`, `template_detail`, `voucher_share_link`

  # Impact Areas

  - [x] Authentication (Login/Signup flow)
  - [x] Subscription (Checkout with voucher)
  - [x] Analytics/Telemetry

  # Checklist

  - [x] I understand that this PR may be closed in case there was no previous discussion or issues.
  - [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods