### PR TITLE
fix: correct toolset key reference in mention node view component

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/launchpad/rich-chat-input/mention-node-view.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/rich-chat-input/mention-node-view.tsx
@@ -31,7 +31,7 @@ function renderNodeIcon(source: MentionItemSource, variableType: string, nodeAtt
   if (source === 'toolsets' || source === 'tools') {
     return (
       <ToolsetIcon
-        toolsetKey={nodeAttrs?.id}
+        toolsetKey={nodeAttrs?.toolsetId}
         toolset={nodeAttrs?.toolset}
         config={TOOLSET_ICON_CONFIG}
       />


### PR DESCRIPTION
Updated the mention node view component to use 'toolsetId' instead of 'id' for the toolset key, ensuring accurate data handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the rendering of toolset and tool references in chat input to display the correct identifiers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->