### PR TITLE
[REF-1046] fix: Optimize pandoc conversion to reduce file size

### DIFF
--- a/apps/api/src/modules/knowledge/parsers/pandoc.parser.ts
+++ b/apps/api/src/modules/knowledge/parsers/pandoc.parser.ts
@@ -182,14 +182,8 @@ export class PandocParser extends BaseParser {
 
       if (this.options.format === 'docx') {
         // For DOCX, try markdown output with pipe tables first
-        pandocArgs = [
-          '-f',
-          this.options.format,
-          '-t',
-          'markdown+pipe_tables',
-          '--wrap=none',
-          '--columns=100000', // Very wide columns to prevent text wrapping
-        ];
+        // DO NOT use --columns=100000, as it will introduce thousands of hyphens and balloons the file size.
+        pandocArgs = ['-f', this.options.format, '-t', 'markdown+pipe_tables', '--wrap=none'];
       } else {
         // For other formats, use markdown
         pandocArgs = [
@@ -198,7 +192,6 @@ export class PandocParser extends BaseParser {
           '-t',
           'markdown-raw_html+pipe_tables',
           '--wrap=none',
-          '--columns=10000',
         ];
       }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue in the Pandoc parser where using a very large `--columns` value introduced excessive hyphens and significantly increased file size during conversion.

## Changes

- Removed `--columns` argument from Pandoc conversion settings for DOCX and other formats
- Added a warning comment to explain why large column values should be avoided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document conversion by removing hard column-width constraints, enhancing compatibility and performance across various formats.
  * Updated internal notes to warn against using excessively large column values and clarify conversion behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->