### PR TITLE
[REF-1020] fix(canvas): support resource variables with only storageKey in workf…

### DIFF
--- a/apps/api/src/modules/canvas/canvas.service.ts
+++ b/apps/api/src/modules/canvas/canvas.service.ts
@@ -1341,6 +1341,31 @@ export class CanvasService {
       };
     }
 
+    // If only storageKey exists (no fileId), create a new DriveFile from the storageKey
+    if (resource.storageKey) {
+      try {
+        const driveFile = await this.driveService.createDriveFile(user, {
+          canvasId,
+          name: resource.name || 'uploaded_file',
+          storageKey: resource.storageKey,
+          source: 'variable',
+        });
+
+        return {
+          ...value,
+          resource: {
+            ...resource,
+            fileId: driveFile.fileId,
+          },
+        };
+      } catch (error) {
+        this.logger.warn(
+          `Failed to create DriveFile from storageKey ${resource.storageKey}: ${error?.message}`,
+        );
+        return value;
+      }
+    }
+
     return value;
   }
 


### PR DESCRIPTION
…low app execution

When users replace file variables in workflow app, the uploaded files only have storageKey without fileId. This fix adds handling for this case in processResourceValue to create DriveFile from storageKey, enabling proper file resolution for tools like digital human video generator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource initialization handling for edge cases, with enhanced error management to ensure graceful fallback when initialization fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->