### PR TITLE
[REF-1060] fix: Add recursive processing for nested union types in Gemini schema simplification

### DIFF
--- a/packages/skill-template/src/utils/schema-simplifier.ts
+++ b/packages/skill-template/src/utils/schema-simplifier.ts
@@ -102,6 +102,20 @@ function simplifyUnionTypesForGemini(schema: JsonSchema | SchemaProperty): void 
         // Remove union keywords
         schema.oneOf = undefined;
         schema.anyOf = undefined;
+
+        // IMPORTANT: Recursively process the selected option's nested structures
+        // The selected option may contain nested union types that need to be simplified
+        if (schema.properties && typeof schema.properties === 'object') {
+          for (const key in schema.properties) {
+            simplifyUnionTypesForGemini(schema.properties[key]);
+          }
+        }
+        if (schema.type === 'array' && schema.items) {
+          if (typeof schema.items === 'object' && !Array.isArray(schema.items)) {
+            simplifyUnionTypesForGemini(schema.items);
+          }
+        }
+
         return;
       }
     }
@@ -112,6 +126,19 @@ function simplifyUnionTypesForGemini(schema: JsonSchema | SchemaProperty): void 
       Object.assign(schema, objectOption);
       schema.oneOf = undefined;
       schema.anyOf = undefined;
+
+      // IMPORTANT: Recursively process the selected option's nested structures
+      if (schema.properties && typeof schema.properties === 'object') {
+        for (const key in schema.properties) {
+          simplifyUnionTypesForGemini(schema.properties[key]);
+        }
+      }
+      if (schema.type === 'array' && schema.items) {
+        if (typeof schema.items === 'object' && !Array.isArray(schema.items)) {
+          simplifyUnionTypesForGemini(schema.items);
+        }
+      }
+
       return;
     }
 
@@ -121,6 +148,18 @@ function simplifyUnionTypesForGemini(schema: JsonSchema | SchemaProperty): void 
       Object.assign(schema, nonNullOption);
       schema.oneOf = undefined;
       schema.anyOf = undefined;
+
+      // IMPORTANT: Recursively process the selected option's nested structures
+      if (schema.properties && typeof schema.properties === 'object') {
+        for (const key in schema.properties) {
+          simplifyUnionTypesForGemini(schema.properties[key]);
+        }
+      }
+      if (schema.type === 'array' && schema.items) {
+        if (typeof schema.items === 'object' && !Array.isArray(schema.items)) {
+          simplifyUnionTypesForGemini(schema.items);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where Gemini 3 failed to call Notion tools due to deeply nested union types in tool schemas. The schema simplifier was only processing the first level of union types, leaving nested union types that caused conversion errors.

## Changes

- Add recursive processing for schema properties after union type simplification
- Add recursive processing for array items after union type simplification  
- Ensure all nested union types are flattened to a structure that Gemini can handle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved schema simplification to provide more thorough processing of complex nested data structures, ensuring complete traversal and consistent handling across all schema types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->