### PR TITLE
[REF-1080] fix: Add retry logic for Gemini 3 Pro Preview socket hang up errors

### DIFF
--- a/apps/api/src/modules/notification/notification.service.ts
+++ b/apps/api/src/modules/notification/notification.service.ts
@@ -5,7 +5,7 @@ import { SendEmailRequest, User } from '@refly/openapi-schema';
 import { PrismaService } from '../common/prisma.service';
 import { ParamsError } from '@refly/errors';
 import { MiscService } from '../misc/misc.service';
-import { guard } from '../../utils/guard';
+import { guard } from '@refly/utils';
 
 @Injectable()
 export class NotificationService {

--- a/apps/api/src/modules/tool/sandbox/scalebox.factory.ts
+++ b/apps/api/src/modules/tool/sandbox/scalebox.factory.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PinoLogger } from 'nestjs-pino';
 
-import { guard } from '../../../utils/guard';
+import { guard } from '@refly/utils';
 import { Config } from '../../config/config.decorator';
 import { DEFAULT_WRAPPER_TYPE, WrapperType } from './scalebox.constants';
 import { SandboxRequestParamsException } from './scalebox.exception';

--- a/apps/api/src/modules/tool/sandbox/scalebox.lock.ts
+++ b/apps/api/src/modules/tool/sandbox/scalebox.lock.ts
@@ -21,7 +21,7 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PinoLogger } from 'nestjs-pino';
 
-import { guard } from '../../../utils/guard';
+import { guard } from '@refly/utils';
 import { RedisService } from '../../common/redis.service';
 import { Config } from '../../config/config.decorator';
 import { SandboxLockTimeoutException } from './scalebox.exception';

--- a/apps/api/src/modules/tool/sandbox/scalebox.pool.ts
+++ b/apps/api/src/modules/tool/sandbox/scalebox.pool.ts
@@ -4,7 +4,7 @@ import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { PinoLogger } from 'nestjs-pino';
 
-import { guard } from '../../../utils/guard';
+import { guard } from '@refly/utils';
 import { QUEUE_SCALEBOX_PAUSE, QUEUE_SCALEBOX_KILL } from '../../../utils/const';
 import { Config } from '../../config/config.decorator';
 

--- a/apps/api/src/modules/tool/sandbox/scalebox.processor.ts
+++ b/apps/api/src/modules/tool/sandbox/scalebox.processor.ts
@@ -5,7 +5,7 @@ import { Job } from 'bullmq';
 import { PinoLogger } from 'nestjs-pino';
 import { storage, Store } from 'nestjs-pino/storage';
 
-import { guard } from '../../../utils/guard';
+import { guard } from '@refly/utils';
 import {
   QUEUE_SCALEBOX_EXECUTE,
   QUEUE_SCALEBOX_PAUSE,

--- a/apps/api/src/modules/tool/sandbox/scalebox.service.ts
+++ b/apps/api/src/modules/tool/sandbox/scalebox.service.ts
@@ -12,7 +12,7 @@ import {
 } from '@refly/openapi-schema';
 import { runModuleInitWithTimeoutAndRetry } from '@refly/utils';
 
-import { guard } from '../../../utils/guard';
+import { guard } from '@refly/utils';
 import { QUEUE_SCALEBOX_EXECUTE } from '../../../utils/const';
 import { Config } from '../../config/config.decorator';
 import { DriveService } from '../../drive/drive.service';

--- a/apps/api/src/modules/tool/sandbox/wrapper/base.ts
+++ b/apps/api/src/modules/tool/sandbox/wrapper/base.ts
@@ -2,7 +2,7 @@ import { Sandbox } from '@scalebox/sdk';
 import { PinoLogger } from 'nestjs-pino';
 import { SandboxExecuteParams } from '@refly/openapi-schema';
 
-import { guard } from '../../../../utils/guard';
+import { guard } from '@refly/utils';
 import { Trace } from '@refly/observability';
 import {
   SandboxLifecycleException,

--- a/apps/api/src/modules/tool/sandbox/wrapper/executor.ts
+++ b/apps/api/src/modules/tool/sandbox/wrapper/executor.ts
@@ -1,7 +1,7 @@
 import { PinoLogger } from 'nestjs-pino';
 import { SandboxExecuteParams } from '@refly/openapi-schema';
 
-import { guard } from '../../../../utils/guard';
+import { guard } from '@refly/utils';
 import { Trace } from '@refly/observability';
 import {
   SandboxExecutionFailedException,

--- a/apps/api/src/modules/tool/sandbox/wrapper/interpreter.ts
+++ b/apps/api/src/modules/tool/sandbox/wrapper/interpreter.ts
@@ -1,7 +1,7 @@
 import { PinoLogger } from 'nestjs-pino';
 import { SandboxExecuteParams } from '@refly/openapi-schema';
 
-import { guard } from '../../../../utils/guard';
+import { guard } from '@refly/utils';
 import { Trace } from '@refly/observability';
 import { SandboxExecutionFailedException, SandboxMountException } from '../scalebox.exception';
 import { SANDBOX_DRIVE_MOUNT_POINT, SCALEBOX_DEFAULTS } from '../scalebox.constants';

--- a/packages/providers/src/llm/index.ts
+++ b/packages/providers/src/llm/index.ts
@@ -1,6 +1,7 @@
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { LLMModelConfig } from '@refly/openapi-schema';
 import { EnhancedChatOpenAI } from './openai';
+import { EnhancedChatVertexAI } from './vertex';
 import { ChatOllama } from '@langchain/ollama';
 import { ChatFireworks } from '@langchain/community/chat_models/fireworks';
 import { BaseProvider } from '../types';
@@ -8,7 +9,6 @@ import { AzureChatOpenAI, AzureOpenAIInput, OpenAIBaseInput } from '@langchain/o
 import { ChatBedrockConverse } from '@langchain/aws';
 import { wrapChatModelWithMonitoring } from '../monitoring/langfuse-wrapper';
 import { ProviderMisconfigurationError } from '@refly/errors';
-import { ChatVertexAI } from '@langchain/google-vertexai';
 
 interface BedrockApiKeyConfig {
   accessKeyId: string;
@@ -132,7 +132,7 @@ export const getChatModel = (
       break;
     }
     case 'vertex': {
-      model = new ChatVertexAI({
+      model = new EnhancedChatVertexAI({
         model: config.modelId,
         location: 'global',
         maxOutputTokens: config?.maxOutput,

--- a/packages/providers/src/llm/vertex.ts
+++ b/packages/providers/src/llm/vertex.ts
@@ -1,0 +1,81 @@
+import type { BaseMessage } from '@langchain/core/messages';
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
+import { ChatVertexAI } from '@langchain/google-vertexai';
+import { guard, type RetryConfig } from '@refly/utils';
+
+/**
+ * Default retryable network error codes for Vertex AI
+ * Based on common network errors that can be safely retried
+ */
+const RETRYABLE_ERROR_PATTERNS = [
+  'socket hang up',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'ECONNREFUSED',
+  'EPIPE',
+  'EAI_AGAIN',
+];
+
+/**
+ * Check if an error is retryable based on error message patterns
+ */
+const isRetryableError = (error: unknown): boolean => {
+  if (!error) return false;
+
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  return RETRYABLE_ERROR_PATTERNS.some((pattern) =>
+    errorMessage?.toLowerCase()?.includes(pattern?.toLowerCase()),
+  );
+};
+
+/**
+ * Create retry configuration for Vertex AI with logging
+ */
+const createRetryConfig = (context: string): RetryConfig => ({
+  maxAttempts: 3,
+  initialDelay: 1000,
+  maxDelay: 5000,
+  backoffFactor: 2,
+  retryIf: isRetryableError,
+  onRetry: (error, attempt) => {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `[EnhancedChatVertexAI] Vertex AI ${context} failed (attempt ${attempt}/3): ${errorMessage}. Retrying...`,
+    );
+  },
+});
+
+/**
+ * Enhanced ChatVertexAI with automatic retry logic for network errors
+ *
+ * This wrapper adds exponential backoff retry for transient network errors.
+ */
+export class EnhancedChatVertexAI extends ChatVertexAI {
+  /**
+   * Override _generate to add retry logic for non-streaming calls
+   */
+  async _generate(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: any,
+  ): Promise<any> {
+    return await guard
+      .retry(() => super._generate(messages, options, runManager), createRetryConfig('request'))
+      .orThrow();
+  }
+
+  /**
+   * Override _streamResponseChunks to add retry logic for streaming calls
+   */
+  async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: any,
+  ): AsyncGenerator<ChatGenerationChunk> {
+    yield* guard.retryGenerator(
+      () => super._streamResponseChunks(messages, options, runManager),
+      createRetryConfig('streaming request'),
+    );
+  }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -27,6 +27,7 @@ export * from './artifact';
 export * from './validator';
 export * from './query-processor';
 export * from './drive-file-mapper';
+export * from './guard';
 // Note: token.ts uses tiktoken (WASM) which is not compatible with frontend bundlers
 // Backend should import directly: import { countToken } from '@refly/utils/src/token'
 export * from './on-module-init';


### PR DESCRIPTION
## Summary

This PR fixes socket hang up errors when calling Gemini 3 Pro Preview API by adding automatic retry logic with exponential backoff.

## Changes

- Created EnhancedChatVertexAI wrapper class that extends ChatVertexAI with retry support
- Moved guard utility from apps/api to packages/utils so it can be used across packages
- Updated getChatModel to use EnhancedChatVertexAI for all Vertex AI model calls
- Added retry logic for both streaming and non-streaming API requests
- Updated sandbox module imports to reference the new guard location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retry logic for Vertex AI LLM calls with exponential backoff to handle transient network issues.
  * Introduced retry support for async generator operations in utility functions.

* **Chores**
  * Reorganized internal utility module imports to use centralized package exports instead of relative paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->