### PR TITLE
[REF-1025] fix: add onBeforeUpload callback to FileInput and MixedTextEditor com…ponents

### DIFF
--- a/packages/ai-workspace-common/src/components/workflow-app/mixed-text-editor/file-input.tsx
+++ b/packages/ai-workspace-common/src/components/workflow-app/mixed-text-editor/file-input.tsx
@@ -5,17 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useFileUpload } from '../../canvas/workflow-variables';
 import { getFileType } from '../../canvas/workflow-variables/utils';
 
-interface FileInputProps {
-  id: string;
-  value?: any;
-  placeholder?: string;
-  onChange: (value: any) => void;
-  disabled?: boolean;
-  accept?: string;
-  isDefaultValue?: boolean; // Whether this is a default value
-  isModified?: boolean; // Whether the value has been modified by user
-  onUploadingChange?: (uploading: boolean) => void; // Callback when uploading state changes
-}
+import { FileInputProps } from './types';
 
 // Loading dots animation component
 const LoadingDots: React.FC = () => {
@@ -73,6 +63,7 @@ const FileInput: React.FC<FileInputProps> = memo(
     isDefaultValue = false,
     isModified = false,
     onUploadingChange,
+    onBeforeUpload,
   }) => {
     const { t } = useTranslation();
     const [isHovered, setIsHovered] = useState(false);
@@ -83,6 +74,11 @@ const FileInput: React.FC<FileInputProps> = memo(
 
     const handleFileChange = useCallback(
       async (file: File) => {
+        // Check if upload should be prevented
+        if (onBeforeUpload && !onBeforeUpload()) {
+          return;
+        }
+
         try {
           setUploading(true);
           onUploadingChange?.(true);
@@ -115,6 +111,18 @@ const FileInput: React.FC<FileInputProps> = memo(
     const handleMouseLeave = useCallback(() => {
       setIsHovered(false);
     }, []);
+
+    const handleClick = useCallback(
+      (e: React.MouseEvent) => {
+        // Check if upload should be prevented on click
+        if (onBeforeUpload && !onBeforeUpload()) {
+          e.preventDefault();
+          e.stopPropagation();
+          return;
+        }
+      },
+      [onBeforeUpload],
+    );
 
     return (
       <Upload
@@ -159,6 +167,7 @@ const FileInput: React.FC<FileInputProps> = memo(
           }}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
+          onClick={handleClick}
           title={
             uploading
               ? t('common.upload.notification.uploading', { count: 1 })

--- a/packages/ai-workspace-common/src/components/workflow-app/mixed-text-editor/mixed-text-editor.tsx
+++ b/packages/ai-workspace-common/src/components/workflow-app/mixed-text-editor/mixed-text-editor.tsx
@@ -15,6 +15,7 @@ const MixedTextEditor: React.FC<MixedTextEditorProps> = memo(
     disabled = false,
     originalVariables = [] as WorkflowVariable[],
     onUploadingChange,
+    onBeforeUpload,
   }) => {
     const { t } = useTranslation();
     // Track uploading state for multiple file inputs
@@ -206,6 +207,7 @@ const MixedTextEditor: React.FC<MixedTextEditorProps> = memo(
                   isDefaultValue={segment.isDefaultValue}
                   isModified={segment.isModified}
                   onUploadingChange={(uploading) => handleFileUploadingChange(fileId, uploading)}
+                  onBeforeUpload={onBeforeUpload}
                 />
               );
             }

--- a/packages/ai-workspace-common/src/components/workflow-app/mixed-text-editor/types.ts
+++ b/packages/ai-workspace-common/src/components/workflow-app/mixed-text-editor/types.ts
@@ -18,6 +18,7 @@ export interface MixedTextEditorProps {
   disabled?: boolean;
   originalVariables?: WorkflowVariable[]; // Original variable values for state comparison
   onUploadingChange?: (uploading: boolean) => void; // Callback when any file is uploading
+  onBeforeUpload?: () => boolean; // Callback before file upload, return false to prevent upload
 }
 
 export interface VariableInputProps {
@@ -28,4 +29,17 @@ export interface VariableInputProps {
   disabled?: boolean;
   isDefaultValue?: boolean; // Whether this is a default value
   isModified?: boolean; // Whether the value has been modified by user
+}
+
+export interface FileInputProps {
+  id: string;
+  value?: any;
+  placeholder?: string;
+  onChange: (value: any) => void;
+  disabled?: boolean;
+  accept?: string;
+  isDefaultValue?: boolean; // Whether this is a default value
+  isModified?: boolean; // Whether the value has been modified by user
+  onUploadingChange?: (uploading: boolean) => void; // Callback when uploading state changes
+  onBeforeUpload?: () => boolean; // Callback before file upload, return false to prevent upload
 }

--- a/packages/web-core/src/pages/workflow-app/workflow-app-form.tsx
+++ b/packages/web-core/src/pages/workflow-app/workflow-app-form.tsx
@@ -423,6 +423,13 @@ export const WorkflowAPPForm = ({
   // Handle file upload for resource type variables
   const handleFileUpload = useCallback(
     async (file: File, variableName: string) => {
+      // Check if user is logged in
+      if (!isLogin) {
+        storeSignupEntryPoint('template_detail');
+        setLoginModalOpen(true);
+        return false;
+      }
+
       const currentFileList = variableValues[variableName] || [];
       const result = await uploadFile(file, currentFileList);
 
@@ -481,6 +488,13 @@ export const WorkflowAPPForm = ({
   // Handle file removal for resource type variables
   const handleFileRemove = useCallback(
     (file: UploadFile, variableName: string) => {
+      // Check if user is logged in
+      if (!isLogin) {
+        storeSignupEntryPoint('template_detail');
+        setLoginModalOpen(true);
+        return;
+      }
+
       const currentFileList = variableValues[variableName] || [];
       const newFileList = currentFileList.filter((f: UploadFile) => f.uid !== file.uid);
       handleValueChange(variableName, newFileList);
@@ -488,12 +502,19 @@ export const WorkflowAPPForm = ({
         [variableName]: newFileList,
       });
     },
-    [variableValues, handleValueChange],
+    [variableValues, handleValueChange, isLogin, setLoginModalOpen],
   );
 
   // Handle file refresh for resource type variables
   const handleRefreshFile = useCallback(
     (variableName: string) => {
+      // Check if user is logged in
+      if (!isLogin) {
+        storeSignupEntryPoint('template_detail');
+        setLoginModalOpen(true);
+        return;
+      }
+
       const currentFileList = variableValues[variableName] || [];
       // Find the variable to get its resourceTypes
       const variable = workflowVariables.find((v) => v.name === variableName);
@@ -515,7 +536,16 @@ export const WorkflowAPPForm = ({
         variableId,
       );
     },
-    [refreshFile, variableValues, handleValueChange, form, workflowVariables, canvasId],
+    [
+      refreshFile,
+      variableValues,
+      handleValueChange,
+      form,
+      workflowVariables,
+      canvasId,
+      isLogin,
+      setLoginModalOpen,
+    ],
   );
 
   // Initialize template variables when effectiveTemplateContent changes
@@ -847,6 +877,17 @@ export const WorkflowAPPForm = ({
     setIsFileUploading(uploading);
   }, []);
 
+  // Handle before file upload check
+  const handleBeforeFileUpload = useCallback(() => {
+    // Check if user is logged in
+    if (!isLogin) {
+      storeSignupEntryPoint('template_detail');
+      setLoginModalOpen(true);
+      return false;
+    }
+    return true;
+  }, [isLogin, setLoginModalOpen]);
+
   // Separate executing state (for loading indicator) from disabled state
   const isExecuting = loading || isRunning;
   const isRunButtonDisabled = isExecuting || isFileUploading;
@@ -1004,6 +1045,7 @@ export const WorkflowAPPForm = ({
                   disabled={isFormDisabled}
                   originalVariables={workflowVariables}
                   onUploadingChange={handleFileUploadingChange}
+                  onBeforeUpload={handleBeforeFileUpload}
                 />
                 {/* Tools Dependency Form */}
                 {workflowApp?.canvasData && (


### PR DESCRIPTION
- Introduced onBeforeUpload prop to FileInputProps for pre-upload validation.
- Implemented onBeforeUpload in FileInput and MixedTextEditor to prevent uploads based on user login status.
- Enhanced file upload handling in WorkflowAPPForm to check user login before proceeding with uploads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced pre-upload validation for file uploads
* File uploads now require user authentication; unauthenticated users will be prompted to log in before uploading files

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->