### PR TITLE
[REF-1021] fix: Add supportToolChoice capability for Bedrock Claude Haiku models

### DIFF
--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -61,7 +61,7 @@ paths:
         Unified variable extraction interface that supports two modes:
         - 'direct': Directly update Canvas variables
         - 'candidate': Return candidate solutions for user selection
-        
+
         This endpoint analyzes natural language prompts and extracts workflow variables
         based on the context of existing Canvas variables and content.
       operationId: extractVariables
@@ -72,7 +72,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ExtractVariablesRequest'
+              $ref: "#/components/schemas/ExtractVariablesRequest"
               candidate_mode:
                 summary: Candidate mode example
                 description: Example request for candidate mode
@@ -89,12 +89,12 @@ paths:
                   mode: "direct"
                   sessionId: "session-789"
       responses:
-        '200':
+        "200":
           description: Variables extracted successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VariableExtractionResult'
+                $ref: "#/components/schemas/VariableExtractionResult"
 
   /variable-extraction/generate-template:
     post:
@@ -113,7 +113,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GenerateAppTemplateRequest'
+              $ref: "#/components/schemas/GenerateAppTemplateRequest"
             examples:
               basic_request:
                 summary: Basic template generation request
@@ -121,12 +121,12 @@ paths:
                 value:
                   canvasId: "canvas-123"
       responses:
-        '200':
+        "200":
           description: APP template generated successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppTemplateResult'
+                $ref: "#/components/schemas/AppTemplateResult"
             examples:
               success_response:
                 summary: Successful template generation
@@ -177,12 +177,12 @@ paths:
       security:
         - api_key: []
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListMcpServersResponse'
+                $ref: "#/components/schemas/ListMcpServersResponse"
 
   /mcp-server/create:
     post:
@@ -196,16 +196,16 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertMcpServerRequest'
+              $ref: "#/components/schemas/UpsertMcpServerRequest"
       security:
         - api_key: []
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertMcpServerResponse'
+                $ref: "#/components/schemas/UpsertMcpServerResponse"
 
   /mcp-server/update:
     post:
@@ -219,16 +219,16 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertMcpServerRequest'
+              $ref: "#/components/schemas/UpsertMcpServerRequest"
       security:
         - api_key: []
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertMcpServerResponse'
+                $ref: "#/components/schemas/UpsertMcpServerResponse"
 
   /mcp-server/delete:
     post:
@@ -242,16 +242,16 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteMcpServerRequest'
+              $ref: "#/components/schemas/DeleteMcpServerRequest"
       security:
         - api_key: []
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeleteMcpServerResponse'
+                $ref: "#/components/schemas/DeleteMcpServerResponse"
 
   /mcp-server/validate:
     post:
@@ -265,16 +265,16 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertMcpServerRequest'
+              $ref: "#/components/schemas/UpsertMcpServerRequest"
       security:
         - api_key: []
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ValidateMcpServerResponse'
+                $ref: "#/components/schemas/ValidateMcpServerResponse"
 
   /pages:
     get:
@@ -297,12 +297,12 @@ paths:
             type: number
             default: 20
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListPagesResponse'
+                $ref: "#/components/schemas/ListPagesResponse"
 
   /pages/{pageId}:
     get:
@@ -319,12 +319,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PageDetailResponse'
+                $ref: "#/components/schemas/PageDetailResponse"
     put:
       tags:
         - pages
@@ -343,14 +343,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdatePageRequest'
+              $ref: "#/components/schemas/UpdatePageRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpdatePageResponse'
+                $ref: "#/components/schemas/UpdatePageResponse"
     delete:
       tags:
         - pages
@@ -365,12 +365,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeletePageResponse'
+                $ref: "#/components/schemas/DeletePageResponse"
 
   /pages/{pageId}/share:
     post:
@@ -387,12 +387,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SharePageResponse'
+                $ref: "#/components/schemas/SharePageResponse"
 
   /pages/{pageId}/nodes/{nodeId}:
     delete:
@@ -415,12 +415,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeletePageNodeResponse'
+                $ref: "#/components/schemas/DeletePageNodeResponse"
 
   /pages/canvas/{canvasId}:
     get:
@@ -437,12 +437,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CanvasPageResponse'
+                $ref: "#/components/schemas/CanvasPageResponse"
 
   /pages/canvas/{canvasId}/nodes:
     post:
@@ -463,15 +463,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AddPageNodesRequest'
+              $ref: "#/components/schemas/AddPageNodesRequest"
       responses:
-        '201':
+        "201":
           description: Nodes added to canvas page successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AddPageNodesResponse'
-
+                $ref: "#/components/schemas/AddPageNodesResponse"
 
   /auth/config:
     get:
@@ -481,12 +480,12 @@ paths:
       description: Get auth config
       operationId: getAuthConfig
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthConfigResponse'
+                $ref: "#/components/schemas/AuthConfigResponse"
   /auth/refreshToken:
     post:
       tags:
@@ -495,7 +494,7 @@ paths:
       description: Refresh token
       operationId: refreshToken
       responses:
-        '200':
+        "200":
           description: Successful operation
   /auth/email/signup:
     post:
@@ -509,14 +508,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EmailSignupRequest'
+              $ref: "#/components/schemas/EmailSignupRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmailSignupResponse'
+                $ref: "#/components/schemas/EmailSignupResponse"
   /auth/email/login:
     post:
       tags:
@@ -529,14 +528,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EmailLoginRequest'
+              $ref: "#/components/schemas/EmailLoginRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmailLoginResponse'
+                $ref: "#/components/schemas/EmailLoginResponse"
   /auth/verification/create:
     post:
       tags:
@@ -549,14 +548,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateVerificationRequest'
+              $ref: "#/components/schemas/CreateVerificationRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateVerificationResponse'
+                $ref: "#/components/schemas/CreateVerificationResponse"
   /auth/verification/resend:
     post:
       tags:
@@ -569,14 +568,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ResendVerificationRequest'
+              $ref: "#/components/schemas/ResendVerificationRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /auth/verification/check:
     post:
       tags:
@@ -589,14 +588,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CheckVerificationRequest'
+              $ref: "#/components/schemas/CheckVerificationRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /auth/account/list:
     get:
       tags:
@@ -609,19 +608,19 @@ paths:
           in: query
           description: Auth type
           schema:
-            $ref: '#/components/schemas/AuthType'
+            $ref: "#/components/schemas/AuthType"
         - name: provider
           in: query
           description: Auth provider
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListAccountsResponse'
+                $ref: "#/components/schemas/ListAccountsResponse"
   /auth/logout:
     post:
       tags:
@@ -630,7 +629,7 @@ paths:
       description: Logout
       operationId: logout
       responses:
-        '200':
+        "200":
           description: Successful operation
   /auth/tool-oauth/status:
     get:
@@ -655,12 +654,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: OAuth status checked successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CheckToolOAuthStatusResponse'
+                $ref: "#/components/schemas/CheckToolOAuthStatusResponse"
   /collab/getToken:
     get:
       tags:
@@ -669,12 +668,12 @@ paths:
       description: Get collab token
       operationId: getCollabToken
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetCollabTokenResponse'
+                $ref: "#/components/schemas/GetCollabTokenResponse"
   /canvas/list:
     get:
       tags:
@@ -704,19 +703,19 @@ paths:
           in: query
           description: Order
           schema:
-            $ref: '#/components/schemas/ListOrder'
+            $ref: "#/components/schemas/ListOrder"
         - name: keyword
           in: query
           description: Search keyword
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListCanvasResponse'
+                $ref: "#/components/schemas/ListCanvasResponse"
   /canvas/detail:
     get:
       tags:
@@ -732,12 +731,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetCanvasDetailResponse'
+                $ref: "#/components/schemas/GetCanvasDetailResponse"
   /canvas/data:
     get:
       tags:
@@ -753,12 +752,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetCanvasDataResponse'
+                $ref: "#/components/schemas/GetCanvasDataResponse"
   /canvas/export:
     get:
       tags:
@@ -774,12 +773,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ExportCanvasResponse'
+                $ref: "#/components/schemas/ExportCanvasResponse"
   /canvas/import:
     post:
       tags:
@@ -792,14 +791,14 @@ paths:
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ImportCanvasRequest'
+              $ref: "#/components/schemas/ImportCanvasRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertCanvasResponse'
+                $ref: "#/components/schemas/UpsertCanvasResponse"
   /canvas/create:
     post:
       tags:
@@ -812,14 +811,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertCanvasRequest'
+              $ref: "#/components/schemas/UpsertCanvasRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertCanvasResponse'
+                $ref: "#/components/schemas/UpsertCanvasResponse"
   /canvas/duplicate:
     post:
       tags:
@@ -832,14 +831,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DuplicateCanvasRequest'
+              $ref: "#/components/schemas/DuplicateCanvasRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertCanvasResponse'
+                $ref: "#/components/schemas/UpsertCanvasResponse"
   /canvas/update:
     post:
       tags:
@@ -852,14 +851,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertCanvasRequest'
+              $ref: "#/components/schemas/UpsertCanvasRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertCanvasResponse'
+                $ref: "#/components/schemas/UpsertCanvasResponse"
   /canvas/delete:
     post:
       tags:
@@ -872,14 +871,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteCanvasRequest'
+              $ref: "#/components/schemas/DeleteCanvasRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /canvas/autoName:
     post:
       tags:
@@ -892,14 +891,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AutoNameCanvasRequest'
+              $ref: "#/components/schemas/AutoNameCanvasRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AutoNameCanvasResponse'
+                $ref: "#/components/schemas/AutoNameCanvasResponse"
   /canvas/getState:
     get:
       tags:
@@ -921,12 +920,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetCanvasStateResponse'
+                $ref: "#/components/schemas/GetCanvasStateResponse"
   /canvas/setState:
     post:
       tags:
@@ -939,14 +938,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SetCanvasStateRequest'
+              $ref: "#/components/schemas/SetCanvasStateRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /canvas/getTx:
     get:
       tags:
@@ -974,12 +973,12 @@ paths:
           schema:
             type: number
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetCanvasTransactionsResponse'
+                $ref: "#/components/schemas/GetCanvasTransactionsResponse"
   /canvas/syncState:
     post:
       tags:
@@ -992,14 +991,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SyncCanvasStateRequest'
+              $ref: "#/components/schemas/SyncCanvasStateRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SyncCanvasStateResponse'
+                $ref: "#/components/schemas/SyncCanvasStateResponse"
   /canvas/createVersion:
     post:
       tags:
@@ -1012,14 +1011,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateCanvasVersionRequest'
+              $ref: "#/components/schemas/CreateCanvasVersionRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateCanvasVersionResponse'
+                $ref: "#/components/schemas/CreateCanvasVersionResponse"
   /canvas/workflow/variables:
     get:
       tags:
@@ -1035,12 +1034,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetWorkflowVariablesResponse'
+                $ref: "#/components/schemas/GetWorkflowVariablesResponse"
     post:
       tags:
         - canvas
@@ -1052,14 +1051,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateWorkflowVariablesRequest'
+              $ref: "#/components/schemas/UpdateWorkflowVariablesRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpdateWorkflowVariablesResponse'
+                $ref: "#/components/schemas/UpdateWorkflowVariablesResponse"
   /drive/file/list:
     get:
       tags:
@@ -1078,12 +1077,12 @@ paths:
           in: query
           description: Drive file source
           schema:
-            $ref: '#/components/schemas/DriveFileSource'
+            $ref: "#/components/schemas/DriveFileSource"
         - name: scope
           in: query
           description: Drive file scope
           schema:
-            $ref: '#/components/schemas/DriveFileScope'
+            $ref: "#/components/schemas/DriveFileScope"
         - name: page
           in: query
           description: Page number
@@ -1100,14 +1099,14 @@ paths:
           in: query
           description: Order
           schema:
-            $ref: '#/components/schemas/ListOrder'
+            $ref: "#/components/schemas/ListOrder"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListDriveFilesResponse'
+                $ref: "#/components/schemas/ListDriveFilesResponse"
   /drive/file/create:
     post:
       tags:
@@ -1120,14 +1119,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertDriveFileRequest'
+              $ref: "#/components/schemas/UpsertDriveFileRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertDriveFileResponse'
+                $ref: "#/components/schemas/UpsertDriveFileResponse"
   /drive/file/batchCreate:
     post:
       tags:
@@ -1140,14 +1139,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BatchCreateDriveFilesRequest'
+              $ref: "#/components/schemas/BatchCreateDriveFilesRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BatchCreateDriveFilesResponse'
+                $ref: "#/components/schemas/BatchCreateDriveFilesResponse"
   /drive/file/update:
     post:
       tags:
@@ -1160,14 +1159,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertDriveFileRequest'
+              $ref: "#/components/schemas/UpsertDriveFileRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertDriveFileResponse'
+                $ref: "#/components/schemas/UpsertDriveFileResponse"
   /drive/file/delete:
     post:
       tags:
@@ -1180,14 +1179,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteDriveFileRequest'
+              $ref: "#/components/schemas/DeleteDriveFileRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /template/list:
     get:
       tags:
@@ -1229,12 +1228,12 @@ paths:
               - public
               - private
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListCanvasTemplateResponse'
+                $ref: "#/components/schemas/ListCanvasTemplateResponse"
   /template/create:
     post:
       tags:
@@ -1247,14 +1246,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateCanvasTemplateRequest'
+              $ref: "#/components/schemas/CreateCanvasTemplateRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertCanvasTemplateResponse'
+                $ref: "#/components/schemas/UpsertCanvasTemplateResponse"
   /template/update:
     post:
       tags:
@@ -1267,14 +1266,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateCanvasTemplateRequest'
+              $ref: "#/components/schemas/UpdateCanvasTemplateRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertCanvasTemplateResponse'
+                $ref: "#/components/schemas/UpsertCanvasTemplateResponse"
   /template/category/list:
     get:
       tags:
@@ -1283,12 +1282,12 @@ paths:
       description: List all canvas template categories
       operationId: listCanvasTemplateCategories
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListCanvasTemplateCategoryResponse'
+                $ref: "#/components/schemas/ListCanvasTemplateCategoryResponse"
   /knowledge/resource/list:
     get:
       tags:
@@ -1308,7 +1307,7 @@ paths:
           description: Resource type
           schema:
             type: string
-            $ref: '#/components/schemas/ResourceType'
+            $ref: "#/components/schemas/ResourceType"
         - name: page
           in: query
           description: Page number
@@ -1336,14 +1335,14 @@ paths:
           description: Order
           required: false
           schema:
-            $ref: '#/components/schemas/ListOrder'
+            $ref: "#/components/schemas/ListOrder"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListResourceResponse'
+                $ref: "#/components/schemas/ListResourceResponse"
       security:
         - api_key: []
   /knowledge/resource/detail:
@@ -1367,12 +1366,12 @@ paths:
           schema:
             type: boolean
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetResourceDetailResponse'
+                $ref: "#/components/schemas/GetResourceDetailResponse"
       security:
         - api_key: []
   /knowledge/resource/update:
@@ -1388,14 +1387,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertResourceRequest'
+              $ref: "#/components/schemas/UpsertResourceRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertResourceResponse'
+                $ref: "#/components/schemas/UpsertResourceResponse"
       security:
         - api_key: []
   /knowledge/resource/create:
@@ -1411,14 +1410,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertResourceRequest'
+              $ref: "#/components/schemas/UpsertResourceRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertResourceResponse'
+                $ref: "#/components/schemas/UpsertResourceResponse"
       security:
         - api_key: []
   /knowledge/resource/createWithFile:
@@ -1449,21 +1448,21 @@ paths:
                   example: My Resource
                 resourceType:
                   description: Resource type
-                  $ref: '#/components/schemas/ResourceType'
+                  $ref: "#/components/schemas/ResourceType"
                 resourceId:
                   type: string
                   description: Resource ID (only used for update)
                   example: r-g30e1b80b5g1itbemc0g5jj3
                 data:
                   description: Resource metadata
-                  $ref: '#/components/schemas/ResourceMeta'
+                  $ref: "#/components/schemas/ResourceMeta"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertResourceResponse'
+                $ref: "#/components/schemas/UpsertResourceResponse"
       security:
         - api_key: []
   /knowledge/resource/batchCreate:
@@ -1481,14 +1480,14 @@ paths:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/UpsertResourceRequest'
+                $ref: "#/components/schemas/UpsertResourceRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BatchCreateResourceResponse'
+                $ref: "#/components/schemas/BatchCreateResourceResponse"
       security:
         - api_key: []
   /knowledge/resource/reindex:
@@ -1503,14 +1502,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ReindexResourceRequest'
+              $ref: "#/components/schemas/ReindexResourceRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReindexResourceResponse'
+                $ref: "#/components/schemas/ReindexResourceResponse"
       security:
         - api_key: []
   /knowledge/resource/delete:
@@ -1525,14 +1524,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteResourceRequest'
+              $ref: "#/components/schemas/DeleteResourceRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
       security:
         - api_key: []
   /knowledge/document/list:
@@ -1572,14 +1571,14 @@ paths:
           description: Order by
           required: false
           schema:
-            $ref: '#/components/schemas/ListOrder'
+            $ref: "#/components/schemas/ListOrder"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListDocumentResponse'
+                $ref: "#/components/schemas/ListDocumentResponse"
   /knowledge/document/detail:
     get:
       tags:
@@ -1596,12 +1595,12 @@ paths:
             type: string
             example: d-g30e1b80b5g1itbemc0g5jj3
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetDocumentDetailResponse'
+                $ref: "#/components/schemas/GetDocumentDetailResponse"
   /drive/document/export:
     get:
       tags:
@@ -1627,7 +1626,7 @@ paths:
             default: markdown
             example: markdown
       responses:
-        '200':
+        "200":
           description: operation success
           content:
             text/markdown:
@@ -1655,14 +1654,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertDocumentRequest'
+              $ref: "#/components/schemas/UpsertDocumentRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertDocumentResponse'
+                $ref: "#/components/schemas/UpsertDocumentResponse"
       security:
         - api_key: []
   /knowledge/document/create:
@@ -1678,14 +1677,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertDocumentRequest'
+              $ref: "#/components/schemas/UpsertDocumentRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertDocumentResponse'
+                $ref: "#/components/schemas/UpsertDocumentResponse"
       security:
         - api_key: []
   /knowledge/document/delete:
@@ -1700,14 +1699,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteDocumentRequest'
+              $ref: "#/components/schemas/DeleteDocumentRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
       security:
         - api_key: []
   /knowledge/document/batchUpdate:
@@ -1724,14 +1723,14 @@ paths:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/UpsertDocumentRequest'
+                $ref: "#/components/schemas/UpsertDocumentRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
       security:
         - api_key: []
   /project/list:
@@ -1761,14 +1760,14 @@ paths:
           description: Order by
           required: false
           schema:
-            $ref: '#/components/schemas/ListOrder'
+            $ref: "#/components/schemas/ListOrder"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListProjectResponse'
+                $ref: "#/components/schemas/ListProjectResponse"
   /project/detail:
     get:
       tags:
@@ -1784,12 +1783,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetProjectDetailResponse'
+                $ref: "#/components/schemas/GetProjectDetailResponse"
   /project/new:
     post:
       tags:
@@ -1802,14 +1801,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertProjectRequest'
+              $ref: "#/components/schemas/UpsertProjectRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertProjectResponse'
+                $ref: "#/components/schemas/UpsertProjectResponse"
   /project/update:
     post:
       tags:
@@ -1822,14 +1821,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertProjectRequest'
+              $ref: "#/components/schemas/UpsertProjectRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertProjectResponse'
+                $ref: "#/components/schemas/UpsertProjectResponse"
   /project/updateItems:
     post:
       tags:
@@ -1842,14 +1841,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateProjectItemsRequest'
+              $ref: "#/components/schemas/UpdateProjectItemsRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /project/delete:
     post:
       tags:
@@ -1862,14 +1861,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteProjectRequest'
+              $ref: "#/components/schemas/DeleteProjectRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /project/deleteItems:
     post:
       tags:
@@ -1882,14 +1881,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteProjectItemsRequest'
+              $ref: "#/components/schemas/DeleteProjectItemsRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /codeArtifact/list:
     get:
       tags:
@@ -1932,12 +1931,12 @@ paths:
             type: number
             default: 10
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListCodeArtifactResponse'
+                $ref: "#/components/schemas/ListCodeArtifactResponse"
   /codeArtifact/detail:
     get:
       tags:
@@ -1953,12 +1952,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetCodeArtifactDetailResponse'
+                $ref: "#/components/schemas/GetCodeArtifactDetailResponse"
   /codeArtifact/new:
     post:
       tags:
@@ -1971,14 +1970,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertCodeArtifactRequest'
+              $ref: "#/components/schemas/UpsertCodeArtifactRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertCodeArtifactResponse'
+                $ref: "#/components/schemas/UpsertCodeArtifactResponse"
   /codeArtifact/update:
     post:
       tags:
@@ -1991,14 +1990,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertCodeArtifactRequest'
+              $ref: "#/components/schemas/UpsertCodeArtifactRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertCodeArtifactResponse'
+                $ref: "#/components/schemas/UpsertCodeArtifactResponse"
   /share/new:
     post:
       tags:
@@ -2011,14 +2010,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateShareRequest'
+              $ref: "#/components/schemas/CreateShareRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateShareResponse'
+                $ref: "#/components/schemas/CreateShareResponse"
   /share/list:
     get:
       tags:
@@ -2041,14 +2040,14 @@ paths:
           in: query
           description: Entity type
           schema:
-            $ref: '#/components/schemas/EntityType'
+            $ref: "#/components/schemas/EntityType"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListShareResponse'
+                $ref: "#/components/schemas/ListShareResponse"
   /share/delete:
     post:
       tags:
@@ -2061,14 +2060,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteShareRequest'
+              $ref: "#/components/schemas/DeleteShareRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /share/duplicate:
     post:
       tags:
@@ -2081,14 +2080,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DuplicateShareRequest'
+              $ref: "#/components/schemas/DuplicateShareRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DuplicateShareResponse'
+                $ref: "#/components/schemas/DuplicateShareResponse"
   /label/class/list:
     get:
       tags:
@@ -2110,12 +2109,12 @@ paths:
             type: number
             default: 10
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListLabelClassesResponse'
+                $ref: "#/components/schemas/ListLabelClassesResponse"
       security:
         - api_key: []
   /label/class/new:
@@ -2130,15 +2129,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateLabelClassRequest'
+              $ref: "#/components/schemas/CreateLabelClassRequest"
         required: true
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertLabelClassResponse'
+                $ref: "#/components/schemas/UpsertLabelClassResponse"
   /label/class/update:
     post:
       tags:
@@ -2151,15 +2150,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateLabelClassRequest'
+              $ref: "#/components/schemas/UpdateLabelClassRequest"
         required: true
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertLabelClassResponse'
+                $ref: "#/components/schemas/UpsertLabelClassResponse"
   /label/class/delete:
     post:
       tags:
@@ -2172,14 +2171,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteLabelClassRequest'
+              $ref: "#/components/schemas/DeleteLabelClassRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /label/instance/list:
     get:
       tags:
@@ -2193,7 +2192,7 @@ paths:
           description: Entity type to retrieve
           schema:
             description: Label entity type
-            $ref: '#/components/schemas/EntityType'
+            $ref: "#/components/schemas/EntityType"
         - name: entityId
           in: query
           description: Entity type to retrieve
@@ -2225,12 +2224,12 @@ paths:
             type: number
             default: 10
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListLabelInstancesResponse'
+                $ref: "#/components/schemas/ListLabelInstancesResponse"
   /label/instance/new:
     post:
       tags:
@@ -2243,15 +2242,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateLabelInstanceRequest'
+              $ref: "#/components/schemas/CreateLabelInstanceRequest"
         required: true
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertLabelInstanceResponse'
+                $ref: "#/components/schemas/UpsertLabelInstanceResponse"
   /label/instance/update:
     post:
       tags:
@@ -2264,15 +2263,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateLabelInstanceRequest'
+              $ref: "#/components/schemas/UpdateLabelInstanceRequest"
         required: true
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertLabelInstanceResponse'
+                $ref: "#/components/schemas/UpsertLabelInstanceResponse"
   /label/instance/delete:
     post:
       tags:
@@ -2285,14 +2284,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteLabelInstanceRequest'
+              $ref: "#/components/schemas/DeleteLabelInstanceRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /action/list:
     get:
       tags:
@@ -2301,12 +2300,12 @@ paths:
       description: List all actions
       operationId: listActions
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListActionResponse'
+                $ref: "#/components/schemas/ListActionResponse"
   /action/result:
     get:
       tags:
@@ -2328,12 +2327,12 @@ paths:
           schema:
             type: number
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetActionResultResponse'
+                $ref: "#/components/schemas/GetActionResultResponse"
   /action/abort:
     post:
       tags:
@@ -2346,15 +2345,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AbortActionRequest'
+              $ref: "#/components/schemas/AbortActionRequest"
         required: true
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /skill/list:
     get:
       tags:
@@ -2363,12 +2362,12 @@ paths:
       description: List all skills
       operationId: listSkills
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListSkillResponse'
+                $ref: "#/components/schemas/ListSkillResponse"
   /skill/invoke:
     post:
       tags:
@@ -2381,15 +2380,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/InvokeSkillRequest'
+              $ref: "#/components/schemas/InvokeSkillRequest"
         required: true
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InvokeSkillResponse'
+                $ref: "#/components/schemas/InvokeSkillResponse"
   /skill/streamInvoke:
     post:
       tags:
@@ -2402,10 +2401,10 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/InvokeSkillRequest'
+              $ref: "#/components/schemas/InvokeSkillRequest"
         required: true
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             text/event-stream:
@@ -2443,12 +2442,12 @@ paths:
             type: number
             default: 10
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListSkillInstanceResponse'
+                $ref: "#/components/schemas/ListSkillInstanceResponse"
   /skill/instance/new:
     post:
       tags:
@@ -2461,15 +2460,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateSkillInstanceRequest'
+              $ref: "#/components/schemas/CreateSkillInstanceRequest"
         required: true
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateSkillInstanceResponse'
+                $ref: "#/components/schemas/CreateSkillInstanceResponse"
   /skill/instance/update:
     post:
       tags:
@@ -2482,15 +2481,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateSkillInstanceRequest'
+              $ref: "#/components/schemas/UpdateSkillInstanceRequest"
         required: true
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpdateSkillInstanceResponse'
+                $ref: "#/components/schemas/UpdateSkillInstanceResponse"
   /skill/instance/pin:
     post:
       tags:
@@ -2503,14 +2502,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PinSkillInstanceRequest'
+              $ref: "#/components/schemas/PinSkillInstanceRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /skill/instance/unpin:
     post:
       tags:
@@ -2523,14 +2522,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UnpinSkillInstanceRequest'
+              $ref: "#/components/schemas/UnpinSkillInstanceRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /skill/instance/delete:
     post:
       tags:
@@ -2543,14 +2542,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteSkillInstanceRequest'
+              $ref: "#/components/schemas/DeleteSkillInstanceRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
       security:
         - api_key: []
   /skill/trigger/list:
@@ -2580,12 +2579,12 @@ paths:
             type: number
             default: 10
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListSkillTriggerResponse'
+                $ref: "#/components/schemas/ListSkillTriggerResponse"
   /skill/trigger/new:
     post:
       tags:
@@ -2598,15 +2597,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateSkillTriggerRequest'
+              $ref: "#/components/schemas/CreateSkillTriggerRequest"
         required: true
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateSkillTriggerResponse'
+                $ref: "#/components/schemas/CreateSkillTriggerResponse"
   /skill/trigger/update:
     post:
       tags:
@@ -2619,15 +2618,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateSkillTriggerRequest'
+              $ref: "#/components/schemas/UpdateSkillTriggerRequest"
         required: true
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpdateSkillTriggerResponse'
+                $ref: "#/components/schemas/UpdateSkillTriggerResponse"
   /skill/trigger/delete:
     post:
       tags:
@@ -2640,34 +2639,34 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteSkillTriggerRequest'
+              $ref: "#/components/schemas/DeleteSkillTriggerRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
       security:
         - api_key: []
   /media/generate:
-      post:
-        summary: Generate multimedia content
-        description: Generate image, video or audio based on the given prompt
-        operationId: generateMedia
-        requestBody:
-          required: true
+    post:
+      summary: Generate multimedia content
+      description: Generate image, video or audio based on the given prompt
+      operationId: generateMedia
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MediaGenerateRequest"
+      responses:
+        "200":
+          description: Successful generation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MediaGenerateRequest'
-        responses:
-          '200':
-            description: Successful generation
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/MediaGenerateResponse'
+                $ref: "#/components/schemas/MediaGenerateResponse"
   /pilot/session/new:
     post:
       tags:
@@ -2680,14 +2679,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreatePilotSessionRequest'
+              $ref: "#/components/schemas/CreatePilotSessionRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertPilotSessionResponse'
+                $ref: "#/components/schemas/UpsertPilotSessionResponse"
   /pilot/session/update:
     post:
       tags:
@@ -2700,14 +2699,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdatePilotSessionRequest'
+              $ref: "#/components/schemas/UpdatePilotSessionRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertPilotSessionResponse'
+                $ref: "#/components/schemas/UpsertPilotSessionResponse"
   /pilot/session/list:
     get:
       tags:
@@ -2725,7 +2724,7 @@ paths:
           in: query
           description: Target type
           schema:
-            $ref: '#/components/schemas/EntityType'
+            $ref: "#/components/schemas/EntityType"
         - name: page
           in: query
           description: Page number
@@ -2739,12 +2738,12 @@ paths:
             type: number
             default: 10
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListPilotSessionsResponse'
+                $ref: "#/components/schemas/ListPilotSessionsResponse"
   /pilot/session/detail:
     get:
       tags:
@@ -2760,12 +2759,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetPilotSessionDetailResponse'
+                $ref: "#/components/schemas/GetPilotSessionDetailResponse"
   /pilot/session/recover:
     post:
       tags:
@@ -2778,14 +2777,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RecoverPilotSessionRequest'
+              $ref: "#/components/schemas/RecoverPilotSessionRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /copilot/session/list:
     get:
       tags:
@@ -2800,12 +2799,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListCopilotSessionsResponse'
+                $ref: "#/components/schemas/ListCopilotSessionsResponse"
   /copilot/session/detail:
     get:
       tags:
@@ -2821,12 +2820,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetCopilotSessionDetailResponse'
+                $ref: "#/components/schemas/GetCopilotSessionDetailResponse"
   /workflow/initialize:
     post:
       tags:
@@ -2839,14 +2838,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/InitializeWorkflowRequest'
+              $ref: "#/components/schemas/InitializeWorkflowRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InitializeWorkflowResponse'
+                $ref: "#/components/schemas/InitializeWorkflowResponse"
   /workflow/abort:
     post:
       tags:
@@ -2859,14 +2858,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AbortWorkflowRequest'
+              $ref: "#/components/schemas/AbortWorkflowRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /workflow/detail:
     get:
       tags:
@@ -2882,12 +2881,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetWorkflowDetailResponse'
+                $ref: "#/components/schemas/GetWorkflowDetailResponse"
   /workflow-app/new:
     post:
       tags:
@@ -2900,14 +2899,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateWorkflowAppRequest'
+              $ref: "#/components/schemas/CreateWorkflowAppRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateWorkflowAppResponse'
+                $ref: "#/components/schemas/CreateWorkflowAppResponse"
   /workflow-app/delete:
     post:
       tags:
@@ -2920,14 +2919,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteWorkflowAppRequest'
+              $ref: "#/components/schemas/DeleteWorkflowAppRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /workflow-app/detail:
     get:
       tags:
@@ -2943,12 +2942,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetWorkflowAppDetailResponse'
+                $ref: "#/components/schemas/GetWorkflowAppDetailResponse"
   /workflow-app/execute:
     post:
       tags:
@@ -2961,14 +2960,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ExecuteWorkflowAppRequest'
+              $ref: "#/components/schemas/ExecuteWorkflowAppRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ExecuteWorkflowAppResponse'
+                $ref: "#/components/schemas/ExecuteWorkflowAppResponse"
   /workflow-app/list:
     get:
       tags:
@@ -2999,19 +2998,19 @@ paths:
           in: query
           description: Order
           schema:
-            $ref: '#/components/schemas/ListOrder'
+            $ref: "#/components/schemas/ListOrder"
         - name: keyword
           in: query
           description: Search keyword
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListWorkflowAppsResponse'
+                $ref: "#/components/schemas/ListWorkflowAppsResponse"
   /workflow-app/template-status:
     get:
       tags:
@@ -3027,15 +3026,15 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetTemplateGenerationStatusResponse'
-        '400':
+                $ref: "#/components/schemas/GetTemplateGenerationStatusResponse"
+        "400":
           description: Bad request (missing appId)
-        '404':
+        "404":
           description: Workflow app not found
       security:
         - api_key: []
@@ -3047,12 +3046,12 @@ paths:
       description: Return settings for current user
       operationId: getSettings
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetUserSettingsResponse'
+                $ref: "#/components/schemas/GetUserSettingsResponse"
       security:
         - api_key: []
     put:
@@ -3066,14 +3065,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateUserSettingsRequest'
+              $ref: "#/components/schemas/UpdateUserSettingsRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
       security:
         - api_key: []
   /user/checkSettingsField:
@@ -3100,12 +3099,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CheckSettingsFieldResponse'
+                $ref: "#/components/schemas/CheckSettingsFieldResponse"
   /form/definition:
     get:
       tags:
@@ -3114,12 +3113,12 @@ paths:
       description: Get form definition
       operationId: getFormDefinition
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetFormDefinitionResponse'
+                $ref: "#/components/schemas/GetFormDefinitionResponse"
   /form/submission:
     post:
       tags:
@@ -3132,14 +3131,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SubmitFormRequest'
+              $ref: "#/components/schemas/SubmitFormRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /form/hasFilledForm:
     get:
       tags:
@@ -3148,12 +3147,12 @@ paths:
       description: Check if user has filled the form
       operationId: hasFilledForm
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HasFilledFormResponse'
+                $ref: "#/components/schemas/HasFilledFormResponse"
   /credit/recharge:
     get:
       tags:
@@ -3180,12 +3179,12 @@ paths:
             maximum: 100
             default: 20
       responses:
-        '200':
+        "200":
           description: successful operation
-          content: 
+          content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetCreditRechargeResponse'      
+                $ref: "#/components/schemas/GetCreditRechargeResponse"
   /credit/usage:
     get:
       tags:
@@ -3212,12 +3211,12 @@ paths:
             maximum: 100
             default: 20
       responses:
-        '200':
+        "200":
           description: successful operation
-          content: 
+          content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetCreditUsageResponse'
+                $ref: "#/components/schemas/GetCreditUsageResponse"
   /credit/balance:
     get:
       tags:
@@ -3226,12 +3225,12 @@ paths:
       description: Get credit balance
       operationId: getCreditBalance
       responses:
-        '200':
+        "200":
           description: successful operation
-          content: 
+          content:
             application/json:
               schema:
-                $ref: '#/components/schemas/getCreditBalanceResponse'
+                $ref: "#/components/schemas/getCreditBalanceResponse"
 
   /credit/result:
     get:
@@ -3254,12 +3253,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetCreditUsageByResultIdResponse'
+                $ref: "#/components/schemas/GetCreditUsageByResultIdResponse"
   /credit/execution:
     get:
       tags:
@@ -3275,12 +3274,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetCreditUsageByExecutionIdResponse'
+                $ref: "#/components/schemas/GetCreditUsageByExecutionIdResponse"
   /credit/canvas:
     get:
       tags:
@@ -3296,12 +3295,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetCreditUsageByCanvasIdResponse'
+                $ref: "#/components/schemas/GetCreditUsageByCanvasIdResponse"
   /credit/commission:
     get:
       tags:
@@ -3317,12 +3316,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetCanvasCommissionByCanvasIdResponse'
+                $ref: "#/components/schemas/GetCanvasCommissionByCanvasIdResponse"
   /invitation/list:
     get:
       tags:
@@ -3331,12 +3330,12 @@ paths:
       description: List all invitation codes
       operationId: listInvitationCodes
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListInvitationCodesResponse'
+                $ref: "#/components/schemas/ListInvitationCodesResponse"
   /invitation/activate:
     post:
       tags:
@@ -3349,14 +3348,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ActivateInvitationCodeRequest'
+              $ref: "#/components/schemas/ActivateInvitationCodeRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /invitation/invited:
     get:
       tags:
@@ -3365,12 +3364,12 @@ paths:
       description: Check if user has been invited
       operationId: hasBeenInvited
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HasBeenInvitedResponse'
+                $ref: "#/components/schemas/HasBeenInvitedResponse"
   /subscription/plans:
     get:
       tags:
@@ -3379,12 +3378,12 @@ paths:
       description: Get subscription plans
       operationId: getSubscriptionPlans
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetSubscriptionPlansResponse'
+                $ref: "#/components/schemas/GetSubscriptionPlansResponse"
   /subscription/usage:
     get:
       tags:
@@ -3393,12 +3392,12 @@ paths:
       description: Get subscription usage
       operationId: getSubscriptionUsage
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetSubscriptionUsageResponse'
+                $ref: "#/components/schemas/GetSubscriptionUsageResponse"
   /subscription/modelList:
     get:
       tags:
@@ -3407,12 +3406,12 @@ paths:
       description: List all available models
       operationId: listModels
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListModelsResponse'
+                $ref: "#/components/schemas/ListModelsResponse"
   /subscription/createCheckoutSession:
     post:
       tags:
@@ -3425,14 +3424,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateCheckoutSessionRequest'
+              $ref: "#/components/schemas/CreateCheckoutSessionRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateCheckoutSessionResponse'
+                $ref: "#/components/schemas/CreateCheckoutSessionResponse"
   /subscription/createCreditPackCheckoutSession:
     post:
       tags:
@@ -3445,14 +3444,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateCreditPackCheckoutSessionRequest'
+              $ref: "#/components/schemas/CreateCreditPackCheckoutSessionRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateCheckoutSessionResponse'
+                $ref: "#/components/schemas/CreateCheckoutSessionResponse"
   /subscription/createPortalSession:
     post:
       tags:
@@ -3461,12 +3460,12 @@ paths:
       description: Create a portal session
       operationId: createPortalSession
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreatePortalSessionResponse'
+                $ref: "#/components/schemas/CreatePortalSessionResponse"
   /search:
     post:
       tags:
@@ -3479,14 +3478,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SearchRequest'
+              $ref: "#/components/schemas/SearchRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SearchResponse'
+                $ref: "#/components/schemas/SearchResponse"
   /search/multilingualSearch:
     post:
       tags:
@@ -3499,14 +3498,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MultiLingualWebSearchRequest'
+              $ref: "#/components/schemas/MultiLingualWebSearchRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MultiLingualWebSearchResponse'
+                $ref: "#/components/schemas/MultiLingualWebSearchResponse"
   /provider/list:
     get:
       tags:
@@ -3529,19 +3528,19 @@ paths:
           in: query
           description: Provider category
           schema:
-            $ref: '#/components/schemas/ProviderCategory'
+            $ref: "#/components/schemas/ProviderCategory"
         - name: isGlobal
           in: query
           description: Whether the provider is global. If not passed, return both global and user-specific providers.
           schema:
             type: boolean
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListProvidersResponse'
+                $ref: "#/components/schemas/ListProvidersResponse"
   /provider/create:
     post:
       tags:
@@ -3554,14 +3553,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertProviderRequest'
+              $ref: "#/components/schemas/UpsertProviderRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertProviderResponse'
+                $ref: "#/components/schemas/UpsertProviderResponse"
   /provider/update:
     post:
       tags:
@@ -3574,14 +3573,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertProviderRequest'
+              $ref: "#/components/schemas/UpsertProviderRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertProviderResponse'
+                $ref: "#/components/schemas/UpsertProviderResponse"
   /provider/delete:
     post:
       tags:
@@ -3594,14 +3593,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteProviderRequest'
+              $ref: "#/components/schemas/DeleteProviderRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /provider/test-connection:
     post:
       tags:
@@ -3614,14 +3613,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TestProviderConnectionRequest'
+              $ref: "#/components/schemas/TestProviderConnectionRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TestProviderConnectionResponse'
+                $ref: "#/components/schemas/TestProviderConnectionResponse"
   /provider/item/list:
     get:
       tags:
@@ -3644,19 +3643,19 @@ paths:
           in: query
           description: Provider category
           schema:
-            $ref: '#/components/schemas/ProviderCategory'
+            $ref: "#/components/schemas/ProviderCategory"
         - name: isGlobal
           in: query
           description: Whether the provider item is global. If not passed, return both global and user-specific provider items.
           schema:
             type: boolean
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListProviderItemsResponse'
+                $ref: "#/components/schemas/ListProviderItemsResponse"
   /provider/item/option/list:
     get:
       tags:
@@ -3675,14 +3674,14 @@ paths:
           in: query
           description: Provider category
           schema:
-            $ref: '#/components/schemas/ProviderCategory'
+            $ref: "#/components/schemas/ProviderCategory"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListProviderItemOptionsResponse'
+                $ref: "#/components/schemas/ListProviderItemOptionsResponse"
   /provider/item/create:
     post:
       tags:
@@ -3695,14 +3694,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertProviderItemRequest'
+              $ref: "#/components/schemas/UpsertProviderItemRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertProviderItemResponse'
+                $ref: "#/components/schemas/UpsertProviderItemResponse"
   /provider/item/batchCreate:
     post:
       tags:
@@ -3715,14 +3714,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BatchUpsertProviderItemsRequest'
+              $ref: "#/components/schemas/BatchUpsertProviderItemsRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BatchUpsertProviderItemsResponse'
+                $ref: "#/components/schemas/BatchUpsertProviderItemsResponse"
   /provider/item/update:
     post:
       tags:
@@ -3735,14 +3734,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertProviderItemRequest'
+              $ref: "#/components/schemas/UpsertProviderItemRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertProviderItemResponse'
+                $ref: "#/components/schemas/UpsertProviderItemResponse"
   /provider/item/batchUpdate:
     post:
       tags:
@@ -3755,14 +3754,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BatchUpsertProviderItemsRequest'
+              $ref: "#/components/schemas/BatchUpsertProviderItemsRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BatchUpsertProviderItemsResponse'
+                $ref: "#/components/schemas/BatchUpsertProviderItemsResponse"
   /provider/item/delete:
     post:
       tags:
@@ -3775,14 +3774,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteProviderItemRequest'
+              $ref: "#/components/schemas/DeleteProviderItemRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /tool/list:
     get:
       tags:
@@ -3802,12 +3801,12 @@ paths:
           schema:
             type: boolean
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListToolsResponse'
+                $ref: "#/components/schemas/ListToolsResponse"
   /tool/user/list:
     get:
       tags:
@@ -3816,12 +3815,12 @@ paths:
       description: Get installed tools and unauthorized external OAuth tools for current user.
       operationId: listUserTools
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListUserToolsResponse'
+                $ref: "#/components/schemas/ListUserToolsResponse"
   /tool/inventory/list:
     get:
       tags:
@@ -3830,12 +3829,12 @@ paths:
       description: List all available toolsets in inventory, including uninstalled.
       operationId: listToolsetInventory
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListToolsetInventoryResponse'
+                $ref: "#/components/schemas/ListToolsetInventoryResponse"
   /tool/toolset/list:
     get:
       tags:
@@ -3850,12 +3849,12 @@ paths:
           schema:
             type: boolean
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListToolsetsResponse'
+                $ref: "#/components/schemas/ListToolsetsResponse"
   /tool/toolset/create:
     post:
       tags:
@@ -3868,14 +3867,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertToolsetRequest'
+              $ref: "#/components/schemas/UpsertToolsetRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertToolsetResponse'
+                $ref: "#/components/schemas/UpsertToolsetResponse"
   /tool/toolset/update:
     post:
       tags:
@@ -3888,14 +3887,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpsertToolsetRequest'
+              $ref: "#/components/schemas/UpsertToolsetRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpsertToolsetResponse'
+                $ref: "#/components/schemas/UpsertToolsetResponse"
   /tool/toolset/delete:
     post:
       tags:
@@ -3908,14 +3907,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteToolsetRequest'
+              $ref: "#/components/schemas/DeleteToolsetRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseResponse'
+                $ref: "#/components/schemas/BaseResponse"
   /tool/call/result:
     get:
       tags:
@@ -3931,12 +3930,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetToolCallResultResponse'
+                $ref: "#/components/schemas/GetToolCallResultResponse"
   /tool/composio/{app}/authorize:
     post:
       tags:
@@ -3952,12 +3951,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InitiateComposioConnectionResponse'
+                $ref: "#/components/schemas/InitiateComposioConnectionResponse"
   /tool/composio/{app}/revoke:
     post:
       tags:
@@ -3973,13 +3972,13 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ComposioRevokeResponse'
-        '404':
+                $ref: "#/components/schemas/ComposioRevokeResponse"
+        "404":
           description: connection not found
   /tool/composio/{app}/status:
     get:
@@ -3996,12 +3995,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ComposioConnectionStatusResponse'
+                $ref: "#/components/schemas/ComposioConnectionStatusResponse"
   /misc/scrape:
     post:
       tags:
@@ -4014,14 +4013,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ScrapeWeblinkRequest'
+              $ref: "#/components/schemas/ScrapeWeblinkRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ScrapeWeblinkResponse'
+                $ref: "#/components/schemas/ScrapeWeblinkResponse"
   /misc/upload:
     post:
       tags:
@@ -4034,14 +4033,14 @@ paths:
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/UploadRequest'
+              $ref: "#/components/schemas/UploadRequest"
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UploadResponse'
+                $ref: "#/components/schemas/UploadResponse"
   /misc/static/{fileName}:
     get:
       tags:
@@ -4050,7 +4049,7 @@ paths:
       description: Serve static files (only for local testing)
       operationId: serveStatic
       responses:
-        '200':
+        "200":
           description: successful operation
   /misc/convert:
     post:
@@ -4064,14 +4063,14 @@ paths:
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ConvertRequest'
+              $ref: "#/components/schemas/ConvertRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ConvertResponse'
+                $ref: "#/components/schemas/ConvertResponse"
 
   # Voucher endpoints
   /voucher/available:
@@ -4084,12 +4083,12 @@ paths:
       security:
         - bearerAuth: []
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetAvailableVouchersResponse'
+                $ref: "#/components/schemas/GetAvailableVouchersResponse"
 
   /voucher/list:
     get:
@@ -4101,12 +4100,12 @@ paths:
       security:
         - bearerAuth: []
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListUserVouchersResponse'
+                $ref: "#/components/schemas/ListUserVouchersResponse"
 
   /voucher/validate:
     post:
@@ -4122,14 +4121,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ValidateVoucherRequest'
+              $ref: "#/components/schemas/ValidateVoucherRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ValidateVoucherResponse'
+                $ref: "#/components/schemas/ValidateVoucherResponse"
 
   /voucher/invitation/create:
     post:
@@ -4145,14 +4144,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateVoucherInvitationRequest'
+              $ref: "#/components/schemas/CreateVoucherInvitationRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateVoucherInvitationResponse'
+                $ref: "#/components/schemas/CreateVoucherInvitationResponse"
 
   /voucher/invitation/verify:
     get:
@@ -4169,12 +4168,12 @@ paths:
             type: string
           description: Invitation code
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VerifyVoucherInvitationResponse'
+                $ref: "#/components/schemas/VerifyVoucherInvitationResponse"
 
   /voucher/invitation/claim:
     post:
@@ -4190,14 +4189,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ClaimVoucherInvitationRequest'
+              $ref: "#/components/schemas/ClaimVoucherInvitationRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClaimVoucherInvitationResponse'
+                $ref: "#/components/schemas/ClaimVoucherInvitationResponse"
 
   /voucher/trigger:
     post:
@@ -4213,14 +4212,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TriggerVoucherRequest'
+              $ref: "#/components/schemas/TriggerVoucherRequest"
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TriggerVoucherResponse'
+                $ref: "#/components/schemas/TriggerVoucherResponse"
 
 components:
   schemas:
@@ -4240,7 +4239,7 @@ components:
         canvasId:
           type: string
           description: Canvas ID to retrieve existing variable context and content
-          pattern: '^[a-zA-Z0-9_-]+$'
+          pattern: "^[a-zA-Z0-9_-]+$"
           example: "canvas-123"
         mode:
           type: string
@@ -4280,12 +4279,12 @@ components:
           type: array
           description: List of extracted workflow variables
           items:
-            $ref: '#/components/schemas/WorkflowVariable'
+            $ref: "#/components/schemas/WorkflowVariable"
         reusedVariables:
           type: array
           description: List of variables that were reused from existing context
           items:
-            $ref: '#/components/schemas/VariableReuse'
+            $ref: "#/components/schemas/VariableReuse"
         sessionId:
           type: string
           description: |
@@ -4327,12 +4326,11 @@ components:
           description: Explanation of why this variable was reused
           example: "Similar form structure detected in existing variables"
 
-
     McpServerType:
       type: string
       description: MCP Server type
       enum: [sse, streamable, stdio]
-    
+
     McpServerDTO:
       type: object
       required:
@@ -4346,7 +4344,7 @@ components:
           description: MCP server name
           example: My MCP Server
         type:
-          $ref: '#/components/schemas/McpServerType'
+          $ref: "#/components/schemas/McpServerType"
         url:
           type: string
           description: MCP server URL (for sse and streamable types)
@@ -4409,13 +4407,13 @@ components:
 
     ListMcpServersResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               items:
-                $ref: '#/components/schemas/McpServerDTO'
+                $ref: "#/components/schemas/McpServerDTO"
 
     UpsertMcpServerRequest:
       type: object
@@ -4427,7 +4425,7 @@ components:
           type: string
           description: MCP server name
         type:
-          $ref: '#/components/schemas/McpServerType'
+          $ref: "#/components/schemas/McpServerType"
         url:
           type: string
           description: MCP server URL (required for sse and streamable types)
@@ -4472,11 +4470,11 @@ components:
 
     UpsertMcpServerResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/McpServerDTO'
+              $ref: "#/components/schemas/McpServerDTO"
 
     DeleteMcpServerRequest:
       type: object
@@ -4504,21 +4502,21 @@ components:
 
     ValidateMcpServerResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               items:
-                $ref: '#/components/schemas/McpServerTool'
+                $ref: "#/components/schemas/McpServerTool"
 
     DeleteMcpServerResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              type: 'null'
+              type: "null"
 
     Page:
       type: object
@@ -4590,19 +4588,19 @@ components:
           description: Order index
         nodeData:
           description: Node data
-          $ref: '#/components/schemas/CanvasNodeData'
+          $ref: "#/components/schemas/CanvasNodeData"
 
     PageDetail:
       type: object
       allOf:
-        - $ref: '#/components/schemas/Page'
+        - $ref: "#/components/schemas/Page"
         - type: object
           properties:
             nodeRelations:
               type: array
               description: List of node relations
               items:
-                $ref: '#/components/schemas/PageNodeRelation'
+                $ref: "#/components/schemas/PageNodeRelation"
             pageConfig:
               type: object
               description: Page configuration
@@ -4631,23 +4629,23 @@ components:
 
     UpdatePageResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               allOf:
-                - $ref: '#/components/schemas/Page'
+                - $ref: "#/components/schemas/Page"
                 - type: object
                   properties:
                     nodeRelations:
                       type: array
                       description: List of node relations
                       items:
-                        $ref: '#/components/schemas/PageNodeRelation'
+                        $ref: "#/components/schemas/PageNodeRelation"
 
     DeletePageResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -4662,7 +4660,7 @@ components:
 
     SharePageResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -4683,7 +4681,7 @@ components:
 
     DeletePageNodeResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -4701,7 +4699,7 @@ components:
 
     ListPagesResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -4714,15 +4712,15 @@ components:
                   type: array
                   description: List of pages
                   items:
-                    $ref: '#/components/schemas/Page'
+                    $ref: "#/components/schemas/Page"
 
     PageDetailResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/PageDetail'
+              $ref: "#/components/schemas/PageDetail"
 
     AddPageNodesRequest:
       type: object
@@ -4737,35 +4735,35 @@ components:
 
     AddPageNodesResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: object
               properties:
                 page:
-                  $ref: '#/components/schemas/Page'
+                  $ref: "#/components/schemas/Page"
                 nodeRelations:
                   type: array
                   description: List of node relations
                   items:
-                    $ref: '#/components/schemas/PageNodeRelation'
+                    $ref: "#/components/schemas/PageNodeRelation"
 
     CanvasPageResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: object
               properties:
                 page:
-                  $ref: '#/components/schemas/Page'
+                  $ref: "#/components/schemas/Page"
                 nodeRelations:
                   type: array
                   description: List of node relations
                   items:
-                    $ref: '#/components/schemas/PageNodeRelation'
+                    $ref: "#/components/schemas/PageNodeRelation"
 
     User:
       type: object
@@ -4794,7 +4792,7 @@ components:
         - providerAccountId
       properties:
         type:
-          $ref: '#/components/schemas/AuthType'
+          $ref: "#/components/schemas/AuthType"
           description: Auth type
         provider:
           type: string
@@ -4811,19 +4809,19 @@ components:
       type: object
       description: List auth accounts response
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: List of auth accounts
               items:
-                $ref: '#/components/schemas/Account'
+                $ref: "#/components/schemas/Account"
     CheckToolOAuthStatusResponse:
       type: object
       description: Check tool OAuth status response
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -4900,22 +4898,22 @@ components:
         status:
           type: string
           description: Canvas status
-          $ref: '#/components/schemas/CanvasStatus'
+          $ref: "#/components/schemas/CanvasStatus"
         owner:
           description: Canvas owner
-          $ref: '#/components/schemas/ShareUser'
+          $ref: "#/components/schemas/ShareUser"
         shareRecord:
           description: Canvas share record
-          $ref: '#/components/schemas/ShareRecord'
+          $ref: "#/components/schemas/ShareRecord"
         workflowApp:
           description: Canvas workflow app
-          $ref: '#/components/schemas/WorkflowApp'
+          $ref: "#/components/schemas/WorkflowApp"
         usedToolsets:
           type: array
           description: Used toolsets in the canvas
           items:
             type: object
-            $ref: '#/components/schemas/GenericToolset'
+            $ref: "#/components/schemas/GenericToolset"
         minimapUrl:
           type: string
           description: Minimap URL
@@ -4975,13 +4973,13 @@ components:
           example: can-g30e1b80b5g1itbemc0g5jj3
         shareUser:
           description: Share user
-          $ref: '#/components/schemas/ShareUser'
+          $ref: "#/components/schemas/ShareUser"
         version:
           type: integer
           description: Canvas template version
         category:
           description: Canvas template category
-          $ref: '#/components/schemas/CanvasTemplateCategory'
+          $ref: "#/components/schemas/CanvasTemplateCategory"
         title:
           type: string
           description: Canvas template title
@@ -5069,20 +5067,20 @@ components:
           example: r-g30e1b80b5g1itbemc0g5jj3
         resourceType:
           description: Resource type
-          $ref: '#/components/schemas/ResourceType'
+          $ref: "#/components/schemas/ResourceType"
         title:
           type: string
           description: Resource title
         data:
           type: object
           description: Resource metadata
-          $ref: '#/components/schemas/ResourceMeta'
+          $ref: "#/components/schemas/ResourceMeta"
         indexStatus:
           description: Resource index status
-          $ref: '#/components/schemas/IndexStatus'
+          $ref: "#/components/schemas/IndexStatus"
         indexError:
           description: Error message for resource indexing
-          $ref: '#/components/schemas/IndexError'
+          $ref: "#/components/schemas/IndexError"
         storageKey:
           type: string
           description: Resource storage key
@@ -5180,7 +5178,7 @@ components:
           description: Entity ID
         entityType:
           description: Entity type
-          $ref: '#/components/schemas/EntityType'
+          $ref: "#/components/schemas/EntityType"
     ProjectSource:
       type: object
       description: Project source
@@ -5190,7 +5188,7 @@ components:
           description: Entity ID
         entityType:
           description: Entity type
-          $ref: '#/components/schemas/EntityType'
+          $ref: "#/components/schemas/EntityType"
         title:
           type: string
           description: Project title
@@ -5256,7 +5254,7 @@ components:
           example: Label display name
         icon:
           description: Label icon
-          $ref: '#/components/schemas/Icon'
+          $ref: "#/components/schemas/Icon"
         prompt:
           type: string
           description: Label creation instruction prompt
@@ -5287,7 +5285,7 @@ components:
           example: lc-g30e1b80b5g1itbemc0g5jj3
         labelClass:
           description: Label class
-          $ref: '#/components/schemas/LabelClass'
+          $ref: "#/components/schemas/LabelClass"
         value:
           type: string
           description: Label value
@@ -5341,7 +5339,7 @@ components:
           description: Config key
         inputMode:
           description: Config input mode
-          $ref: '#/components/schemas/InputMode'
+          $ref: "#/components/schemas/InputMode"
         required:
           type: boolean
           description: Specifies whether this config is required
@@ -5369,7 +5367,7 @@ components:
           type: array
           description: Config options
           items:
-            $ref: '#/components/schemas/SelectOption'
+            $ref: "#/components/schemas/SelectOption"
         inputProps:
           type: object
           description: Additional input properties
@@ -5416,7 +5414,7 @@ components:
           description: Config display value
         configScope:
           description: The contexts in which the requirement applies
-          $ref: '#/components/schemas/ConfigScope'
+          $ref: "#/components/schemas/ConfigScope"
     SkillTemplateConfigDefinition:
       type: object
       description: Skill template config schema
@@ -5427,7 +5425,7 @@ components:
           type: array
           description: Config items
           items:
-            $ref: '#/components/schemas/DynamicConfigItem'
+            $ref: "#/components/schemas/DynamicConfigItem"
     IconType:
       type: string
       description: Icon type
@@ -5443,7 +5441,7 @@ components:
       properties:
         type:
           description: Icon type
-          $ref: '#/components/schemas/IconType'
+          $ref: "#/components/schemas/IconType"
         value:
           type: string
           description: Icon value
@@ -5461,13 +5459,13 @@ components:
           description: Skill description
         icon:
           description: Skill icon
-          $ref: '#/components/schemas/Icon'
+          $ref: "#/components/schemas/Icon"
         configSchema:
           description: Skill config schema
-          $ref: '#/components/schemas/SkillTemplateConfigDefinition'
+          $ref: "#/components/schemas/SkillTemplateConfigDefinition"
         tplConfig:
           description: Skill template config
-          $ref: '#/components/schemas/SkillTemplateConfig'
+          $ref: "#/components/schemas/SkillTemplateConfig"
     SkillTriggerType:
       type: string
       description: Skill trigger type
@@ -5487,7 +5485,7 @@ components:
       properties:
         name:
           description: Simple event name
-          $ref: '#/components/schemas/SimpleEventName'
+          $ref: "#/components/schemas/SimpleEventName"
         displayName:
           type: object
           description: Simple event display name (key is locale, value is display name)
@@ -5512,7 +5510,7 @@ components:
         repeatInterval:
           type: string
           description: Repeat interval
-          $ref: '#/components/schemas/TimerInterval'
+          $ref: "#/components/schemas/TimerInterval"
     SkillTrigger:
       type: object
       description: Skill triggers
@@ -5539,22 +5537,22 @@ components:
           example: tr-g30e1b80b5g1itbemc0g5jj3
         triggerType:
           description: Trigger type
-          $ref: '#/components/schemas/SkillTriggerType'
+          $ref: "#/components/schemas/SkillTriggerType"
         simpleEventName:
           description: Simple event name (only required when trigger type is `simpleEvent`)
-          $ref: '#/components/schemas/SimpleEventName'
+          $ref: "#/components/schemas/SimpleEventName"
         timerConfig:
           description: Timer config (only required when trigger type is `timer`)
-          $ref: '#/components/schemas/TimerTriggerConfig'
+          $ref: "#/components/schemas/TimerTriggerConfig"
         input:
           description: Skill input
-          $ref: '#/components/schemas/SkillInput'
+          $ref: "#/components/schemas/SkillInput"
         context:
           description: Skill context
-          $ref: '#/components/schemas/SkillContext'
+          $ref: "#/components/schemas/SkillContext"
         tplConfig:
           description: Skill template config
-          $ref: '#/components/schemas/SkillTemplateConfig'
+          $ref: "#/components/schemas/SkillTemplateConfig"
         enabled:
           type: boolean
           description: Trigger enabled
@@ -5577,7 +5575,7 @@ components:
           description: Skill name
         icon:
           description: Skill icon
-          $ref: '#/components/schemas/Icon'
+          $ref: "#/components/schemas/Icon"
     ActionMeta:
       type: object
       description: Action metadata
@@ -5587,13 +5585,13 @@ components:
         type:
           type: string
           description: Action type
-          $ref: '#/components/schemas/ActionType'
+          $ref: "#/components/schemas/ActionType"
         name:
           type: string
           description: Action name
         icon:
           description: Action icon
-          $ref: '#/components/schemas/Icon'
+          $ref: "#/components/schemas/Icon"
     SkillRuntimeConfig:
       type: object
       description: Skill runtime config
@@ -5609,18 +5607,18 @@ components:
       description: Skill template config (key is config item key, value is config value)
       additionalProperties:
         description: Skill template config value
-        $ref: '#/components/schemas/DynamicConfigValue'
+        $ref: "#/components/schemas/DynamicConfigValue"
     ActionConfig:
       type: object
       description: Action config (key is config item key, value is config value)
       additionalProperties:
         description: Skill template config value
-        $ref: '#/components/schemas/DynamicConfigValue'
+        $ref: "#/components/schemas/DynamicConfigValue"
     SkillInstance:
       type: object
       description: Skill
       allOf:
-        - $ref: '#/components/schemas/SkillMeta'
+        - $ref: "#/components/schemas/SkillMeta"
         - type: object
           required:
             - createdAt
@@ -5635,10 +5633,10 @@ components:
               description: Skill instance prompt hint
             tplConfig:
               description: Skill template config
-              $ref: '#/components/schemas/SkillTemplateConfig'
+              $ref: "#/components/schemas/SkillTemplateConfig"
             tplConfigSchema:
               description: Skill template config schema
-              $ref: '#/components/schemas/SkillTemplateConfigDefinition'
+              $ref: "#/components/schemas/SkillTemplateConfigDefinition"
             pinnedAt:
               type: string
               format: date-time
@@ -5739,12 +5737,12 @@ components:
         metadata:
           type: object
           description: Source metadata
-          $ref: '#/components/schemas/SourceMeta'
+          $ref: "#/components/schemas/SourceMeta"
         selections:
           type: array
           description: Source selections
           items:
-            $ref: '#/components/schemas/SourceSelection'
+            $ref: "#/components/schemas/SourceSelection"
     SearchStep:
       type: object
       description: Search step
@@ -5874,7 +5872,7 @@ components:
         type:
           type: string
           description: Artifact type
-          $ref: '#/components/schemas/ArtifactType'
+          $ref: "#/components/schemas/ArtifactType"
         entityId:
           type: string
           description: Entity ID
@@ -5883,7 +5881,7 @@ components:
           description: Artifact title
         status:
           description: Artifact status
-          $ref: '#/components/schemas/ArtifactStatus'
+          $ref: "#/components/schemas/ArtifactStatus"
         content:
           type: string
           description: Artifact content
@@ -5942,7 +5940,7 @@ components:
           type: array
           description: Step artifacts
           items:
-            $ref: '#/components/schemas/Artifact'
+            $ref: "#/components/schemas/Artifact"
         structuredData:
           type: object
           description: Step structured data output
@@ -5953,17 +5951,17 @@ components:
           type: array
           description: Action step logs
           items:
-            $ref: '#/components/schemas/ActionLog'
+            $ref: "#/components/schemas/ActionLog"
         tokenUsage:
           type: array
           description: Token usage
           items:
-            $ref: '#/components/schemas/TokenUsageItem'
+            $ref: "#/components/schemas/TokenUsageItem"
         toolCalls:
           type: array
           description: Tool calls in this step
           items:
-            $ref: '#/components/schemas/ToolCallResult'
+            $ref: "#/components/schemas/ToolCallResult"
     CodeArtifactType:
       type: string
       description: Code artifact type
@@ -5989,7 +5987,7 @@ components:
         type:
           type: string
           description: Artifact type
-          $ref: '#/components/schemas/CodeArtifactType'
+          $ref: "#/components/schemas/CodeArtifactType"
         artifactId:
           type: string
           description: Artifact ID
@@ -6034,7 +6032,7 @@ components:
           type: string
           description: Action message ID
         type:
-          $ref: '#/components/schemas/ActionMessageType'
+          $ref: "#/components/schemas/ActionMessageType"
           description: Action message type
         content:
           type: string
@@ -6043,13 +6041,13 @@ components:
           type: string
           description: Action message reasoning content
         toolCallMeta:
-          $ref: '#/components/schemas/ToolCallMeta'
+          $ref: "#/components/schemas/ToolCallMeta"
           description: Action message tool call metadata
         toolCallId:
           type: string
           description: Action message tool call ID
         toolCallResult:
-          $ref: '#/components/schemas/ToolCallResult'
+          $ref: "#/components/schemas/ToolCallResult"
           description: Tool call result
         createdAt:
           type: string
@@ -6079,24 +6077,24 @@ components:
           deprecated: true
         input:
           description: Action input
-          $ref: '#/components/schemas/SkillInput'
+          $ref: "#/components/schemas/SkillInput"
         tier:
           description: Model tier
-          $ref: '#/components/schemas/ModelTier'
+          $ref: "#/components/schemas/ModelTier"
         status:
           type: string
           description: Step status
-          $ref: '#/components/schemas/ActionStatus'
+          $ref: "#/components/schemas/ActionStatus"
         errorType:
           type: string
           description: Error type (defaults to systemError when omitted)
-          $ref: '#/components/schemas/ActionErrorType'
+          $ref: "#/components/schemas/ActionErrorType"
         type:
           description: Action type
-          $ref: '#/components/schemas/ActionType'
+          $ref: "#/components/schemas/ActionType"
         modelInfo:
           description: Selected model
-          $ref: '#/components/schemas/ModelInfo'
+          $ref: "#/components/schemas/ModelInfo"
         actualProviderItemId:
           type: string
           description: Actual provider item ID used for execution after routing (e.g. routed from Auto)
@@ -6105,44 +6103,44 @@ components:
           description: Whether the action execution was routed from the Auto model
         targetType:
           description: Action target type
-          $ref: '#/components/schemas/EntityType'
+          $ref: "#/components/schemas/EntityType"
         targetId:
           type: string
           description: Action target ID
         actionMeta:
           type: object
           description: Action metadata
-          $ref: '#/components/schemas/ActionMeta'
+          $ref: "#/components/schemas/ActionMeta"
         context:
           type: object
           description: Action context
-          $ref: '#/components/schemas/SkillContext'
+          $ref: "#/components/schemas/SkillContext"
         tplConfig:
           type: object
           description: Action template config
-          $ref: '#/components/schemas/SkillTemplateConfig'
+          $ref: "#/components/schemas/SkillTemplateConfig"
           deprecated: true
         runtimeConfig:
           type: object
           description: Action runtime config
-          $ref: '#/components/schemas/SkillRuntimeConfig'
+          $ref: "#/components/schemas/SkillRuntimeConfig"
           deprecated: true
         history:
           type: array
           description: Action result history
           items:
-            $ref: '#/components/schemas/ActionResult'
+            $ref: "#/components/schemas/ActionResult"
         steps:
           type: array
           description: Action steps
           deprecated: true
           items:
-            $ref: '#/components/schemas/ActionStep'
+            $ref: "#/components/schemas/ActionStep"
         messages:
           type: array
           description: Action messages
           items:
-            $ref: '#/components/schemas/ActionMessage'
+            $ref: "#/components/schemas/ActionMessage"
         errors:
           type: array
           description: Errors
@@ -6152,17 +6150,17 @@ components:
           type: array
           description: Action toolsets
           items:
-            $ref: '#/components/schemas/GenericToolset'
+            $ref: "#/components/schemas/GenericToolset"
         toolCalls:
           type: array
           description: Tool calls during action execution
           items:
-            $ref: '#/components/schemas/ToolCallResult'
+            $ref: "#/components/schemas/ToolCallResult"
         files:
           type: array
           description: Files generated by the action
           items:
-            $ref: '#/components/schemas/DriveFile'
+            $ref: "#/components/schemas/DriveFile"
         outputUrl:
           type: string
           format: uri
@@ -6245,14 +6243,14 @@ components:
         planType:
           type: string
           description: Subscription plan type
-          $ref: '#/components/schemas/SubscriptionPlanType'
+          $ref: "#/components/schemas/SubscriptionPlanType"
         interval:
           description: Payment recurring interval
-          $ref: '#/components/schemas/SubscriptionInterval'
+          $ref: "#/components/schemas/SubscriptionInterval"
         status:
           type: string
           description: Subscription status
-          $ref: '#/components/schemas/SubscriptionStatus'
+          $ref: "#/components/schemas/SubscriptionStatus"
         isTrial:
           type: boolean
           description: Whether the subscription is a trial
@@ -6356,32 +6354,32 @@ components:
         objectStorageQuota:
           type: string
           description: Object storage quota (in bytes), including resource, canvas and static files
-          example: '104857600'
+          example: "104857600"
           deprecated: true
         resourceSize:
           type: string
           description: Resource storage size in use (in bytes)
-          example: '1048576'
+          example: "1048576"
           deprecated: true
         canvasSize:
           type: string
           description: Canvas storage size in use (in bytes)
-          example: '1048576'
+          example: "1048576"
           deprecated: true
         fileSize:
           type: string
           description: Static file storage size in use (in bytes)
-          example: '1048576'
+          example: "1048576"
           deprecated: true
         vectorStorageQuota:
           type: string
           description: Vector storage quota (in bytes)
-          example: '1048576'
+          example: "1048576"
           deprecated: true
         vectorStorageUsed:
           type: string
           description: Vector storage size used (in bytes)
-          example: '1048576'
+          example: "1048576"
           deprecated: true
     FileParsingMeter:
       type: object
@@ -6432,28 +6430,28 @@ components:
       properties:
         chat:
           description: Default chat model to use
-          $ref: '#/components/schemas/ProviderItem'
+          $ref: "#/components/schemas/ProviderItem"
         copilot:
           description: Default copilot model to use
-          $ref: '#/components/schemas/ProviderItem'
+          $ref: "#/components/schemas/ProviderItem"
         agent:
           description: Default agent model to use
-          $ref: '#/components/schemas/ProviderItem'
+          $ref: "#/components/schemas/ProviderItem"
         queryAnalysis:
           description: Query analysis and context processing model
-          $ref: '#/components/schemas/ProviderItem'
+          $ref: "#/components/schemas/ProviderItem"
         titleGeneration:
           description: Title generation model for canvas and documents
-          $ref: '#/components/schemas/ProviderItem'
+          $ref: "#/components/schemas/ProviderItem"
         image:
           description: Default image generation model
-          $ref: '#/components/schemas/ProviderItem'
+          $ref: "#/components/schemas/ProviderItem"
         video:
           description: Default video generation model
-          $ref: '#/components/schemas/ProviderItem'
+          $ref: "#/components/schemas/ProviderItem"
         audio:
           description: Default audio generation model
-          $ref: '#/components/schemas/ProviderItem'
+          $ref: "#/components/schemas/ProviderItem"
     ProviderMode:
       type: string
       description: Provider mode
@@ -6466,10 +6464,10 @@ components:
       properties:
         operationMode:
           description: Operation mode
-          $ref: '#/components/schemas/OperationMode'
+          $ref: "#/components/schemas/OperationMode"
         providerMode:
           description: Provider mode
-          $ref: '#/components/schemas/ProviderMode'
+          $ref: "#/components/schemas/ProviderMode"
         disableHoverCard:
           type: boolean
           description: Whether to disable hover tutorial
@@ -6483,16 +6481,16 @@ components:
           description: Whether to require invitation code
         webSearch:
           description: Web search config
-          $ref: '#/components/schemas/ProviderConfig'
+          $ref: "#/components/schemas/ProviderConfig"
         urlParsing:
           description: URL parsing config
-          $ref: '#/components/schemas/ProviderConfig'
+          $ref: "#/components/schemas/ProviderConfig"
         pdfParsing:
           description: PDF parsing config
-          $ref: '#/components/schemas/ProviderConfig'
+          $ref: "#/components/schemas/ProviderConfig"
         defaultModel:
           description: Default model config
-          $ref: '#/components/schemas/DefaultModelConfig'
+          $ref: "#/components/schemas/DefaultModelConfig"
     OnboardingStatus:
       type: string
       description: Onboarding status
@@ -6505,10 +6503,10 @@ components:
       properties:
         settings:
           description: Settings onboarding status
-          $ref: '#/components/schemas/OnboardingStatus'
+          $ref: "#/components/schemas/OnboardingStatus"
         tour:
           description: Tour onboarding status
-          $ref: '#/components/schemas/OnboardingStatus'
+          $ref: "#/components/schemas/OnboardingStatus"
     UserSettings:
       type: object
       required:
@@ -6554,17 +6552,17 @@ components:
           description: Stripe customer ID
         subscription:
           description: User subscription
-          $ref: '#/components/schemas/Subscription'
+          $ref: "#/components/schemas/Subscription"
         hasBetaAccess:
           type: boolean
           description: Whether the user has beta access
           default: false
         preferences:
           description: User preferences
-          $ref: '#/components/schemas/UserPreferences'
+          $ref: "#/components/schemas/UserPreferences"
         onboarding:
           description: Onboarding config
-          $ref: '#/components/schemas/OnboardingConfig'
+          $ref: "#/components/schemas/OnboardingConfig"
     AuthProvider:
       type: string
       description: Auth provider
@@ -6580,17 +6578,17 @@ components:
       properties:
         provider:
           description: Auth provider
-          $ref: '#/components/schemas/AuthProvider'
+          $ref: "#/components/schemas/AuthProvider"
     AuthConfigResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Auth providers
               items:
-                $ref: '#/components/schemas/AuthConfigItem'
+                $ref: "#/components/schemas/AuthConfigItem"
     EmailSignupRequest:
       type: object
       description: Email signup request
@@ -6615,11 +6613,11 @@ components:
           description: Whether email verification is skipped
     EmailSignupResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/EmailSignupData'
+              $ref: "#/components/schemas/EmailSignupData"
     VerificationPurpose:
       type: string
       description: Verification purpose
@@ -6639,7 +6637,7 @@ components:
         purpose:
           type: string
           description: Verification purpose
-          $ref: '#/components/schemas/VerificationPurpose'
+          $ref: "#/components/schemas/VerificationPurpose"
         password:
           type: string
           description: Password
@@ -6651,11 +6649,11 @@ components:
           description: Verification session ID
     CreateVerificationResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/CreateVerificationData'
+              $ref: "#/components/schemas/CreateVerificationData"
     ResendVerificationRequest:
       type: object
       description: Resend verification request
@@ -6699,18 +6697,18 @@ components:
           description: Access token
     EmailLoginResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/EmailLoginData'
+              $ref: "#/components/schemas/EmailLoginData"
     GetUserSettingsResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/UserSettings'
+              $ref: "#/components/schemas/UserSettings"
     CollabTokenData:
       type: object
       required:
@@ -6724,11 +6722,11 @@ components:
           description: Token expiration time (in unix milliseconds)
     GetCollabTokenResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/CollabTokenData'
+              $ref: "#/components/schemas/CollabTokenData"
     BaseResponse:
       type: object
       required:
@@ -6785,25 +6783,25 @@ components:
           type: array
           description: Array of error objects (present when status is error)
           items:
-            $ref: '#/components/schemas/ErrorDetail'
+            $ref: "#/components/schemas/ErrorDetail"
 
     ListCanvasResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Canvas list
               items:
-                $ref: '#/components/schemas/Canvas'
+                $ref: "#/components/schemas/Canvas"
     GetCanvasDetailResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/Canvas'
+              $ref: "#/components/schemas/Canvas"
     CanvasHistoryVersion:
       type: object
       required:
@@ -6831,17 +6829,17 @@ components:
           type: array
           description: Canvas nodes
           items:
-            $ref: '#/components/schemas/CanvasNode'
+            $ref: "#/components/schemas/CanvasNode"
         edges:
           type: array
           description: Canvas edges
           items:
-            $ref: '#/components/schemas/CanvasEdge'
+            $ref: "#/components/schemas/CanvasEdge"
     CanvasState:
       type: object
       description: Canvas state
       allOf:
-        - $ref: '#/components/schemas/CanvasData'
+        - $ref: "#/components/schemas/CanvasData"
         - type: object
           properties:
             version:
@@ -6854,12 +6852,12 @@ components:
               type: array
               description: Canvas transaction list
               items:
-                $ref: '#/components/schemas/CanvasTransaction'
+                $ref: "#/components/schemas/CanvasTransaction"
             history:
               type: array
               description: Canvas history versions
               items:
-                $ref: '#/components/schemas/CanvasHistoryVersion'
+                $ref: "#/components/schemas/CanvasHistoryVersion"
             createdAt:
               type: number
               description: Canvas creation timestamp (in unix milliseconds)
@@ -6870,7 +6868,7 @@ components:
       type: object
       description: Raw canvas data
       allOf:
-        - $ref: '#/components/schemas/CanvasData'
+        - $ref: "#/components/schemas/CanvasData"
         - type: object
           properties:
             canvasId:
@@ -6882,7 +6880,7 @@ components:
             owner:
               type: object
               description: Canvas owner
-              $ref: '#/components/schemas/ShareUser'
+              $ref: "#/components/schemas/ShareUser"
             minimapUrl:
               type: string
               description: Minimap URL
@@ -6890,17 +6888,17 @@ components:
               type: array
               description: Workflow variables
               items:
-                $ref: '#/components/schemas/WorkflowVariable'
+                $ref: "#/components/schemas/WorkflowVariable"
     GetCanvasDataResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/RawCanvasData'
+              $ref: "#/components/schemas/RawCanvasData"
     SharedCanvasData:
       allOf:
-        - $ref: '#/components/schemas/RawCanvasData'
+        - $ref: "#/components/schemas/RawCanvasData"
         - type: object
           properties:
             resources:
@@ -6908,15 +6906,15 @@ components:
               description: Resources in the canvas
               deprecated: true
               items:
-                $ref: '#/components/schemas/Resource'
+                $ref: "#/components/schemas/Resource"
             files:
               type: array
               description: Drive files in the canvas
               items:
-                $ref: '#/components/schemas/DriveFile'
+                $ref: "#/components/schemas/DriveFile"
     ExportCanvasResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -7003,18 +7001,18 @@ components:
           type: array
           description: Workflow variables
           items:
-            $ref: '#/components/schemas/WorkflowVariable'
+            $ref: "#/components/schemas/WorkflowVariable"
         visibility:
           type: boolean
           description: Whether this canvas is visible in lists
           default: true
     UpsertCanvasResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/Canvas'
+              $ref: "#/components/schemas/Canvas"
     DeleteCanvasRequest:
       type: object
       required:
@@ -7042,7 +7040,7 @@ components:
           default: false
     AutoNameCanvasResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -7054,11 +7052,11 @@ components:
                   description: New canvas title
     GetCanvasStateResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/CanvasState'
+              $ref: "#/components/schemas/CanvasState"
     SetCanvasStateRequest:
       type: object
       required:
@@ -7071,17 +7069,17 @@ components:
         state:
           type: object
           description: Canvas state to set
-          $ref: '#/components/schemas/CanvasState'
+          $ref: "#/components/schemas/CanvasState"
     GetCanvasTransactionsResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Canvas diff list
               items:
-                $ref: '#/components/schemas/CanvasTransaction'
+                $ref: "#/components/schemas/CanvasTransaction"
     DiffType:
       type: string
       description: Diff type
@@ -7101,7 +7099,7 @@ components:
         type:
           type: string
           description: Node diff type
-          $ref: '#/components/schemas/DiffType'
+          $ref: "#/components/schemas/DiffType"
         from:
           type: object
           description: Node diff from (only the fields that are different will be included)
@@ -7122,15 +7120,15 @@ components:
         type:
           type: string
           description: Edge diff type
-          $ref: '#/components/schemas/DiffType'
+          $ref: "#/components/schemas/DiffType"
         from:
           type: object
           description: Edge diff from
-          $ref: '#/components/schemas/CanvasEdge'
+          $ref: "#/components/schemas/CanvasEdge"
         to:
           type: object
           description: Edge diff to
-          $ref: '#/components/schemas/CanvasEdge'
+          $ref: "#/components/schemas/CanvasEdge"
     CanvasTransactionSource:
       type: object
       description: Canvas transaction source
@@ -7161,19 +7159,19 @@ components:
           type: array
           description: Node diffs
           items:
-            $ref: '#/components/schemas/NodeDiff'
+            $ref: "#/components/schemas/NodeDiff"
         edgeDiffs:
           type: array
           description: Edge diffs
           items:
-            $ref: '#/components/schemas/EdgeDiff'
+            $ref: "#/components/schemas/EdgeDiff"
         revoked:
           type: boolean
           description: Whether the transaction is revoked
         source:
           type: object
           description: Transaction source
-          $ref: '#/components/schemas/CanvasTransactionSource'
+          $ref: "#/components/schemas/CanvasTransactionSource"
         deleted:
           type: boolean
           description: Whether the transaction is deleted
@@ -7199,7 +7197,7 @@ components:
           type: array
           description: Transaction list
           items:
-            $ref: '#/components/schemas/CanvasTransaction'
+            $ref: "#/components/schemas/CanvasTransaction"
     SyncCanvasStateResult:
       type: object
       required:
@@ -7209,16 +7207,16 @@ components:
           type: array
           description: Transaction list
           items:
-            $ref: '#/components/schemas/CanvasTransaction'
+            $ref: "#/components/schemas/CanvasTransaction"
     SyncCanvasStateResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: object
               description: Apply canvas state result
-              $ref: '#/components/schemas/SyncCanvasStateResult'
+              $ref: "#/components/schemas/SyncCanvasStateResult"
     CreateCanvasVersionRequest:
       type: object
       required:
@@ -7231,7 +7229,7 @@ components:
         state:
           type: object
           description: Canvas state
-          $ref: '#/components/schemas/CanvasState'
+          $ref: "#/components/schemas/CanvasState"
     VersionConflict:
       type: object
       required:
@@ -7241,11 +7239,11 @@ components:
         localState:
           type: object
           description: Local canvas state
-          $ref: '#/components/schemas/CanvasState'
+          $ref: "#/components/schemas/CanvasState"
         remoteState:
           type: object
           description: Server canvas state
-          $ref: '#/components/schemas/CanvasState'
+          $ref: "#/components/schemas/CanvasState"
     CreateCanvasVersionResult:
       type: object
       required:
@@ -7257,30 +7255,30 @@ components:
         conflict:
           type: object
           description: Version conflict (when there is a conflict)
-          $ref: '#/components/schemas/VersionConflict'
+          $ref: "#/components/schemas/VersionConflict"
         newState:
           type: object
           description: New canvas state (when there is no conflict)
-          $ref: '#/components/schemas/CanvasState'
+          $ref: "#/components/schemas/CanvasState"
     CreateCanvasVersionResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: object
               description: Create canvas version result
-              $ref: '#/components/schemas/CreateCanvasVersionResult'
+              $ref: "#/components/schemas/CreateCanvasVersionResult"
     ListCanvasTemplateResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Canvas template list
               items:
-                $ref: '#/components/schemas/CanvasTemplate'
+                $ref: "#/components/schemas/CanvasTemplate"
     CreateCanvasTemplateRequest:
       type: object
       required:
@@ -7329,22 +7327,22 @@ components:
           description: Canvas template language code
     UpsertCanvasTemplateResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               description: Canvas template
-              $ref: '#/components/schemas/CanvasTemplate'
+              $ref: "#/components/schemas/CanvasTemplate"
     ListCanvasTemplateCategoryResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Canvas template category list
               items:
-                $ref: '#/components/schemas/CanvasTemplateCategory'
+                $ref: "#/components/schemas/CanvasTemplateCategory"
     UpsertResourceRequest:
       type: object
       required:
@@ -7357,7 +7355,7 @@ components:
           example: My Resource
         resourceType:
           description: Resource type
-          $ref: '#/components/schemas/ResourceType'
+          $ref: "#/components/schemas/ResourceType"
         resourceId:
           type: string
           description: Resource ID (only used for update)
@@ -7370,7 +7368,7 @@ components:
           description: Canvas ID to bind with
         data:
           description: Resource metadata
-          $ref: '#/components/schemas/ResourceMeta'
+          $ref: "#/components/schemas/ResourceMeta"
         storageKey:
           type: string
           description: Storage key
@@ -7379,21 +7377,21 @@ components:
           description: Resource content (this will be ignored if storageKey was set)
     UpsertResourceResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/Resource'
+              $ref: "#/components/schemas/Resource"
     BatchCreateResourceResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Resource list
               items:
-                $ref: '#/components/schemas/Resource'
+                $ref: "#/components/schemas/Resource"
     ReindexResourceRequest:
       type: object
       required:
@@ -7406,14 +7404,14 @@ components:
             type: string
     ReindexResourceResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Resource list
               items:
-                $ref: '#/components/schemas/Resource'
+                $ref: "#/components/schemas/Resource"
     DeleteResourceRequest:
       type: object
       required:
@@ -7425,42 +7423,42 @@ components:
           example: r-g30e1b80b5g1itbemc0g5jj3
     ListResourceResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Resource list
               items:
-                $ref: '#/components/schemas/Resource'
+                $ref: "#/components/schemas/Resource"
     GetResourceDetailResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: object
               description: Resource data
-              $ref: '#/components/schemas/Resource'
+              $ref: "#/components/schemas/Resource"
     ListDocumentResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Canvas list
               items:
-                $ref: '#/components/schemas/Document'
+                $ref: "#/components/schemas/Document"
     GetDocumentDetailResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: object
               description: Document data
-              $ref: '#/components/schemas/Document'
+              $ref: "#/components/schemas/Document"
     UpsertDocumentRequest:
       type: object
       properties:
@@ -7490,11 +7488,11 @@ components:
           description: Action result ID to bind with
     UpsertDocumentResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/Document'
+              $ref: "#/components/schemas/Document"
     DeleteDocumentRequest:
       type: object
       required:
@@ -7506,11 +7504,11 @@ components:
           example: d-g30e1b80b5g1itbemc0g5jj3
     GetActionResultResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/ActionResult'
+              $ref: "#/components/schemas/ActionResult"
     AbortActionRequest:
       type: object
       required:
@@ -7524,21 +7522,21 @@ components:
           description: Action result version
     ListProjectResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Project list
               items:
-                $ref: '#/components/schemas/Project'
+                $ref: "#/components/schemas/Project"
     GetProjectDetailResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/Project'
+              $ref: "#/components/schemas/Project"
     UpsertProjectRequest:
       type: object
       properties:
@@ -7559,11 +7557,11 @@ components:
           description: Custom instructions
     UpsertProjectResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/Project'
+              $ref: "#/components/schemas/Project"
     UpdateProjectItemsRequest:
       type: object
       properties:
@@ -7580,7 +7578,7 @@ components:
           type: array
           description: Item list
           items:
-            $ref: '#/components/schemas/Entity'
+            $ref: "#/components/schemas/Entity"
     DeleteProjectRequest:
       type: object
       required:
@@ -7603,7 +7601,7 @@ components:
           type: array
           description: Item list
           items:
-            $ref: '#/components/schemas/Entity'
+            $ref: "#/components/schemas/Entity"
     SkillEventType:
       type: string
       description: Skill event type
@@ -7629,13 +7627,13 @@ components:
       properties:
         event:
           description: Event type
-          $ref: '#/components/schemas/SkillEventType'
+          $ref: "#/components/schemas/SkillEventType"
         skillMeta:
           description: Skill metadata
-          $ref: '#/components/schemas/SkillMeta'
+          $ref: "#/components/schemas/SkillMeta"
         step:
           description: Action step metadata
-          $ref: '#/components/schemas/ActionStepMeta'
+          $ref: "#/components/schemas/ActionStepMeta"
           deprecated: true
         resultId:
           type: string
@@ -7654,31 +7652,31 @@ components:
           description: Reasoning content. Only present when `event` is `stream`
         tokenUsage:
           description: Token usage data. Only present when `event` is `token_usage`.
-          $ref: '#/components/schemas/TokenUsageItem'
+          $ref: "#/components/schemas/TokenUsageItem"
         log:
           description: Log data. Only present when `event` is `log`.
-          $ref: '#/components/schemas/ActionLog'
+          $ref: "#/components/schemas/ActionLog"
         structuredData:
           type: object
           description: Structured data. Only present when `event` is `structured_data`.
         artifact:
           description: Artifact data. Only present when `event` is `artifact`.
-          $ref: '#/components/schemas/Artifact'
+          $ref: "#/components/schemas/Artifact"
         node:
           description: Canvas node data. Only present when `event` is `create_node`.
-          $ref: '#/components/schemas/CanvasNode'
+          $ref: "#/components/schemas/CanvasNode"
         error:
           description: Error data. Only present when `event` is `error`.
-          $ref: '#/components/schemas/BaseResponse'
+          $ref: "#/components/schemas/BaseResponse"
         originError:
           type: string
           description: Original error message. Only present when `event` is `error`.
         toolCallMeta:
           description: Tool call metadata. Only present when `event` is `tool_call_start`, `tool_call_end`, or `tool_call_error`.
-          $ref: '#/components/schemas/ToolCallMeta'
+          $ref: "#/components/schemas/ToolCallMeta"
         toolCallResult:
           description: Tool call result data.
-          $ref: '#/components/schemas/ToolCallResult'
+          $ref: "#/components/schemas/ToolCallResult"
     ToolCallStatus:
       type: string
       description: Tool call status
@@ -7702,7 +7700,7 @@ components:
           type: string
           description: Tool call ID
         status:
-          $ref: '#/components/schemas/ToolCallStatus'
+          $ref: "#/components/schemas/ToolCallStatus"
           description: Tool call status
         startTs:
           type: number
@@ -7753,7 +7751,7 @@ components:
           description: Error message if tool execution failed
         status:
           description: Tool call status
-          $ref: '#/components/schemas/ToolCallStatus'
+          $ref: "#/components/schemas/ToolCallStatus"
         createdAt:
           type: number
           description: Tool call start timestamp (milliseconds)
@@ -7777,7 +7775,7 @@ components:
           type: string
           description: Share title
         entityType:
-          $ref: '#/components/schemas/EntityType'
+          $ref: "#/components/schemas/EntityType"
           description: Entity type
         entityId:
           type: string
@@ -7833,28 +7831,28 @@ components:
           default: false
     UpsertCodeArtifactResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/CodeArtifact'
+              $ref: "#/components/schemas/CodeArtifact"
     ListCodeArtifactResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Code artifact list
               items:
-                $ref: '#/components/schemas/CodeArtifact'
+                $ref: "#/components/schemas/CodeArtifact"
     GetCodeArtifactDetailResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/CodeArtifact'
+              $ref: "#/components/schemas/CodeArtifact"
     DuplicateCodeArtifactRequest:
       type: object
       required:
@@ -7873,7 +7871,7 @@ components:
         - entityId
       properties:
         entityType:
-          $ref: '#/components/schemas/EntityType'
+          $ref: "#/components/schemas/EntityType"
           description: Entity type
         entityId:
           type: string
@@ -7902,22 +7900,22 @@ components:
           description: Credit usage
     CreateShareResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/ShareRecord'
+              $ref: "#/components/schemas/ShareRecord"
               description: Share created
     ListShareResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Share record list
               items:
-                $ref: '#/components/schemas/ShareRecord'
+                $ref: "#/components/schemas/ShareRecord"
     DeleteShareRequest:
       type: object
       required:
@@ -7945,22 +7943,22 @@ components:
           description: Custom title for the duplicated entity
     DuplicateShareResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               description: Duplicated entity
-              $ref: '#/components/schemas/Entity'
+              $ref: "#/components/schemas/Entity"
     ListLabelClassesResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Label class list
               items:
-                $ref: '#/components/schemas/LabelClass'
+                $ref: "#/components/schemas/LabelClass"
     CreateLabelClassRequest:
       type: object
       required:
@@ -7978,7 +7976,7 @@ components:
           example: My Class
         icon:
           description: Label icon
-          $ref: '#/components/schemas/Icon'
+          $ref: "#/components/schemas/Icon"
         prompt:
           type: string
           description: Label creation instruction prompt
@@ -8001,19 +7999,19 @@ components:
           example: My Class
         icon:
           description: Label icon
-          $ref: '#/components/schemas/Icon'
+          $ref: "#/components/schemas/Icon"
         prompt:
           type: string
           description: Label creation instruction prompt
           example: Extract labels for the tech-related keywords
     UpsertLabelClassResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               description: Label class upserted
-              $ref: '#/components/schemas/LabelClass'
+              $ref: "#/components/schemas/LabelClass"
     DeleteLabelClassRequest:
       type: object
       required:
@@ -8025,14 +8023,14 @@ components:
           example: lc-g30e1b80b5g1itbemc0g5jj3
     ListLabelInstancesResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Label list
               items:
-                $ref: '#/components/schemas/LabelInstance'
+                $ref: "#/components/schemas/LabelInstance"
     CreateLabelInstanceRequest:
       type: object
       required:
@@ -8053,7 +8051,7 @@ components:
             example: label-1
         entityType:
           description: Label entity type
-          $ref: '#/components/schemas/EntityType'
+          $ref: "#/components/schemas/EntityType"
         entityId:
           description: Label entity ID
           type: string
@@ -8068,14 +8066,14 @@ components:
           description: Updated label value
     UpsertLabelInstanceResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Label instance upserted
               items:
-                $ref: '#/components/schemas/LabelInstance'
+                $ref: "#/components/schemas/LabelInstance"
     DeleteLabelInstanceRequest:
       type: object
       required:
@@ -8094,43 +8092,43 @@ components:
         actionType:
           type: string
           description: Action type
-          $ref: '#/components/schemas/ActionType'
+          $ref: "#/components/schemas/ActionType"
         actionName:
           type: string
           description: Action name
         icon:
           description: Action icon
-          $ref: '#/components/schemas/Icon'
+          $ref: "#/components/schemas/Icon"
     ListActionResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Action list
               items:
-                $ref: '#/components/schemas/Action'
+                $ref: "#/components/schemas/Action"
     ListSkillResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Skill list
               items:
-                $ref: '#/components/schemas/Skill'
+                $ref: "#/components/schemas/Skill"
     ListSkillInstanceResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Skill list
               items:
-                $ref: '#/components/schemas/SkillInstance'
+                $ref: "#/components/schemas/SkillInstance"
     SkillInstanceCreateParam:
       type: object
       required:
@@ -8149,10 +8147,10 @@ components:
           description: Skill description
         icon:
           description: Skill instance icon
-          $ref: '#/components/schemas/Icon'
+          $ref: "#/components/schemas/Icon"
         tplConfig:
           description: Skill template config
-          $ref: '#/components/schemas/SkillTemplateConfig'
+          $ref: "#/components/schemas/SkillTemplateConfig"
     CreateSkillInstanceRequest:
       type: object
       required:
@@ -8162,17 +8160,17 @@ components:
           type: array
           description: Skill instances to upsert
           items:
-            $ref: '#/components/schemas/SkillInstanceCreateParam'
+            $ref: "#/components/schemas/SkillInstanceCreateParam"
     CreateSkillInstanceResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Skill instance list
               items:
-                $ref: '#/components/schemas/SkillInstance'
+                $ref: "#/components/schemas/SkillInstance"
     UpdateSkillInstanceRequest:
       type: object
       required:
@@ -8191,18 +8189,18 @@ components:
           description: Skill description
         icon:
           description: Skill instance icon
-          $ref: '#/components/schemas/Icon'
+          $ref: "#/components/schemas/Icon"
         tplConfig:
           description: Skill template config
-          $ref: '#/components/schemas/SkillTemplateConfig'
+          $ref: "#/components/schemas/SkillTemplateConfig"
     UpdateSkillInstanceResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               description: Skill instance list
-              $ref: '#/components/schemas/SkillInstance'
+              $ref: "#/components/schemas/SkillInstance"
     PinSkillInstanceRequest:
       type: object
       required:
@@ -8252,7 +8250,7 @@ components:
           description: Resource ID (if empty, this will be considered as external resource)
         resource:
           description: Resource
-          $ref: '#/components/schemas/Resource'
+          $ref: "#/components/schemas/Resource"
         isCurrent:
           type: boolean
           description: Whether this resource is current
@@ -8268,7 +8266,7 @@ components:
           description: Document ID
         document:
           description: Document
-          $ref: '#/components/schemas/Document'
+          $ref: "#/components/schemas/Document"
         isCurrent:
           type: boolean
           description: Whether this document is current
@@ -8284,7 +8282,7 @@ components:
           description: Artifact ID
         codeArtifact:
           description: Code artifact
-          $ref: '#/components/schemas/CodeArtifact'
+          $ref: "#/components/schemas/CodeArtifact"
         isCurrent:
           type: boolean
           description: Whether this code artifact is current
@@ -8328,7 +8326,7 @@ components:
         mediaType:
           type: string
           description: Media type
-          $ref: '#/components/schemas/MediaType'
+          $ref: "#/components/schemas/MediaType"
         entityId:
           type: string
           description: Media entity ID
@@ -8355,7 +8353,7 @@ components:
           description: File ID
         file:
           description: File object
-          $ref: '#/components/schemas/DriveFile'
+          $ref: "#/components/schemas/DriveFile"
         variableId:
           type: string
           description: Variable ID if this file is from a workflow variable
@@ -8371,7 +8369,7 @@ components:
           description: Result ID
         result:
           description: Result
-          $ref: '#/components/schemas/ActionResult'
+          $ref: "#/components/schemas/ActionResult"
     SkillContext:
       type: object
       description: Skill invocation context
@@ -8380,43 +8378,43 @@ components:
           type: array
           description: Context resources
           items:
-            $ref: '#/components/schemas/SkillContextResourceItem'
+            $ref: "#/components/schemas/SkillContextResourceItem"
         documents:
           type: array
           description: Context documents
           items:
-            $ref: '#/components/schemas/SkillContextDocumentItem'
+            $ref: "#/components/schemas/SkillContextDocumentItem"
         codeArtifacts:
           type: array
           description: Context code artifacts
           items:
-            $ref: '#/components/schemas/SkillContextCodeArtifactItem'
+            $ref: "#/components/schemas/SkillContextCodeArtifactItem"
         contentList:
           type: array
           description: Context content list
           items:
-            $ref: '#/components/schemas/SkillContextContentItem'
+            $ref: "#/components/schemas/SkillContextContentItem"
         urls:
           type: array
           description: List of URLs
           items:
-            $ref: '#/components/schemas/SkillContextUrlItem'
+            $ref: "#/components/schemas/SkillContextUrlItem"
           deprecated: true
         mediaList:
           type: array
           description: List of media
           items:
-            $ref: '#/components/schemas/SkillContextMediaItem'
+            $ref: "#/components/schemas/SkillContextMediaItem"
         files:
           type: array
           description: List of files
           items:
-            $ref: '#/components/schemas/SkillContextFileItem'
+            $ref: "#/components/schemas/SkillContextFileItem"
         results:
           type: array
           description: List of results
           items:
-            $ref: '#/components/schemas/SkillContextResultItem'
+            $ref: "#/components/schemas/SkillContextResultItem"
     SelectionKey:
       type: string
       enum:
@@ -8443,26 +8441,26 @@ components:
       properties:
         input:
           description: Skill input
-          $ref: '#/components/schemas/SkillInput'
+          $ref: "#/components/schemas/SkillInput"
         title:
           description: Agent title
           type: string
         context:
           description: Skill invocation context
-          $ref: '#/components/schemas/SkillContext'
+          $ref: "#/components/schemas/SkillContext"
         resultHistory:
           type: array
           description: Skill result history
           items:
-            $ref: '#/components/schemas/ActionResult'
+            $ref: "#/components/schemas/ActionResult"
           deprecated: true
         runtimeConfig:
           description: Skill runtime config
-          $ref: '#/components/schemas/SkillRuntimeConfig'
+          $ref: "#/components/schemas/SkillRuntimeConfig"
           deprecated: true
         tplConfig:
           description: Skill template config
-          $ref: '#/components/schemas/SkillTemplateConfig'
+          $ref: "#/components/schemas/SkillTemplateConfig"
           deprecated: true
         skillName:
           type: string
@@ -8470,7 +8468,7 @@ components:
           deprecated: true
         target:
           description: Skill invocation target
-          $ref: '#/components/schemas/Entity'
+          $ref: "#/components/schemas/Entity"
         projectId:
           type: string
           description: Project ID
@@ -8507,10 +8505,10 @@ components:
           type: array
           description: Selected toolsets
           items:
-            $ref: '#/components/schemas/GenericToolset'
+            $ref: "#/components/schemas/GenericToolset"
         mode:
           description: Agent mode
-          $ref: '#/components/schemas/AgentMode'
+          $ref: "#/components/schemas/AgentMode"
           default: node_agent
         copilotSessionId:
           type: string
@@ -8523,7 +8521,7 @@ components:
           description: Workflow node execution ID for workflow context
     InvokeSkillResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             resultId:
@@ -8531,14 +8529,14 @@ components:
               description: Skill result ID
     ListSkillTriggerResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Skill trigger list
               items:
-                $ref: '#/components/schemas/SkillTrigger'
+                $ref: "#/components/schemas/SkillTrigger"
     SkillTriggerCreateParam:
       type: object
       required:
@@ -8556,22 +8554,22 @@ components:
           example: My trigger
         triggerType:
           description: Trigger type
-          $ref: '#/components/schemas/SkillTriggerType'
+          $ref: "#/components/schemas/SkillTriggerType"
         simpleEventName:
           description: Simple event name (only required when trigger type is `simpleEvent`)
-          $ref: '#/components/schemas/SimpleEventName'
+          $ref: "#/components/schemas/SimpleEventName"
         timerConfig:
           description: Timer config (only required when trigger type is `timer`)
-          $ref: '#/components/schemas/TimerTriggerConfig'
+          $ref: "#/components/schemas/TimerTriggerConfig"
         input:
           description: Skill input
-          $ref: '#/components/schemas/SkillInput'
+          $ref: "#/components/schemas/SkillInput"
         context:
           description: Skill invocation context
-          $ref: '#/components/schemas/SkillContext'
+          $ref: "#/components/schemas/SkillContext"
         tplConfig:
           description: Skill template config
-          $ref: '#/components/schemas/SkillTemplateConfig'
+          $ref: "#/components/schemas/SkillTemplateConfig"
         enabled:
           type: boolean
           description: Whether this trigger is enabled
@@ -8584,20 +8582,20 @@ components:
           type: array
           description: Skill triggers to upsert
           items:
-            $ref: '#/components/schemas/SkillTriggerCreateParam'
+            $ref: "#/components/schemas/SkillTriggerCreateParam"
     CreateSkillTriggerResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Skill trigger list
               items:
-                $ref: '#/components/schemas/SkillTrigger'
+                $ref: "#/components/schemas/SkillTrigger"
     UpdateSkillTriggerRequest:
       allOf:
-        - $ref: '#/components/schemas/SkillTriggerCreateParam'
+        - $ref: "#/components/schemas/SkillTriggerCreateParam"
         - type: object
           required:
             - triggerId
@@ -8608,12 +8606,12 @@ components:
               example: tr-g30e1b80b5g1itbemc0g5jj3
     UpdateSkillTriggerResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               description: Updated skill trigger
-              $ref: '#/components/schemas/SkillTrigger'
+              $ref: "#/components/schemas/SkillTrigger"
     DeleteSkillTriggerRequest:
       type: object
       required:
@@ -8628,63 +8626,63 @@ components:
       enum: [image, video, audio]
       example: image
     MediaGenerateRequest:
-        type: object
-        required:
-          - mediaType
-          - prompt
-        properties:
-          mediaType:
-            $ref: '#/components/schemas/MediaType'
-          model:
-            type: string
-            description: Model name for content generation
-          title:
-            type: string
-            description: Title of the generated media
-          targetType:
-            description: Target type
-            $ref: '#/components/schemas/EntityType'
-          targetId:
-            type: string
-            description: Target ID
-          providerItemId:
-            type: string
-            description: Provider item ID
-          provider:
-            type: string
-            description: Optional provider selection (use providerItemId instead)
-            nullable: true
-          prompt:
-            type: string
-            description: Text prompt for content generation
-          wait:
-            type: boolean
-            description: Whether to wait for the generation to complete
-            default: false
-          resultId:
-            type: string
-            description: Media generation result ID
-          parentResultId:
-            type: string
-            description: Parent result ID for the media generation (usually the actor agent result ID)
-          parentResultVersion:
-            type: number
-            description: Parent result version for the media generation (usually the actor agent result version)
-          apiKey:
-            type: string
-            description: API key for the provider
-          inputParameters:
-            type: array
-            description: Input parameter configurations
-            items:
-              $ref: '#/components/schemas/MediaModelParameter'
-          input:
-            type: object
-            description: Flexible key-value pairs for additional input parameters
-            additionalProperties: true
-          unitCost:
-            type: number
-            description: Unit cost for the media generation
+      type: object
+      required:
+        - mediaType
+        - prompt
+      properties:
+        mediaType:
+          $ref: "#/components/schemas/MediaType"
+        model:
+          type: string
+          description: Model name for content generation
+        title:
+          type: string
+          description: Title of the generated media
+        targetType:
+          description: Target type
+          $ref: "#/components/schemas/EntityType"
+        targetId:
+          type: string
+          description: Target ID
+        providerItemId:
+          type: string
+          description: Provider item ID
+        provider:
+          type: string
+          description: Optional provider selection (use providerItemId instead)
+          nullable: true
+        prompt:
+          type: string
+          description: Text prompt for content generation
+        wait:
+          type: boolean
+          description: Whether to wait for the generation to complete
+          default: false
+        resultId:
+          type: string
+          description: Media generation result ID
+        parentResultId:
+          type: string
+          description: Parent result ID for the media generation (usually the actor agent result ID)
+        parentResultVersion:
+          type: number
+          description: Parent result version for the media generation (usually the actor agent result version)
+        apiKey:
+          type: string
+          description: API key for the provider
+        inputParameters:
+          type: array
+          description: Input parameter configurations
+          items:
+            $ref: "#/components/schemas/MediaModelParameter"
+        input:
+          type: object
+          description: Flexible key-value pairs for additional input parameters
+          additionalProperties: true
+        unitCost:
+          type: number
+          description: Unit cost for the media generation
     MediaGenerationResult:
       type: object
       required:
@@ -8695,7 +8693,7 @@ components:
           description: Media generation result ID
           example: ar-g30e1b80b5g1itbemc0g5jj3
         file:
-          $ref: '#/components/schemas/DriveFile'
+          $ref: "#/components/schemas/DriveFile"
           description: Generated file
         outputUrl:
           type: string
@@ -8710,15 +8708,15 @@ components:
           description: Media generation original result from provider
     MediaGenerateResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/MediaGenerationResult'
+              $ref: "#/components/schemas/MediaGenerationResult"
 
     FishAudioTextToSpeechRequest:
       allOf:
-        - $ref: '#/components/schemas/MediaGenerateRequest'
+        - $ref: "#/components/schemas/MediaGenerateRequest"
         - type: object
           required:
             - text
@@ -8796,7 +8794,7 @@ components:
 
     FishAudioTextToSpeechResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponseV2'
+        - $ref: "#/components/schemas/BaseResponseV2"
         - type: object
           properties:
             data:
@@ -8852,7 +8850,7 @@ components:
 
     FishAudioSpeechToTextResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponseV2'
+        - $ref: "#/components/schemas/BaseResponseV2"
         - type: object
           properties:
             data:
@@ -9021,7 +9019,7 @@ components:
 
     HeyGenGenerateVideoResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponseV2'
+        - $ref: "#/components/schemas/BaseResponseV2"
         - type: object
           properties:
             data:
@@ -9104,13 +9102,13 @@ components:
         - params
       properties:
         params:
-          $ref: '#/components/schemas/SandboxExecuteParams'
+          $ref: "#/components/schemas/SandboxExecuteParams"
         context:
-          $ref: '#/components/schemas/SandboxExecuteContext'
+          $ref: "#/components/schemas/SandboxExecuteContext"
 
     SandboxExecuteResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponseV2'
+        - $ref: "#/components/schemas/BaseResponseV2"
         - type: object
           properties:
             data:
@@ -9136,7 +9134,7 @@ components:
                   type: array
                   description: List of files generated by the code execution (available even when exitCode!=0)
                   items:
-                    $ref: '#/components/schemas/DriveFile'
+                    $ref: "#/components/schemas/DriveFile"
                 warnings:
                   type: array
                   description: System warnings from sandbox (e.g., file rename due to conflict, temporary directory creation)
@@ -9170,13 +9168,13 @@ components:
           description: Pilot step entity type
         status:
           description: Pilot step status
-          $ref: '#/components/schemas/PilotStepStatus'
+          $ref: "#/components/schemas/PilotStepStatus"
         rawOutput:
           type: string
           description: Pilot step raw output
         actionResult:
           description: Pilot step action result
-          $ref: '#/components/schemas/ActionResult'
+          $ref: "#/components/schemas/ActionResult"
         createdAt:
           type: string
           description: Pilot step created at
@@ -9211,13 +9209,13 @@ components:
           description: Pilot session title
         input:
           description: Pilot session input
-          $ref: '#/components/schemas/SkillInput'
+          $ref: "#/components/schemas/SkillInput"
         status:
           description: Pilot session status
-          $ref: '#/components/schemas/PilotSessionStatus'
+          $ref: "#/components/schemas/PilotSessionStatus"
         targetType:
           description: Pilot session target type
-          $ref: '#/components/schemas/EntityType'
+          $ref: "#/components/schemas/EntityType"
         targetId:
           type: string
           description: Pilot session target ID
@@ -9231,7 +9229,7 @@ components:
           type: array
           description: Pilot steps
           items:
-            $ref: '#/components/schemas/PilotStep'
+            $ref: "#/components/schemas/PilotStep"
         createdAt:
           type: string
           description: Pilot session created at
@@ -9250,7 +9248,7 @@ components:
           description: Pilot session target ID
         targetType:
           description: Pilot session target type
-          $ref: '#/components/schemas/EntityType'
+          $ref: "#/components/schemas/EntityType"
         maxEpoch:
           type: number
           description: Pilot session max epoch
@@ -9260,7 +9258,7 @@ components:
           description: Pilot session title
         input:
           description: Pilot session input
-          $ref: '#/components/schemas/SkillInput'
+          $ref: "#/components/schemas/SkillInput"
         providerItemId:
           type: string
           description: Pilot session provider item ID
@@ -9274,7 +9272,7 @@ components:
           description: Pilot session ID
         input:
           description: Pilot session input
-          $ref: '#/components/schemas/SkillInput'
+          $ref: "#/components/schemas/SkillInput"
         maxEpoch:
           type: number
           description: Pilot session max epoch
@@ -9294,30 +9292,30 @@ components:
             type: string
     UpsertPilotSessionResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               description: Upserted pilot session
-              $ref: '#/components/schemas/PilotSession'
+              $ref: "#/components/schemas/PilotSession"
     ListPilotSessionsResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Pilot session list
               items:
-                $ref: '#/components/schemas/PilotSession'
+                $ref: "#/components/schemas/PilotSession"
     GetPilotSessionDetailResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               description: Pilot session detail
-              $ref: '#/components/schemas/PilotSession'
+              $ref: "#/components/schemas/PilotSession"
     CopilotSession:
       type: object
       properties:
@@ -9340,25 +9338,25 @@ components:
           type: array
           description: Copilot session results (only returned in detail API)
           items:
-            $ref: '#/components/schemas/ActionResult'
+            $ref: "#/components/schemas/ActionResult"
     ListCopilotSessionsResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Copilot session list
               items:
-                $ref: '#/components/schemas/CopilotSession'
+                $ref: "#/components/schemas/CopilotSession"
     GetCopilotSessionDetailResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               description: Copilot session detail
-              $ref: '#/components/schemas/CopilotSession'
+              $ref: "#/components/schemas/CopilotSession"
     UpdateUserSettingsRequest:
       type: object
       properties:
@@ -9386,10 +9384,10 @@ components:
           example: en
         preferences:
           description: User preferences
-          $ref: '#/components/schemas/UserPreferences'
+          $ref: "#/components/schemas/UserPreferences"
         onboarding:
           description: Onboarding config
-          $ref: '#/components/schemas/OnboardingConfig'
+          $ref: "#/components/schemas/OnboardingConfig"
     CheckSettingsFieldResult:
       type: object
       required:
@@ -9408,12 +9406,12 @@ components:
           description: Whether the field value is available
     CheckSettingsFieldResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               description: Settings field check result
-              $ref: '#/components/schemas/CheckSettingsFieldResult'
+              $ref: "#/components/schemas/CheckSettingsFieldResult"
     CreateCheckoutSessionRequest:
       type: object
       required:
@@ -9421,10 +9419,10 @@ components:
       properties:
         planType:
           description: Subscription plan type
-          $ref: '#/components/schemas/SubscriptionPlanType'
+          $ref: "#/components/schemas/SubscriptionPlanType"
         interval:
           description: Subscription billing interval
-          $ref: '#/components/schemas/SubscriptionInterval'
+          $ref: "#/components/schemas/SubscriptionInterval"
         voucherId:
           type: string
           description: Optional voucher ID to apply discount
@@ -9442,7 +9440,7 @@ components:
           description: Source
     CreateCreditPackCheckoutSessionRequest:
       type: object
-      required: 
+      required:
         - packId
       properties:
         packId:
@@ -9456,7 +9454,7 @@ components:
           description: Source
     CreateCheckoutSessionResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -9468,7 +9466,7 @@ components:
                   description: Checkout session URL
     CreatePortalSessionResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -9485,19 +9483,19 @@ components:
       properties:
         formSubmission:
           description: Form submission
-          $ref: '#/components/schemas/FormSubmission'
+          $ref: "#/components/schemas/FormSubmission"
     GetFormDefinitionResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: object
               description: Form definition
-              $ref: '#/components/schemas/FormDefinition'
+              $ref: "#/components/schemas/FormDefinition"
     HasFilledFormResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -9510,7 +9508,7 @@ components:
                   default: false
     GetCreditRechargeResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -9521,7 +9519,7 @@ components:
                   type: array
                   description: Credit recharge list
                   items:
-                    $ref: '#/components/schemas/CreditRecharge'
+                    $ref: "#/components/schemas/CreditRecharge"
                 total:
                   type: integer
                   description: Total number of records
@@ -9533,7 +9531,7 @@ components:
                   description: Number of items per page
     GetCreditUsageResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -9544,7 +9542,7 @@ components:
                   type: array
                   description: Credit usage list
                   items:
-                    $ref: '#/components/schemas/CreditUsage'
+                    $ref: "#/components/schemas/CreditUsage"
                 total:
                   type: integer
                   description: Total number of records
@@ -9556,7 +9554,7 @@ components:
                   description: Number of items per page
     getCreditBalanceResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -9574,13 +9572,13 @@ components:
                   description: Regular credits (from purchases, gifts, subscriptions)
                 templateEarningsCredits:
                   type: number
-                  description: Template earnings credits      
+                  description: Template earnings credits
                 cumulativeEarningsCredits:
                   type: number
-                  description: Cumulative earnings credits                  
+                  description: Cumulative earnings credits
     GetCreditUsageByResultIdResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -9594,10 +9592,10 @@ components:
                   type: array
                   description: Credit usage list by result ID
                   items:
-                    $ref: '#/components/schemas/CreditUsage'
+                    $ref: "#/components/schemas/CreditUsage"
     GetCreditUsageByExecutionIdResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -9611,10 +9609,10 @@ components:
                   type: array
                   description: Credit usage list by execution ID
                   items:
-                    $ref: '#/components/schemas/CreditUsage'
+                    $ref: "#/components/schemas/CreditUsage"
     GetCreditUsageByCanvasIdResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -9628,10 +9626,10 @@ components:
                   type: array
                   description: Credit usage list by canvas ID
                   items:
-                    $ref: '#/components/schemas/CreditUsage'
+                    $ref: "#/components/schemas/CreditUsage"
     GetCanvasCommissionByCanvasIdResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -9672,17 +9670,17 @@ components:
           description: Invitation code
     ListInvitationCodesResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Invitation code list
               items:
-                $ref: '#/components/schemas/InvitationCode'
+                $ref: "#/components/schemas/InvitationCode"
     HasBeenInvitedResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -9719,35 +9717,35 @@ components:
           description: Vector storage quota (in bytes)
     GetSubscriptionPlansResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Subscription plans
               items:
-                $ref: '#/components/schemas/SubscriptionPlan'
+                $ref: "#/components/schemas/SubscriptionPlan"
     SubscriptionUsageData:
       type: object
       properties:
         token:
           description: Token usage meter
-          $ref: '#/components/schemas/TokenUsageMeter'
+          $ref: "#/components/schemas/TokenUsageMeter"
         storage:
           description: Storage usage meter
-          $ref: '#/components/schemas/StorageUsageMeter'
+          $ref: "#/components/schemas/StorageUsageMeter"
         fileParsing:
           description: File parsing meter
-          $ref: '#/components/schemas/FileParsingMeter'
+          $ref: "#/components/schemas/FileParsingMeter"
     GetSubscriptionUsageResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: object
               description: Subscription usage
-              $ref: '#/components/schemas/SubscriptionUsageData'
+              $ref: "#/components/schemas/SubscriptionUsageData"
     WebSearchRequest:
       type: object
       properties:
@@ -9778,7 +9776,7 @@ components:
           type: array
           description: Web search queries
           items:
-            $ref: '#/components/schemas/WebSearchRequest'
+            $ref: "#/components/schemas/WebSearchRequest"
     MultiLingualWebSearchRequest:
       type: object
       required:
@@ -9811,7 +9809,7 @@ components:
           description: Relevance threshold for reranking
     MultiLingualWebSearchResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -9825,12 +9823,12 @@ components:
                   type: array
                   description: Search result sources
                   items:
-                    $ref: '#/components/schemas/Source'
+                    $ref: "#/components/schemas/Source"
                 searchSteps:
                   type: array
                   description: Search steps
                   items:
-                    $ref: '#/components/schemas/SearchStep'
+                    $ref: "#/components/schemas/SearchStep"
     WebSearchResult:
       type: object
       properties:
@@ -9848,24 +9846,24 @@ components:
           description: Web search result locale
     WebSearchResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Web search results
               items:
-                $ref: '#/components/schemas/WebSearchResult'
+                $ref: "#/components/schemas/WebSearchResult"
     RerankResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Reranked results
               items:
-                $ref: '#/components/schemas/SearchResult'
+                $ref: "#/components/schemas/SearchResult"
     SearchOptions:
       type: object
       description: Search options for internal use
@@ -9898,16 +9896,16 @@ components:
           type: array
           description: Search domains (if not specified, return all domains)
           items:
-            $ref: '#/components/schemas/SearchDomain'
+            $ref: "#/components/schemas/SearchDomain"
         entities:
           type: array
           description: Search entities
           items:
-            $ref: '#/components/schemas/Entity'
+            $ref: "#/components/schemas/Entity"
         mode:
           type: string
           description: Search mode
-          $ref: '#/components/schemas/SearchMode'
+          $ref: "#/components/schemas/SearchMode"
           default: keyword
         projectId:
           type: string
@@ -9937,7 +9935,7 @@ components:
           description: Search result ID to navigate to
         domain:
           description: Search result domain
-          $ref: '#/components/schemas/SearchDomain'
+          $ref: "#/components/schemas/SearchDomain"
         title:
           type: string
           description: Search result title
@@ -9951,7 +9949,7 @@ components:
           type: array
           description: Search result content list with highlight marks
           items:
-            $ref: '#/components/schemas/SearchResultSnippet'
+            $ref: "#/components/schemas/SearchResultSnippet"
         relevanceScore:
           type: number
           description: Search result relevance score
@@ -9969,14 +9967,14 @@ components:
           description: Data update time
     SearchResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Search result
               items:
-                $ref: '#/components/schemas/SearchResult'
+                $ref: "#/components/schemas/SearchResult"
     ScrapeWeblinkRequest:
       type: object
       required:
@@ -9999,12 +9997,12 @@ components:
           description: Weblink image
     ScrapeWeblinkResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               description: Weblink scrape result
-              $ref: '#/components/schemas/ScrapeWeblinkResult'
+              $ref: "#/components/schemas/ScrapeWeblinkResult"
     FileVisibility:
       type: string
       enum:
@@ -10024,16 +10022,16 @@ components:
           description: Entity ID
         entityType:
           description: Entity type
-          $ref: '#/components/schemas/EntityType'
+          $ref: "#/components/schemas/EntityType"
         visibility:
           description: File visibility (default is private)
-          $ref: '#/components/schemas/FileVisibility'
+          $ref: "#/components/schemas/FileVisibility"
         storageKey:
           type: string
           description: Storage key (if provided, the file will be replaced if it already exists)
     UploadResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -10068,7 +10066,7 @@ components:
           default: markdown
     ConvertResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -10104,6 +10102,9 @@ components:
         contextCaching:
           type: boolean
           description: Whether this model supports context caching
+        supportToolChoice:
+          type: boolean
+          description: Whether this model supports tool_choice parameter
         image:
           type: boolean
           description: Whether this model supports image generation
@@ -10137,7 +10138,7 @@ components:
         tier:
           type: string
           description: Model tier
-          $ref: '#/components/schemas/ModelTier'
+          $ref: "#/components/schemas/ModelTier"
         contextLimit:
           type: number
           description: Model context limit (in tokens)
@@ -10146,7 +10147,7 @@ components:
           description: Model max output length (in tokens)
         capabilities:
           description: Model capabilities
-          $ref: '#/components/schemas/ModelCapabilities'
+          $ref: "#/components/schemas/ModelCapabilities"
         isDefault:
           type: boolean
           description: Whether this model is the default model
@@ -10156,28 +10157,28 @@ components:
         category:
           type: string
           description: Model category
-          $ref: '#/components/schemas/ProviderCategory'
+          $ref: "#/components/schemas/ProviderCategory"
         creditBilling:
-          $ref: '#/components/schemas/CreditBilling'
+          $ref: "#/components/schemas/CreditBilling"
           description: Credit billing info
         tooltip:
           type: string
           description: Tooltip text for the model (e.g., "Smart Routing")
         inputParameters:
-            type: array
-            description: Input parameter configurations
-            items:
-              $ref: '#/components/schemas/MediaModelParameter'
+          type: array
+          description: Input parameter configurations
+          items:
+            $ref: "#/components/schemas/MediaModelParameter"
     ListModelsResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Model list
               items:
-                $ref: '#/components/schemas/ModelInfo'
+                $ref: "#/components/schemas/ModelInfo"
     ProviderCategory:
       type: string
       enum:
@@ -10211,7 +10212,7 @@ components:
           type: array
           description: Provider categories
           items:
-            $ref: '#/components/schemas/ProviderCategory'
+            $ref: "#/components/schemas/ProviderCategory"
         baseUrl:
           type: string
           description: Provider base URL
@@ -10248,7 +10249,7 @@ components:
           description: Whether the model disallow setting custom temperature
         capabilities:
           description: Model capabilities
-          $ref: '#/components/schemas/ModelCapabilities'
+          $ref: "#/components/schemas/ModelCapabilities"
         tooltip:
           type: string
           description: Tooltip text for the model (e.g., "Smart Routing")
@@ -10321,7 +10322,7 @@ components:
           description: Model name
         capabilities:
           description: Model capabilities
-          $ref: '#/components/schemas/MediaGenerationModelCapabilities'
+          $ref: "#/components/schemas/MediaGenerationModelCapabilities"
         description:
           type: string
           description: Model description
@@ -10338,12 +10339,12 @@ components:
           type: array
           description: Input parameter configurations
           items:
-            $ref: '#/components/schemas/MediaModelParameter'
+            $ref: "#/components/schemas/MediaModelParameter"
         outputParameters:
           type: array
           description: Output parameter configurations
           items:
-            $ref: '#/components/schemas/MediaModelParameter'
+            $ref: "#/components/schemas/MediaModelParameter"
         baseModel:
           type: string
           description: Base model for the model
@@ -10387,10 +10388,10 @@ components:
           description: Minimum relevance score threshold (0.0-1.0)
     ProviderItemConfig:
       oneOf:
-        - $ref: '#/components/schemas/LLMModelConfig'
-        - $ref: '#/components/schemas/EmbeddingModelConfig'
-        - $ref: '#/components/schemas/RerankerModelConfig'
-        - $ref: '#/components/schemas/MediaGenerationModelConfig'
+        - $ref: "#/components/schemas/LLMModelConfig"
+        - $ref: "#/components/schemas/EmbeddingModelConfig"
+        - $ref: "#/components/schemas/RerankerModelConfig"
+        - $ref: "#/components/schemas/MediaGenerationModelConfig"
     CreditBilling:
       type: object
       description: Credit billing configuration for provider items
@@ -10437,15 +10438,15 @@ components:
           description: Provider item name
         category:
           description: Provider category
-          $ref: '#/components/schemas/ProviderCategory'
+          $ref: "#/components/schemas/ProviderCategory"
         tier:
           type: string
           description: Provider item tier
-          $ref: '#/components/schemas/ModelTier'
+          $ref: "#/components/schemas/ModelTier"
         config:
           type: object
           description: Provider item config
-          $ref: '#/components/schemas/ProviderItemConfig'
+          $ref: "#/components/schemas/ProviderItemConfig"
     ProviderItem:
       type: object
       required:
@@ -10466,20 +10467,20 @@ components:
           description: Whether the provider item is enabled
         category:
           description: Provider category
-          $ref: '#/components/schemas/ProviderCategory'
+          $ref: "#/components/schemas/ProviderCategory"
         tier:
           description: Provider item tier
-          $ref: '#/components/schemas/ModelTier'
+          $ref: "#/components/schemas/ModelTier"
         providerId:
           type: string
           description: Provider ID
         provider:
           type: object
           description: Provider detail info
-          $ref: '#/components/schemas/Provider'
+          $ref: "#/components/schemas/Provider"
         config:
           description: Provider item config
-          $ref: '#/components/schemas/ProviderItemConfig'
+          $ref: "#/components/schemas/ProviderItemConfig"
         order:
           type: number
           description: Provider item order
@@ -10488,7 +10489,7 @@ components:
           description: Provider item group
         creditBilling:
           description: Credit billing info
-          $ref: '#/components/schemas/CreditBilling'
+          $ref: "#/components/schemas/CreditBilling"
     CreditRecharge:
       type: object
       description: Credit recharge record for user balance management
@@ -10540,7 +10541,7 @@ components:
         extraData:
           type: string
           description: Extra data for this recharge (JSON)
-          $ref: '#/components/schemas/CreditRechargeExtraData'
+          $ref: "#/components/schemas/CreditRechargeExtraData"
         shareId:
           type: string
           description: Related share ID (if applicable)
@@ -10615,7 +10616,7 @@ components:
         extraData:
           type: string
           description: Extra data for this usage (JSON)
-          $ref: '#/components/schemas/CreditUsageExtraData'
+          $ref: "#/components/schemas/CreditUsageExtraData"
         shareId:
           type: string
           description: Related share ID (if applicable)
@@ -10678,13 +10679,13 @@ components:
           description: Related tool name
     ListProvidersResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               items:
-                $ref: '#/components/schemas/Provider'
+                $ref: "#/components/schemas/Provider"
     UpsertProviderRequest:
       type: object
       properties:
@@ -10701,7 +10702,7 @@ components:
           type: array
           description: Provider categories
           items:
-            $ref: '#/components/schemas/ProviderCategory'
+            $ref: "#/components/schemas/ProviderCategory"
         apiKey:
           type: string
           description: Provider API key
@@ -10713,11 +10714,11 @@ components:
           description: Whether the provider is enabled
     UpsertProviderResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/Provider'
+              $ref: "#/components/schemas/Provider"
     DeleteProviderRequest:
       type: object
       required:
@@ -10736,7 +10737,7 @@ components:
           description: Provider ID to test
         category:
           description: Provider category to test (optional)
-          $ref: '#/components/schemas/ProviderCategory'
+          $ref: "#/components/schemas/ProviderCategory"
     ProviderTestResult:
       type: object
       properties:
@@ -10777,29 +10778,29 @@ components:
           format: date-time
     TestProviderConnectionResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/ProviderTestResult'
+              $ref: "#/components/schemas/ProviderTestResult"
     ListProviderItemOptionsResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               items:
-                $ref: '#/components/schemas/ProviderItemOption'
+                $ref: "#/components/schemas/ProviderItemOption"
     ListProviderItemsResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               items:
-                $ref: '#/components/schemas/ProviderItem'
+                $ref: "#/components/schemas/ProviderItem"
     UpsertProviderItemRequest:
       type: object
       properties:
@@ -10817,13 +10818,13 @@ components:
           description: Provider item name
         category:
           description: Provider category
-          $ref: '#/components/schemas/ProviderCategory'
+          $ref: "#/components/schemas/ProviderCategory"
         enabled:
           type: boolean
           description: Whether the provider item is enabled
         config:
           description: Provider item config
-          $ref: '#/components/schemas/ProviderItemConfig'
+          $ref: "#/components/schemas/ProviderItemConfig"
         order:
           type: number
           description: Provider item order
@@ -10832,11 +10833,11 @@ components:
           description: Provider item group
     UpsertProviderItemResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/ProviderItem'
+              $ref: "#/components/schemas/ProviderItem"
     BatchUpsertProviderItemsRequest:
       type: object
       required:
@@ -10846,17 +10847,17 @@ components:
           type: array
           description: Provider items to upsert
           items:
-            $ref: '#/components/schemas/UpsertProviderItemRequest'
+            $ref: "#/components/schemas/UpsertProviderItemRequest"
     BatchUpsertProviderItemsResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Upserted provider items
               items:
-                $ref: '#/components/schemas/ProviderItem'
+                $ref: "#/components/schemas/ProviderItem"
     DeleteProviderItemRequest:
       type: object
       required:
@@ -10897,12 +10898,12 @@ components:
         type:
           type: string
           description: Auth pattern type
-          $ref: '#/components/schemas/ToolsetAuthType'
+          $ref: "#/components/schemas/ToolsetAuthType"
         credentialItems:
           type: array
           description: Credential items, only for `credentials` type
           items:
-            $ref: '#/components/schemas/DynamicConfigItem'
+            $ref: "#/components/schemas/DynamicConfigItem"
         provider:
           type: string
           description: Auth provider, only for `oauth` type
@@ -10922,7 +10923,7 @@ components:
           type: string
           description: Toolset key
         type:
-          $ref: '#/components/schemas/GenericToolsetType'
+          $ref: "#/components/schemas/GenericToolsetType"
           description: Toolset type (regular, mcp, external_oauth)
         builtin:
           type: boolean
@@ -10945,7 +10946,7 @@ components:
           type: array
           description: Toolset tools
           items:
-            $ref: '#/components/schemas/ToolDefinition'
+            $ref: "#/components/schemas/ToolDefinition"
         requiresAuth:
           type: boolean
           description: Whether the toolset requires auth
@@ -10954,12 +10955,12 @@ components:
           type: array
           description: Toolset auth patterns
           items:
-            $ref: '#/components/schemas/AuthPattern'
+            $ref: "#/components/schemas/AuthPattern"
         configItems:
           type: array
           description: Toolset config items
           items:
-            $ref: '#/components/schemas/DynamicConfigItem'
+            $ref: "#/components/schemas/DynamicConfigItem"
     ToolsetInstance:
       type: object
       required:
@@ -10983,7 +10984,7 @@ components:
           type: boolean
           description: Whether the toolset is enabled
         authType:
-          $ref: '#/components/schemas/ToolsetAuthType'
+          $ref: "#/components/schemas/ToolsetAuthType"
           description: Toolset auth type
         authData:
           type: object
@@ -10995,7 +10996,7 @@ components:
           description: Toolset config
         definition:
           description: Toolset definition
-          $ref: '#/components/schemas/ToolsetDefinition'
+          $ref: "#/components/schemas/ToolsetDefinition"
         createdAt:
           type: string
           format: date-time
@@ -11006,22 +11007,22 @@ components:
           description: Toolset update timestamp
     ListToolsetInventoryResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               items:
-                $ref: '#/components/schemas/ToolsetDefinition'
+                $ref: "#/components/schemas/ToolsetDefinition"
     ListToolsetsResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               items:
-                $ref: '#/components/schemas/ToolsetInstance'
+                $ref: "#/components/schemas/ToolsetInstance"
     UpsertToolsetRequest:
       type: object
       properties:
@@ -11038,7 +11039,7 @@ components:
           type: boolean
           description: Whether the toolset is enabled
         authType:
-          $ref: '#/components/schemas/ToolsetAuthType'
+          $ref: "#/components/schemas/ToolsetAuthType"
           description: Toolset auth type
         authData:
           type: object
@@ -11058,11 +11059,11 @@ components:
             type: string
     UpsertToolsetResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/ToolsetInstance'
+              $ref: "#/components/schemas/ToolsetInstance"
     InitiateComposioConnectionResponse:
       type: object
       required:
@@ -11093,7 +11094,7 @@ components:
         - integrationId
       properties:
         status:
-          $ref: '#/components/schemas/ComposioConnectionStatus'
+          $ref: "#/components/schemas/ComposioConnectionStatus"
         connectedAccountId:
           type: string
           nullable: true
@@ -11124,7 +11125,7 @@ components:
         - creditCost
       properties:
         user:
-          $ref: '#/components/schemas/User'
+          $ref: "#/components/schemas/User"
           description: User who executed the tool
         toolName:
           type: string
@@ -11159,7 +11160,7 @@ components:
           type: array
           description: Files uploaded during post-processing
           items:
-            $ref: '#/components/schemas/DriveFile'
+            $ref: "#/components/schemas/DriveFile"
         creditCost:
           type: number
           description: Credit cost recorded
@@ -11195,7 +11196,7 @@ components:
         properties:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/ComposioSchemaProperty'
+            $ref: "#/components/schemas/ComposioSchemaProperty"
           description: Schema properties
         required:
           type: array
@@ -11241,7 +11242,7 @@ components:
           type: number
           description: Credit cost for tool execution
         toolsetType:
-          $ref: '#/components/schemas/GenericToolsetType'
+          $ref: "#/components/schemas/GenericToolsetType"
           description: Toolset type identifier
         toolsetKey:
           type: string
@@ -11263,7 +11264,7 @@ components:
         - name
       properties:
         type:
-          $ref: '#/components/schemas/GenericToolsetType'
+          $ref: "#/components/schemas/GenericToolsetType"
           description: Toolset type
         id:
           type: string
@@ -11278,10 +11279,10 @@ components:
           type: boolean
           description: Whether the toolset is uninstalled
         toolset:
-          $ref: '#/components/schemas/ToolsetInstance'
+          $ref: "#/components/schemas/ToolsetInstance"
           description: Toolset detail
         mcpServer:
-          $ref: '#/components/schemas/McpServerDTO'
+          $ref: "#/components/schemas/McpServerDTO"
           description: MCP server
         selectedTools:
           type: array
@@ -11290,22 +11291,22 @@ components:
             type: string
     ListToolsResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               items:
-                $ref: '#/components/schemas/GenericToolset'
+                $ref: "#/components/schemas/GenericToolset"
     ListUserToolsResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               items:
-                $ref: '#/components/schemas/UserTool'
+                $ref: "#/components/schemas/UserTool"
     UserTool:
       type: object
       properties:
@@ -11328,10 +11329,10 @@ components:
           type: string
           description: Tool domain for favicon
         toolset:
-          $ref: '#/components/schemas/GenericToolset'
+          $ref: "#/components/schemas/GenericToolset"
           description: Full toolset data (only for authorized tools)
         definition:
-          $ref: '#/components/schemas/ToolsetDefinition'
+          $ref: "#/components/schemas/ToolsetDefinition"
           description: Toolset definition (for unauthorized tools)
     DeleteToolsetRequest:
       type: object
@@ -11343,14 +11344,14 @@ components:
           description: Toolset ID
     GetToolCallResultResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: object
               properties:
                 result:
-                  $ref: '#/components/schemas/ToolCallResult'
+                  $ref: "#/components/schemas/ToolCallResult"
     DocumentInterface:
       type: object
       properties:
@@ -11366,13 +11367,13 @@ components:
           description: Metadata associated with the document.
     InMemorySearchResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               items:
-                $ref: '#/components/schemas/DocumentInterface'
+                $ref: "#/components/schemas/DocumentInterface"
     CanvasNodeType:
       type: string
       enum:
@@ -11442,17 +11443,17 @@ components:
           description: Node ID
         type:
           description: Node type
-          $ref: '#/components/schemas/CanvasNodeType'
+          $ref: "#/components/schemas/CanvasNodeType"
         position:
-          $ref: '#/components/schemas/XYPosition'
+          $ref: "#/components/schemas/XYPosition"
           description: Node position
         offsetPosition:
-          $ref: '#/components/schemas/XYPosition'
+          $ref: "#/components/schemas/XYPosition"
           description: Node offset position
         data:
           type: object
           description: Node data
-          $ref: '#/components/schemas/CanvasNodeData'
+          $ref: "#/components/schemas/CanvasNodeData"
         style:
           type: object
           description: Node style
@@ -11500,7 +11501,7 @@ components:
           example: "canvas-456"
         sourceCanvasData:
           description: Source canvas data
-          $ref: '#/components/schemas/RawCanvasData'
+          $ref: "#/components/schemas/RawCanvasData"
         createNewCanvas:
           description: Whether to create a new canvas
           type: boolean
@@ -11516,7 +11517,7 @@ components:
           type: array
           description: Workflow variables
           items:
-            $ref: '#/components/schemas/WorkflowVariable'
+            $ref: "#/components/schemas/WorkflowVariable"
         startNodes:
           type: array
           description: Start node IDs
@@ -11525,7 +11526,7 @@ components:
             example: "node-123"
     InitializeWorkflowResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
@@ -11574,7 +11575,7 @@ components:
           description: Node title
         status:
           description: Node status
-          $ref: '#/components/schemas/ActionStatus'
+          $ref: "#/components/schemas/ActionStatus"
         progress:
           type: number
           description: Node progress
@@ -11611,7 +11612,7 @@ components:
           type: string
           description: Workflow title
         status:
-          $ref: '#/components/schemas/WorkflowExecutionStatus'
+          $ref: "#/components/schemas/WorkflowExecutionStatus"
           description: Workflow status
         abortedByUser:
           type: boolean
@@ -11620,7 +11621,7 @@ components:
           type: array
           description: Node executions
           items:
-            $ref: '#/components/schemas/WorkflowNodeExecution'
+            $ref: "#/components/schemas/WorkflowNodeExecution"
         appId:
           type: string
           description: Workflow app ID
@@ -11634,12 +11635,12 @@ components:
           description: Workflow update timestamp
     GetWorkflowDetailResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: object
-              $ref: '#/components/schemas/WorkflowExecution'
+              $ref: "#/components/schemas/WorkflowExecution"
     CreateWorkflowAppRequest:
       type: object
       required:
@@ -11666,7 +11667,7 @@ components:
           type: array
           description: Workflow app variables
           items:
-            $ref: '#/components/schemas/WorkflowVariable'
+            $ref: "#/components/schemas/WorkflowVariable"
         resultNodeIds:
           type: array
           description: Result node IDs
@@ -11711,7 +11712,7 @@ components:
           description: Workflow app description
         owner:
           description: Workflow app owner
-          $ref: '#/components/schemas/ShareUser'
+          $ref: "#/components/schemas/ShareUser"
         canvasId:
           type: string
           description: Canvas ID
@@ -11722,7 +11723,7 @@ components:
           type: array
           description: Workflow app variables
           items:
-            $ref: '#/components/schemas/WorkflowVariable'
+            $ref: "#/components/schemas/WorkflowVariable"
         resultNodeIds:
           type: array
           description: Result node IDs
@@ -11749,32 +11750,32 @@ components:
           format: date-time
           description: Workflow app update timestamp
         voucherTriggerResult:
-          $ref: '#/components/schemas/VoucherTriggerResult'
+          $ref: "#/components/schemas/VoucherTriggerResult"
           description: Voucher trigger result when publishing to community
     CreateWorkflowAppResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/WorkflowApp'
+              $ref: "#/components/schemas/WorkflowApp"
     GetWorkflowAppDetailResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/WorkflowApp'
+              $ref: "#/components/schemas/WorkflowApp"
     ListWorkflowAppsResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: List of workflow apps
               items:
-                $ref: '#/components/schemas/WorkflowApp'
+                $ref: "#/components/schemas/WorkflowApp"
     TemplateGenerationStatus:
       type: string
       description: Template generation status
@@ -11787,7 +11788,7 @@ components:
       example: "completed"
     GetTemplateGenerationStatusResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           required:
             - data
@@ -11800,7 +11801,7 @@ components:
                 - createdAt
               properties:
                 status:
-                  $ref: '#/components/schemas/TemplateGenerationStatus'
+                  $ref: "#/components/schemas/TemplateGenerationStatus"
                 templateContent:
                   type: string
                   nullable: true
@@ -11830,7 +11831,7 @@ components:
           type: array
           description: Workflow app variables
           items:
-            $ref: '#/components/schemas/WorkflowVariable'
+            $ref: "#/components/schemas/WorkflowVariable"
     ExecuteWorkflowAppResult:
       type: object
       required:
@@ -11841,11 +11842,11 @@ components:
           description: Workflow execution ID
     ExecuteWorkflowAppResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/ExecuteWorkflowAppResult'
+              $ref: "#/components/schemas/ExecuteWorkflowAppResult"
     ValueType:
       type: string
       enum:
@@ -11862,7 +11863,7 @@ components:
           description: Resource name
         fileType:
           description: Resource file type
-          $ref: '#/components/schemas/VariableResourceType'
+          $ref: "#/components/schemas/VariableResourceType"
         fileId:
           type: string
           description: DriveFile ID (primary identifier for resource)
@@ -11879,13 +11880,13 @@ components:
       properties:
         type:
           description: Variable type
-          $ref: '#/components/schemas/ValueType'
+          $ref: "#/components/schemas/ValueType"
         text:
           type: string
           description: Variable text value (for text type)
         resource:
           description: Variable resource value (for resource type)
-          $ref: '#/components/schemas/ResourceValue'
+          $ref: "#/components/schemas/ResourceValue"
     VariableResourceType:
       type: string
       enum:
@@ -11911,7 +11912,7 @@ components:
         value:
           type: array
           items:
-            $ref: '#/components/schemas/VariableValue'
+            $ref: "#/components/schemas/VariableValue"
           description: Variable values
         description:
           type: string
@@ -11949,18 +11950,18 @@ components:
         resourceTypes:
           type: array
           items:
-            $ref: '#/components/schemas/VariableResourceType'
+            $ref: "#/components/schemas/VariableResourceType"
           description: Supported resource types (only valid when variable type is resource)
     GetWorkflowVariablesResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: List of workflow variables
               items:
-                $ref: '#/components/schemas/WorkflowVariable'
+                $ref: "#/components/schemas/WorkflowVariable"
     UpdateWorkflowVariablesRequest:
       type: object
       required:
@@ -11974,20 +11975,20 @@ components:
           type: array
           description: List of workflow variables
           items:
-            $ref: '#/components/schemas/WorkflowVariable'
+            $ref: "#/components/schemas/WorkflowVariable"
         archiveOldFiles:
           type: boolean
           description: Whether to archive existing drive files associated with old resource variables before updating
     UpdateWorkflowVariablesResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: Updated list of workflow variables
               items:
-                $ref: '#/components/schemas/WorkflowVariable'
+                $ref: "#/components/schemas/WorkflowVariable"
     DriveFileCategory:
       type: string
       enum:
@@ -12028,13 +12029,13 @@ components:
           type: string
           description: Drive file type
         category:
-          $ref: '#/components/schemas/DriveFileCategory'
+          $ref: "#/components/schemas/DriveFileCategory"
           description: Drive file category
         source:
-          $ref: '#/components/schemas/DriveFileSource'
+          $ref: "#/components/schemas/DriveFileSource"
           description: Drive file source
         scope:
-          $ref: '#/components/schemas/DriveFileScope'
+          $ref: "#/components/schemas/DriveFileScope"
           description: Drive file scope
         size:
           type: number
@@ -12070,14 +12071,14 @@ components:
           description: Private access URL for the file (requires authentication)
     ListDriveFilesResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: List of drive files
               items:
-                $ref: '#/components/schemas/DriveFile'
+                $ref: "#/components/schemas/DriveFile"
     UpsertDriveFileRequest:
       type: object
       required:
@@ -12109,7 +12110,7 @@ components:
           type: string
           description: External URL to download from
         source:
-          $ref: '#/components/schemas/DriveFileSource'
+          $ref: "#/components/schemas/DriveFileSource"
           description: File source
         variableId:
           type: string
@@ -12136,24 +12137,24 @@ components:
           type: array
           description: List of drive files
           items:
-            $ref: '#/components/schemas/UpsertDriveFileRequest'
+            $ref: "#/components/schemas/UpsertDriveFileRequest"
     BatchCreateDriveFilesResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               description: List of drive files
               items:
-                $ref: '#/components/schemas/DriveFile'
+                $ref: "#/components/schemas/DriveFile"
     UpsertDriveFileResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/DriveFile'
+              $ref: "#/components/schemas/DriveFile"
     DeleteDriveFileRequest:
       type: object
       required:
@@ -12193,7 +12194,7 @@ components:
         canvasId:
           type: string
           description: Canvas ID to generate template for
-          pattern: '^[a-zA-Z0-9_-]+$'
+          pattern: "^[a-zA-Z0-9_-]+$"
           example: "canvas-123"
 
     AppTemplateResult:
@@ -12213,7 +12214,7 @@ components:
           type: array
           description: List of related workflow variables used in the template
           items:
-            $ref: '#/components/schemas/WorkflowVariable'
+            $ref: "#/components/schemas/WorkflowVariable"
         metadata:
           type: object
           required:
@@ -12410,20 +12411,31 @@ components:
       type: object
       description: RJSF UI schema for controlling form appearance and behavior
       properties:
-        'ui:widget':
+        "ui:widget":
           type: string
           description: Widget type override
-          enum: [text, textarea, select, radio, checkbox, checkboxes, date, email, password]
+          enum:
+            [
+              text,
+              textarea,
+              select,
+              radio,
+              checkbox,
+              checkboxes,
+              date,
+              email,
+              password,
+            ]
           example: "textarea"
-        'ui:placeholder':
+        "ui:placeholder":
           type: string
           description: Input placeholder text
           example: "Please enter content..."
-        'ui:help':
+        "ui:help":
           type: string
           description: Help text displayed below the field
           example: "This field is required"
-        'ui:options':
+        "ui:options":
           type: object
           description: Widget-specific options (can include emoji, layout settings, etc.)
           properties:
@@ -12466,7 +12478,7 @@ components:
           type: boolean
           description: Whether billing is enabled
         type:
-          $ref: '#/components/schemas/BillingType'
+          $ref: "#/components/schemas/BillingType"
         creditsPerCall:
           type: number
           description: Credits per call (for PER_CALL type)
@@ -12509,7 +12521,7 @@ components:
         - type
       properties:
         type:
-          $ref: '#/components/schemas/SchemaPropertyType'
+          $ref: "#/components/schemas/SchemaPropertyType"
         description:
           type: string
           description: Property description
@@ -12518,19 +12530,19 @@ components:
           description: Whether this property is a resource reference
         format:
           type: string
-          description: 'Format for the property value. For resources: base64, url, binary, text. For strings: date-time, uri, email, etc.'
-          example: 'binary'
+          description: "Format for the property value. For resources: base64, url, binary, text. For strings: date-time, uri, email, etc."
+          example: "binary"
         const:
           description: Constant value for discriminator matching in oneOf/anyOf
         oneOf:
           type: array
           items:
-            $ref: '#/components/schemas/SchemaProperty'
+            $ref: "#/components/schemas/SchemaProperty"
           description: One of the listed schemas must match
         anyOf:
           type: array
           items:
-            $ref: '#/components/schemas/SchemaProperty'
+            $ref: "#/components/schemas/SchemaProperty"
           description: Any of the listed schemas can match
         minLength:
           type: number
@@ -12557,10 +12569,10 @@ components:
         properties:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/SchemaProperty'
+            $ref: "#/components/schemas/SchemaProperty"
           description: Nested properties (for object type)
         items:
-          $ref: '#/components/schemas/SchemaProperty'
+          $ref: "#/components/schemas/SchemaProperty"
         required:
           type: array
           items:
@@ -12582,7 +12594,7 @@ components:
         properties:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/SchemaProperty'
+            $ref: "#/components/schemas/SchemaProperty"
           description: Schema properties
         required:
           type: array
@@ -12597,7 +12609,7 @@ components:
 
     # Deprecated: Use JsonSchema instead
     ResponseSchema:
-      $ref: '#/components/schemas/JsonSchema'
+      $ref: "#/components/schemas/JsonSchema"
 
     ResourceField:
       type: object
@@ -12609,15 +12621,15 @@ components:
           type: string
           description: JSONPath to the resource field
         type:
-          $ref: '#/components/schemas/ToolResourceType'
+          $ref: "#/components/schemas/ToolResourceType"
           description: Resource type hint (optional, can be inferred from file MIME type)
         isArray:
           type: boolean
           description: Whether this field is an array of resources
         format:
           type: string
-          description: 'Format to convert resource content to (default is binary). Options: base64, url, binary, text'
-          example: 'binary'
+          description: "Format to convert resource content to (default is binary). Options: base64, url, binary, text"
+          example: "binary"
 
     # Tool Configuration
     HttpMethod:
@@ -12655,7 +12667,7 @@ components:
           type: string
           description: API endpoint URL
         method:
-          $ref: '#/components/schemas/HttpMethod'
+          $ref: "#/components/schemas/HttpMethod"
         schema:
           type: string
           description: Input parameter schema (JSON string)
@@ -12663,7 +12675,7 @@ components:
           type: string
           description: Response schema for resource identification (JSON string)
         billing:
-          $ref: '#/components/schemas/BillingConfig'
+          $ref: "#/components/schemas/BillingConfig"
         customHandler:
           type: string
           description: Custom handler class name (optional)
@@ -12719,11 +12731,11 @@ components:
           type: string
           description: Display name
         credentials:
-          $ref: '#/components/schemas/CredentialConfig'
+          $ref: "#/components/schemas/CredentialConfig"
         methods:
           type: array
           items:
-            $ref: '#/components/schemas/ToolMethodConfig'
+            $ref: "#/components/schemas/ToolMethodConfig"
           description: Tool methods
         version:
           type: number
@@ -12758,13 +12770,13 @@ components:
           type: string
           description: API endpoint URL
         method:
-          $ref: '#/components/schemas/HttpMethod'
+          $ref: "#/components/schemas/HttpMethod"
         schema:
-          $ref: '#/components/schemas/JsonSchema'
+          $ref: "#/components/schemas/JsonSchema"
         responseSchema:
-          $ref: '#/components/schemas/ResponseSchema'
+          $ref: "#/components/schemas/ResponseSchema"
         billing:
-          $ref: '#/components/schemas/BillingConfig'
+          $ref: "#/components/schemas/BillingConfig"
         customHandler:
           type: string
           description: Custom handler class name
@@ -12804,11 +12816,11 @@ components:
           type: string
           description: Display name
         credentials:
-          $ref: '#/components/schemas/CredentialConfig'
+          $ref: "#/components/schemas/CredentialConfig"
         methods:
           type: array
           items:
-            $ref: '#/components/schemas/ParsedMethodConfig'
+            $ref: "#/components/schemas/ParsedMethodConfig"
           description: Parsed methods with JSON schemas
         version:
           type: number
@@ -12833,7 +12845,7 @@ components:
           type: string
           description: Configuration MD5 hash
         config:
-          $ref: '#/components/schemas/ToolsetConfig'
+          $ref: "#/components/schemas/ToolsetConfig"
         timestamp:
           type: string
           format: date-time
@@ -12850,7 +12862,7 @@ components:
           type: string
           description: API endpoint or SDK method path
         method:
-          $ref: '#/components/schemas/HttpMethod'
+          $ref: "#/components/schemas/HttpMethod"
         params:
           type: object
           additionalProperties: true
@@ -12913,7 +12925,7 @@ components:
           type: string
           description: HTTP proxy URL
         polling:
-          $ref: '#/components/schemas/PollingConfig'
+          $ref: "#/components/schemas/PollingConfig"
           description: Polling configuration for async task tracking
 
     PollingConfig:
@@ -12932,7 +12944,7 @@ components:
         statusBody:
           type: object
           additionalProperties: true
-          description: 'Request body template for POST status check. Supports placeholders like {task_id}, {req_key}'
+          description: "Request body template for POST status check. Supports placeholders like {task_id}, {req_key}"
         taskIdPath:
           type: string
           description: 'JSON path to extract task ID from initial response (e.g., "data.task_id")'
@@ -13057,7 +13069,7 @@ components:
           additionalProperties: true
           description: Input parameters
         user:
-          $ref: '#/components/schemas/User'
+          $ref: "#/components/schemas/User"
         metadata:
           type: object
           additionalProperties: true
@@ -13095,9 +13107,9 @@ components:
           type: string
           description: File ID in database (DriveService)
         resourceType:
-          $ref: '#/components/schemas/ToolResourceType'
+          $ref: "#/components/schemas/ToolResourceType"
         metadata:
-          $ref: '#/components/schemas/UploadResultMetadata'
+          $ref: "#/components/schemas/UploadResultMetadata"
 
     HandlerResponse:
       type: object
@@ -13132,7 +13144,7 @@ components:
           type: array
           description: List of drive files generated by the tool
           items:
-            $ref: '#/components/schemas/DriveFile'
+            $ref: "#/components/schemas/DriveFile"
         url:
           type: string
           description: CDN/public URL
@@ -13153,14 +13165,14 @@ components:
         - startTime
       properties:
         user:
-          $ref: '#/components/schemas/User'
+          $ref: "#/components/schemas/User"
           description: User information for billing and tracking
         credentials:
           type: object
           additionalProperties: true
           description: Credentials for authentication
         responseSchema:
-          $ref: '#/components/schemas/ResponseSchema'
+          $ref: "#/components/schemas/ResponseSchema"
           description: Response schema for identifying resource fields via traversal
         startTime:
           type: number
@@ -13175,13 +13187,13 @@ components:
           type: string
           description: API endpoint URL
         method:
-          $ref: '#/components/schemas/HttpMethod'
+          $ref: "#/components/schemas/HttpMethod"
         credentials:
           type: object
           additionalProperties: true
           description: Credentials
         responseSchema:
-          $ref: '#/components/schemas/ResponseSchema'
+          $ref: "#/components/schemas/ResponseSchema"
           description: Response schema for identifying resource fields via traversal
         timeout:
           type: number
@@ -13241,7 +13253,7 @@ components:
           type: string
           description: Method name
         type:
-          $ref: '#/components/schemas/ToolResourceType'
+          $ref: "#/components/schemas/ToolResourceType"
         mimeType:
           type: string
           description: MIME type
@@ -13322,7 +13334,7 @@ components:
           type: string
           description: Method name
         billing:
-          $ref: '#/components/schemas/ToolMetadataBilling'
+          $ref: "#/components/schemas/ToolMetadataBilling"
         resourceTypes:
           type: array
           items:
@@ -13358,7 +13370,7 @@ components:
         - toolsetId
       properties:
         user:
-          $ref: '#/components/schemas/ToolInstantiationContextUser'
+          $ref: "#/components/schemas/ToolInstantiationContextUser"
         toolsetId:
           type: string
           description: Toolset ID
@@ -13391,7 +13403,7 @@ components:
         - user
       properties:
         user:
-          $ref: '#/components/schemas/ToolExecutionContextUser'
+          $ref: "#/components/schemas/ToolExecutionContextUser"
         parentResultId:
           type: string
           description: Parent result ID (for workflow chaining)
@@ -13455,7 +13467,7 @@ components:
         schema:
           description: Zod schema for parameters (runtime only, not serializable)
         metadata:
-          $ref: '#/components/schemas/ToolMetadata'
+          $ref: "#/components/schemas/ToolMetadata"
 
     InstantiatedTool:
       type: object
@@ -13465,7 +13477,7 @@ components:
         tool:
           description: LangChain DynamicStructuredTool instance (runtime only, not serializable)
         metadata:
-          $ref: '#/components/schemas/ToolMetadata'
+          $ref: "#/components/schemas/ToolMetadata"
         configVersion:
           type: number
           description: Configuration version
@@ -13503,7 +13515,7 @@ components:
         definitions:
           type: array
           items:
-            $ref: '#/components/schemas/DynamicToolDefinition'
+            $ref: "#/components/schemas/DynamicToolDefinition"
           description: Tool definitions
         configVersion:
           type: number
@@ -13560,9 +13572,9 @@ components:
           type: number
           description: Discount percentage (10-90)
         status:
-          $ref: '#/components/schemas/VoucherStatus'
+          $ref: "#/components/schemas/VoucherStatus"
         source:
-          $ref: '#/components/schemas/VoucherSource'
+          $ref: "#/components/schemas/VoucherSource"
         sourceId:
           type: string
           description: Source entity ID (template ID or invitation ID)
@@ -13621,7 +13633,7 @@ components:
           type: number
           description: Discount percentage
         status:
-          $ref: '#/components/schemas/InvitationStatus'
+          $ref: "#/components/schemas/InvitationStatus"
         claimedAt:
           type: string
           format: date-time
@@ -13645,7 +13657,7 @@ components:
         - score
       properties:
         voucher:
-          $ref: '#/components/schemas/Voucher'
+          $ref: "#/components/schemas/Voucher"
         score:
           type: number
           description: LLM score (0-100)
@@ -13668,10 +13680,10 @@ components:
         vouchers:
           type: array
           items:
-            $ref: '#/components/schemas/Voucher'
+            $ref: "#/components/schemas/Voucher"
           description: List of available vouchers
         bestVoucher:
-          $ref: '#/components/schemas/Voucher'
+          $ref: "#/components/schemas/Voucher"
           description: Best available voucher (highest discount)
 
     VoucherValidateResult:
@@ -13683,7 +13695,7 @@ components:
           type: boolean
           description: Whether voucher is valid
         voucher:
-          $ref: '#/components/schemas/Voucher'
+          $ref: "#/components/schemas/Voucher"
           description: Voucher details
         reason:
           type: string
@@ -13695,7 +13707,7 @@ components:
         - invitation
       properties:
         invitation:
-          $ref: '#/components/schemas/VoucherInvitation'
+          $ref: "#/components/schemas/VoucherInvitation"
           description: Created invitation
 
     ClaimInvitationResult:
@@ -13707,7 +13719,7 @@ components:
           type: boolean
           description: Whether claim was successful
         voucher:
-          $ref: '#/components/schemas/Voucher'
+          $ref: "#/components/schemas/Voucher"
           description: Created voucher for invitee
         inviterName:
           type: string
@@ -13746,37 +13758,37 @@ components:
 
     GetAvailableVouchersResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/VoucherAvailableResult'
+              $ref: "#/components/schemas/VoucherAvailableResult"
 
     ListUserVouchersResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
               type: array
               items:
-                $ref: '#/components/schemas/Voucher'
+                $ref: "#/components/schemas/Voucher"
 
     ValidateVoucherResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/VoucherValidateResult'
+              $ref: "#/components/schemas/VoucherValidateResult"
 
     CreateVoucherInvitationResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/CreateInvitationResult'
+              $ref: "#/components/schemas/CreateInvitationResult"
 
     VerifyInvitationResult:
       type: object
@@ -13787,9 +13799,9 @@ components:
           type: boolean
           description: Whether the invitation is valid and can be claimed
         invitation:
-          $ref: '#/components/schemas/VoucherInvitation'
+          $ref: "#/components/schemas/VoucherInvitation"
         voucher:
-          $ref: '#/components/schemas/Voucher'
+          $ref: "#/components/schemas/Voucher"
           description: The original voucher being shared (for unclaimed invitations)
         claimedByUid:
           type: string
@@ -13803,19 +13815,19 @@ components:
 
     VerifyVoucherInvitationResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/VerifyInvitationResult'
+              $ref: "#/components/schemas/VerifyInvitationResult"
 
     ClaimVoucherInvitationResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/ClaimInvitationResult'
+              $ref: "#/components/schemas/ClaimInvitationResult"
 
     TriggerVoucherRequest:
       type: object
@@ -13837,11 +13849,11 @@ components:
 
     TriggerVoucherResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseResponse'
+        - $ref: "#/components/schemas/BaseResponse"
         - type: object
           properties:
             data:
-              $ref: '#/components/schemas/VoucherTriggerResult'
+              $ref: "#/components/schemas/VoucherTriggerResult"
 
   securitySchemes:
     api_key:

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -8223,6 +8223,10 @@ export const ModelCapabilitiesSchema = {
       type: 'boolean',
       description: 'Whether this model supports context caching',
     },
+    supportToolChoice: {
+      type: 'boolean',
+      description: 'Whether this model supports tool_choice parameter',
+    },
     image: {
       type: 'boolean',
       description: 'Whether this model supports image generation',

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -5813,6 +5813,10 @@ export type ModelCapabilities = {
    */
   contextCaching?: boolean;
   /**
+   * Whether this model supports tool_choice parameter
+   */
+  supportToolChoice?: boolean;
+  /**
    * Whether this model supports image generation
    */
   image?: boolean;

--- a/packages/skill-template/src/skills/agent.ts
+++ b/packages/skill-template/src/skills/agent.ts
@@ -158,12 +158,20 @@ export class Agent extends BaseSkill {
 
       if (validTools.length > 0) {
         const toolNames = validTools.map((tool) => tool.name);
-        this.engine.logger.info(
-          `Binding ${validTools.length} valid tools to LLM with tool_choice="auto": [${toolNames.join(', ')}]`,
-        );
+
+        // Check if the model supports tool_choice parameter
+        // Claude Haiku models on Bedrock do not support tool_choice
+        const agentModelInfo = config?.configurable?.modelConfigMap?.agent;
+        const supportsToolChoice = agentModelInfo?.capabilities?.supportToolChoice !== false;
+
         // Use tool_choice="auto" to force LLM to decide when to use tools
         // This ensures proper tool_calls format generation
-        llmForGraph = baseLlm.bindTools(validTools, { tool_choice: 'auto' });
+        const bindOptions = supportsToolChoice ? { tool_choice: 'auto' } : undefined;
+        this.engine.logger.info(
+          `Binding ${validTools.length} valid tools to LLM with options: ${JSON.stringify(bindOptions)}: [${toolNames.join(', ')}]`,
+        );
+        llmForGraph = baseLlm.bindTools(validTools, bindOptions);
+
         actualToolNodeInstance = new ToolNode(validTools);
         availableToolsForNode = validTools;
       } else {


### PR DESCRIPTION
## Summary

This PR fixes an issue where Bedrock Claude Haiku models fail when binding tools because they don't support the tool_choice parameter. The system now checks model capabilities and only uses tool_choice when the model supports it.

## Changes

- Added supportToolChoice field to ModelCapabilities in OpenAPI schema
- Implemented dynamic detection in agent tool binding to check model capabilities
- Conditionally apply tool_choice parameter only when model supports it
- Updated tool binding logic to handle models without tool_choice support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for model support of the tool_choice parameter, enabling more intelligent and adaptive tool binding during agent execution based on actual model capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->