### PR TITLE
[REF-1013] feat(workflow-app): disable run button during file upload in MixedTex…

### DIFF
--- a/packages/ai-workspace-common/src/components/workflow-app/mixed-text-editor/file-input.tsx
+++ b/packages/ai-workspace-common/src/components/workflow-app/mixed-text-editor/file-input.tsx
@@ -14,6 +14,7 @@ interface FileInputProps {
   accept?: string;
   isDefaultValue?: boolean; // Whether this is a default value
   isModified?: boolean; // Whether the value has been modified by user
+  onUploadingChange?: (uploading: boolean) => void; // Callback when uploading state changes
 }
 
 // Loading dots animation component
@@ -71,6 +72,7 @@ const FileInput: React.FC<FileInputProps> = memo(
     accept = '*',
     isDefaultValue = false,
     isModified = false,
+    onUploadingChange,
   }) => {
     const { t } = useTranslation();
     const [isHovered, setIsHovered] = useState(false);
@@ -83,6 +85,7 @@ const FileInput: React.FC<FileInputProps> = memo(
       async (file: File) => {
         try {
           setUploading(true);
+          onUploadingChange?.(true);
           // Upload file and get storageKey
           const result = await uploadFile(file, []);
 
@@ -99,9 +102,10 @@ const FileInput: React.FC<FileInputProps> = memo(
           console.error('File upload failed:', error);
         } finally {
           setUploading(false);
+          onUploadingChange?.(false);
         }
       },
-      [onChange, uploadFile],
+      [onChange, uploadFile, onUploadingChange],
     );
 
     const handleMouseEnter = useCallback(() => {

--- a/packages/ai-workspace-common/src/components/workflow-app/mixed-text-editor/mixed-text-editor.tsx
+++ b/packages/ai-workspace-common/src/components/workflow-app/mixed-text-editor/mixed-text-editor.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, useCallback, useMemo, useRef, useEffect } from 'react';
 import { MixedTextEditorProps, TextSegment } from './types';
 import VariableInput from './variable-input';
 import FileInput from './file-input';
@@ -14,8 +14,34 @@ const MixedTextEditor: React.FC<MixedTextEditorProps> = memo(
     className = '',
     disabled = false,
     originalVariables = [] as WorkflowVariable[],
+    onUploadingChange,
   }) => {
     const { t } = useTranslation();
+    // Track uploading state for multiple file inputs
+    const uploadingFilesRef = useRef<Set<string>>(new Set());
+
+    // Callback for individual FileInput uploading state changes
+    const handleFileUploadingChange = useCallback(
+      (fileId: string, uploading: boolean) => {
+        if (uploading) {
+          uploadingFilesRef.current.add(fileId);
+        } else {
+          uploadingFilesRef.current.delete(fileId);
+        }
+        // Notify parent about overall uploading state
+        onUploadingChange?.(uploadingFilesRef.current.size > 0);
+      },
+      [onUploadingChange],
+    );
+
+    // Reset uploading state when component unmounts
+    useEffect(() => {
+      return () => {
+        if (uploadingFilesRef.current.size > 0) {
+          onUploadingChange?.(false);
+        }
+      };
+    }, [onUploadingChange]);
     // Parse template content to extract variables and text segments
     const segments = useMemo((): TextSegment[] => {
       const segments: TextSegment[] = [];
@@ -167,17 +193,19 @@ const MixedTextEditor: React.FC<MixedTextEditorProps> = memo(
 
             if (segment.variable?.variableType === 'resource') {
               const currentFile = segment.variable.value?.[0]?.resource;
+              const fileId = segment.id || `file-${index}`;
 
               return (
                 <FileInput
                   key={`${segment.id}-${index}`}
-                  id={segment.id || ''}
+                  id={fileId}
                   value={currentFile}
                   placeholder={segment.variable?.name || segment.placeholder}
                   onChange={(value) => handleVariableChange(segment.id || '', value)}
                   disabled={disabled}
                   isDefaultValue={segment.isDefaultValue}
                   isModified={segment.isModified}
+                  onUploadingChange={(uploading) => handleFileUploadingChange(fileId, uploading)}
                 />
               );
             }

--- a/packages/ai-workspace-common/src/components/workflow-app/mixed-text-editor/types.ts
+++ b/packages/ai-workspace-common/src/components/workflow-app/mixed-text-editor/types.ts
@@ -17,6 +17,7 @@ export interface MixedTextEditorProps {
   className?: string;
   disabled?: boolean;
   originalVariables?: WorkflowVariable[]; // Original variable values for state comparison
+  onUploadingChange?: (uploading: boolean) => void; // Callback when any file is uploading
 }
 
 export interface VariableInputProps {

--- a/packages/web-core/src/pages/workflow-app/workflow-app-form.tsx
+++ b/packages/web-core/src/pages/workflow-app/workflow-app-form.tsx
@@ -174,6 +174,7 @@ export const WorkflowAPPForm = ({
   const [internalIsRunning, setInternalIsRunning] = useState(false);
   const [toolsPanelOpen, setToolsPanelOpen] = useState(false);
   const [highlightInstallButtons, setHighlightInstallButtons] = useState(false);
+  const [isFileUploading, setIsFileUploading] = useState(false);
 
   const handleToolsDependencyOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -748,7 +749,12 @@ export const WorkflowAPPForm = ({
           name={name}
           rules={
             required
-              ? [{ required: true, message: t('canvas.workflow.variables.inputPlaceholder') }]
+              ? [
+                  {
+                    required: true,
+                    message: t('canvas.workflow.variables.inputPlaceholder'),
+                  },
+                ]
               : []
           }
           data-field-name={name}
@@ -773,7 +779,12 @@ export const WorkflowAPPForm = ({
           name={name}
           rules={
             required
-              ? [{ required: true, message: t('canvas.workflow.variables.selectPlaceholder') }]
+              ? [
+                  {
+                    required: true,
+                    message: t('canvas.workflow.variables.selectPlaceholder'),
+                  },
+                ]
               : []
           }
         >
@@ -799,7 +810,12 @@ export const WorkflowAPPForm = ({
           name={name}
           rules={
             required
-              ? [{ required: true, message: t('canvas.workflow.variables.uploadPlaceholder') }]
+              ? [
+                  {
+                    required: true,
+                    message: t('canvas.workflow.variables.uploadPlaceholder'),
+                  },
+                ]
               : []
           }
         >
@@ -825,7 +841,14 @@ export const WorkflowAPPForm = ({
     setTemplateVariables(variables);
   }, []);
 
-  const isRunButtonDisabled = loading || isRunning;
+  // Handle file uploading state changes from MixedTextEditor
+  const handleFileUploadingChange = useCallback((uploading: boolean) => {
+    setIsFileUploading(uploading);
+  }, []);
+
+  // Separate executing state (for loading indicator) from disabled state
+  const isExecuting = loading || isRunning;
+  const isRunButtonDisabled = isExecuting || isFileUploading;
 
   return (
     <div>
@@ -979,6 +1002,7 @@ export const WorkflowAPPForm = ({
                   onVariablesChange={handleTemplateVariableChange}
                   disabled={isFormDisabled}
                   originalVariables={workflowVariables}
+                  onUploadingChange={handleFileUploadingChange}
                 />
                 {/* Tools Dependency Form */}
                 {workflowApp?.canvasData && (
@@ -1094,14 +1118,14 @@ export const WorkflowAPPForm = ({
                     )}
                     type="primary"
                     onClick={handleRun}
-                    loading={isRunButtonDisabled}
+                    loading={isExecuting}
                     disabled={isRunButtonDisabled}
                   >
                     <span className="inline-flex items-center gap-[2px]">
-                      {isRunButtonDisabled
+                      {isExecuting
                         ? t('canvas.workflow.run.executing')
                         : t('canvas.workflow.run.run')}
-                      {!isRunButtonDisabled && (
+                      {!isExecuting && (
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
                           width="18"
@@ -1245,14 +1269,14 @@ export const WorkflowAPPForm = ({
                     )}
                     type="primary"
                     onClick={handleRun}
-                    loading={isRunButtonDisabled}
+                    loading={isExecuting}
                     disabled={isRunButtonDisabled || !isFormValid}
                   >
                     <span className="inline-flex items-center gap-[2px]">
-                      {isRunButtonDisabled
+                      {isExecuting
                         ? t('canvas.workflow.run.executing')
                         : t('canvas.workflow.run.run')}
-                      {!isRunButtonDisabled && (
+                      {!isExecuting && (
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
                           width="18"


### PR DESCRIPTION
…tEditor

- Add onUploadingChange callback to FileInput component
- Track uploading state in MixedTextEditor for multiple file inputs
- Pass uploading state to WorkflowAPPForm via onUploadingChange
- Separate isExecuting (for loading indicator) from isRunButtonDisabled
- Button shows disabled state during upload without loading indicator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added file upload state tracking that notifies components when uploads begin and complete
  * Workflow execution is now prevented while file uploads are in progress, ensuring data integrity during file transfers
  * Multi-file upload progress is aggregated and communicated to parent components

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->