### PR TITLE
[REF-1060] fix: Add recursive processing for nested union types in Gemini schema simplification

### DIFF
--- a/packages/skill-template/src/utils/schema-simplifier.ts
+++ b/packages/skill-template/src/utils/schema-simplifier.ts
@@ -102,6 +102,20 @@ function simplifyUnionTypesForGemini(schema: JsonSchema | SchemaProperty): void 
         // Remove union keywords
         schema.oneOf = undefined;
         schema.anyOf = undefined;
+
+        // IMPORTANT: Recursively process the selected option's nested structures
+        // The selected option may contain nested union types that need to be simplified
+        if (schema.properties && typeof schema.properties === 'object') {
+          for (const key in schema.properties) {
+            simplifyUnionTypesForGemini(schema.properties[key]);
+          }
+        }
+        if (schema.type === 'array' && schema.items) {
+          if (typeof schema.items === 'object' && !Array.isArray(schema.items)) {
+            simplifyUnionTypesForGemini(schema.items);
+          }
+        }
+
         return;
       }
     }
@@ -112,6 +126,19 @@ function simplifyUnionTypesForGemini(schema: JsonSchema | SchemaProperty): void 
       Object.assign(schema, objectOption);
       schema.oneOf = undefined;
       schema.anyOf = undefined;
+
+      // IMPORTANT: Recursively process the selected option's nested structures
+      if (schema.properties && typeof schema.properties === 'object') {
+        for (const key in schema.properties) {
+          simplifyUnionTypesForGemini(schema.properties[key]);
+        }
+      }
+      if (schema.type === 'array' && schema.items) {
+        if (typeof schema.items === 'object' && !Array.isArray(schema.items)) {
+          simplifyUnionTypesForGemini(schema.items);
+        }
+      }
+
       return;
     }
 
@@ -121,6 +148,18 @@ function simplifyUnionTypesForGemini(schema: JsonSchema | SchemaProperty): void 
       Object.assign(schema, nonNullOption);
       schema.oneOf = undefined;
       schema.anyOf = undefined;
+
+      // IMPORTANT: Recursively process the selected option's nested structures
+      if (schema.properties && typeof schema.properties === 'object') {
+        for (const key in schema.properties) {
+          simplifyUnionTypesForGemini(schema.properties[key]);
+        }
+      }
+      if (schema.type === 'array' && schema.items) {
+        if (typeof schema.items === 'object' && !Array.isArray(schema.items)) {
+          simplifyUnionTypesForGemini(schema.items);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where deeply nested union types in tool schemas were not fully simplified for Gemini compatibility. The schema simplifier was only processing the first level of union types, leaving nested union types in the simplified schema which caused Gemini to reject the tool definitions.

## Changes

- Add recursive processing after Object.assign in union type replacement
- Process nested properties and array items after selecting union option
- Ensure all nested union types are flattened for Gemini compatibility
- Fix deep nesting issue where union types remained in simplified schema

The fix ensures that when a union type is replaced with one of its options, the selected option's nested structures are also recursively simplified, preventing any union types from remaining in the final schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced recursive processing of nested union types and complex structures in schema simplification, improving accuracy throughout the entire schema hierarchy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->