### PR TITLE
[REF-1021] fix: Support Claude Haiku models without tool_choice parameter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,9 @@
   "[typescript]": {
     "editor.defaultFormatter": "prettier.prettier-vscode"
   },
-
+  "[yaml]": {
+    "editor.formatOnSave": false
+  },
   "typescript.tsserver.maxTsServerMemory": 8192,
   "files.exclude": {
     "**/node_modules/**": true,

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -10104,6 +10104,9 @@ components:
         contextCaching:
           type: boolean
           description: Whether this model supports context caching
+        supportToolChoice:
+          type: boolean
+          description: Whether this model supports tool_choice parameter
         image:
           type: boolean
           description: Whether this model supports image generation

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -8223,6 +8223,10 @@ export const ModelCapabilitiesSchema = {
       type: 'boolean',
       description: 'Whether this model supports context caching',
     },
+    supportToolChoice: {
+      type: 'boolean',
+      description: 'Whether this model supports tool_choice parameter',
+    },
     image: {
       type: 'boolean',
       description: 'Whether this model supports image generation',

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -5813,6 +5813,10 @@ export type ModelCapabilities = {
    */
   contextCaching?: boolean;
   /**
+   * Whether this model supports tool_choice parameter
+   */
+  supportToolChoice?: boolean;
+  /**
    * Whether this model supports image generation
    */
   image?: boolean;


### PR DESCRIPTION
## Summary

This PR fixes an issue where Claude Haiku models on AWS Bedrock fail when using tool_choice parameter. The system now checks model capabilities and only uses tool_choice when the model supports it.

## Changes

- Added supportToolChoice field to ModelCapabilities type in OpenAPI schema
- Updated agent tool binding logic to conditionally apply tool_choice based on model capabilities
- Models without supportToolChoice capability will bind tools without tool_choice parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents now adapt tool binding based on model capabilities, automatically falling back to a tool-free language-model path when needed.
  * Model capability metadata now includes an explicit flag indicating support for tool-choice parameters.

* **Chores**
  * Added a VS Code editor setting to disable format-on-save for YAML files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->