### PR TITLE
[REF-982] feat: Add auto model trial for new users

### DIFF
--- a/apps/api/src/modules/provider/auto-model-router.service.ts
+++ b/apps/api/src/modules/provider/auto-model-router.service.ts
@@ -28,6 +28,13 @@ export interface RuleCondition {
    * Used for matching specific toolsets like "fal_image", "fal_video", etc.
    */
   toolsetInventoryKeys?: string[];
+
+  /**
+   * Whether the user is in the auto model trial period.
+   * If true, this rule matches only when the user is within their first N Auto model requests.
+   * Used for routing new users to powerful models during their trial period.
+   */
+  inAutoModelTrial?: boolean;
 }
 
 export enum RoutingStrategy {
@@ -94,6 +101,12 @@ export interface RoutingContext {
    * Used for tool-based routing to check for specific tools
    */
   toolsets?: GenericToolset[];
+
+  /**
+   * Whether the user is in the auto model trial period.
+   * Set by AutoModelTrialService based on user's Auto model usage count.
+   */
+  inAutoModelTrial?: boolean;
 }
 
 /**
@@ -151,6 +164,11 @@ class RuleRouter {
       if (!this.matchToolsetInventoryKeys(condition.toolsetInventoryKeys)) {
         return false;
       }
+    }
+
+    // Match auto model trial condition
+    if (condition.inAutoModelTrial) {
+      return this.context.inAutoModelTrial ?? false;
     }
 
     return true;

--- a/apps/api/src/modules/provider/auto-model-trial.service.ts
+++ b/apps/api/src/modules/provider/auto-model-trial.service.ts
@@ -1,0 +1,145 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service';
+import { RedisService } from '../common/redis.service';
+import { getAutoModelTrialCount } from '@refly/utils';
+
+/**
+ * Result of checking user's auto model trial status
+ */
+export interface TrialStatus {
+  /**
+   * Whether the user is in the trial period
+   */
+  inTrial: boolean;
+
+  /**
+   * Current usage count (before this request)
+   */
+  currentCount: number;
+}
+
+/**
+ * Service for managing auto model trial for new users.
+ * Tracks user's Auto model usage count and determines if they are in trial period.
+ *
+ * Uses Redis caching for performance with DB fallback for cache misses.
+ */
+@Injectable()
+export class AutoModelTrialService {
+  private readonly logger = new Logger(AutoModelTrialService.name);
+
+  /**
+   * Redis key prefix for trial counter
+   */
+  private readonly CACHE_KEY_PREFIX = 'auto-model-trial:';
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly redis: RedisService,
+  ) {}
+
+  /**
+   * Check if user is in the auto model trial period and update the counter.
+   *
+   * Flow:
+   * 1. Check Redis cache for the counter
+   * 2. If cache miss, query DB to get historical count
+   * 3. Determine trial status based on count
+   * 4. Increment Redis counter (async)
+   *
+   * @param userId - User ID to check
+   * @returns TrialStatus indicating if user is in trial and current count
+   */
+  async checkAndUpdateTrialStatus(userId: string): Promise<TrialStatus> {
+    const trialCount = getAutoModelTrialCount();
+    const cacheTtl = 30 * 24 * 60 * 60; // 30 days
+    const cacheKey = this.buildCacheKey(userId);
+
+    try {
+      // Try to get current count from Redis
+      const cachedCount = await this.redis.get(cacheKey);
+
+      let currentCount: number;
+
+      if (cachedCount !== null) {
+        // Cache hit - parse the counter value
+        currentCount = Number.parseInt(cachedCount, 10);
+        if (Number.isNaN(currentCount)) {
+          currentCount = 0;
+        }
+      } else {
+        // Cache miss - query DB to get historical count
+        currentCount = await this.getCountFromDatabase(userId, trialCount);
+
+        // Initialize Redis cache with DB count
+        await this.redis.setex(cacheKey, cacheTtl, String(currentCount));
+      }
+
+      // Determine if user is in trial period (count < threshold)
+      const inTrial = currentCount < trialCount;
+
+      // Increment counter asynchronously (fire and forget)
+      this.incrementCounterAsync(cacheKey, cacheTtl);
+
+      return { inTrial, currentCount };
+    } catch (error) {
+      this.logger.warn(`Failed to check trial status for user ${userId}`, error);
+      // On error, default to not in trial to avoid blocking
+      return { inTrial: false, currentCount: 0 };
+    }
+  }
+
+  /**
+   * Get count from database with optimized query.
+   * Uses findMany with take limit instead of count(*) for performance.
+   *
+   * @param userId - User ID
+   * @param trialCount - Trial threshold (e.g., 20)
+   * @returns Number of routing results found (capped at trialCount + 1)
+   */
+  private async getCountFromDatabase(userId: string, trialCount: number): Promise<number> {
+    try {
+      // Query at most (trialCount + 1) records to determine if trial is over
+      // This uses the (userId, createdAt) index and limits scan to constant rows
+      const results = await this.prisma.autoModelRoutingResult.findMany({
+        where: { userId },
+        take: trialCount + 1,
+        select: { pk: true },
+        orderBy: { createdAt: 'asc' },
+      });
+
+      return results.length;
+    } catch (error) {
+      this.logger.warn(`Failed to get trial count from DB for user ${userId}`, error);
+      return 0;
+    }
+  }
+
+  /**
+   * Increment the trial counter in Redis asynchronously.
+   * Uses INCR + EXPIRE to update counter and refresh TTL.
+   *
+   * @param cacheKey - Redis key
+   * @param ttlSeconds - TTL in seconds
+   */
+  private incrementCounterAsync(cacheKey: string, ttlSeconds: number): void {
+    // Fire and forget - don't await
+    this.redis
+      .incr(cacheKey)
+      .then(async (newValue) => {
+        // Refresh TTL after increment
+        await this.redis.expire(cacheKey, ttlSeconds);
+        return newValue;
+      })
+      .catch((error) => {
+        this.logger.warn(`Failed to increment trial counter: ${cacheKey}`, error);
+      });
+  }
+
+  /**
+   * Build Redis cache key for user's trial counter
+   */
+  private buildCacheKey(userId: string): string {
+    return `${this.CACHE_KEY_PREFIX}${userId}`;
+  }
+}

--- a/apps/api/src/modules/provider/provider.module.ts
+++ b/apps/api/src/modules/provider/provider.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 import { ProviderController } from './provider.controller';
 import { ProviderService } from './provider.service';
 import { AutoModelRoutingService } from './auto-model-router.service';
+import { AutoModelTrialService } from './auto-model-trial.service';
 import { CommonModule } from '../common/common.module';
 
 @Module({
   imports: [CommonModule],
   controllers: [ProviderController],
-  providers: [ProviderService, AutoModelRoutingService],
-  exports: [ProviderService, AutoModelRoutingService],
+  providers: [ProviderService, AutoModelRoutingService, AutoModelTrialService],
+  exports: [ProviderService, AutoModelRoutingService, AutoModelTrialService],
 })
 export class ProviderModule {}

--- a/packages/utils/src/auto-model.ts
+++ b/packages/utils/src/auto-model.ts
@@ -48,6 +48,15 @@ export const selectAutoModel = (): string | null => {
 };
 
 /**
+ * Get auto model trial count threshold from environment variable
+ * @returns Number of trial requests for new users (default: 20)
+ */
+export const getAutoModelTrialCount = (): number => {
+  const trialCount = Number.parseInt(process.env.AUTO_MODEL_TRIAL_COUNT || '20', 10);
+  return Number.isNaN(trialCount) ? 20 : trialCount;
+};
+
+/**
  * Tool-based routing configuration
  */
 export interface ToolBasedRoutingConfig {


### PR DESCRIPTION
## Summary

This PR adds auto model trial support for new users. When users use Auto model for the first 20 times, they will be routed to powerful models like Claude Opus 4.5 to ensure a high-quality initial experience.

## Changes

- Added AutoModelTrialService to track user's Auto model usage count with Redis caching
- Extended routing rules to support inAutoModelTrial condition matching
- Integrated trial status check in SkillService routing flow
- Added getAutoModelTrialCount utility function for configurable threshold
- Optimized DB queries to use findMany with take limit instead of count(*) for better performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced auto-model trial system that tracks per-user trial usage and status.
  * Enhanced auto-model routing to evaluate trial-period constraints during rule matching decisions.
  * Implemented efficient caching for optimized trial status lookups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->