### PR TITLE
[REF-1018] fix: Resolve file export timeout caused by HTML fragments in content

### DIFF
--- a/apps/api/src/modules/knowledge/parsers/docx.parser.ts
+++ b/apps/api/src/modules/knowledge/parsers/docx.parser.ts
@@ -50,8 +50,9 @@ export class DocxParser extends BaseParser {
     const outputFile = path.join(tempDir, 'output.docx');
 
     try {
-      // 设置 pandoc 参数，从 markdown 转换为 docx
-      const pandocArgs = ['-f', 'markdown', '-o', outputFile, '--standalone'];
+      // Convert Markdown to DOCX using pandoc. Avoid parsing HTML fragments.
+      const inputFormat = 'markdown' + '-raw_html' + '-raw_tex' + '-tex_math_dollars';
+      const pandocArgs = ['-f', inputFormat, '-o', outputFile, '--standalone'];
 
       const pandoc = spawn('pandoc', pandocArgs);
 

--- a/apps/api/src/modules/knowledge/parsers/pdf.parser.ts
+++ b/apps/api/src/modules/knowledge/parsers/pdf.parser.ts
@@ -50,9 +50,9 @@ export class PdfParser extends BaseParser {
     const outputFile = path.join(tempDir, 'output.pdf');
 
     try {
-      // 设置 pandoc 参数，从 markdown 转换为 pdf
-      const pandocArgs = ['-f', 'markdown', '-o', outputFile, '--pdf-engine=wkhtmltopdf'];
-
+      // Convert Markdown to PDF using pandoc. Avoid parsing HTML fragments.
+      const inputFormat = 'markdown' + '-raw_html' + '-raw_tex' + '-tex_math_dollars';
+      const pandocArgs = ['-f', inputFormat, '-o', outputFile, '--pdf-engine=wkhtmltopdf'];
       const pandoc = spawn('pandoc', pandocArgs);
 
       return new Promise((resolve, reject) => {
@@ -80,7 +80,7 @@ export class PdfParser extends BaseParser {
             resolve({
               content: '', // 可以为空或包含文本预览
               buffer: pdfBuffer, // 存储二进制数据
-              metadata: { format: 'docx' },
+              metadata: { format: 'pdf' },
             });
           } finally {
             await this.cleanupTempDir(tempDir);


### PR DESCRIPTION
## Summary

This PR fixes a file export timeout issue where pandoc would hang when processing content containing HTML fragments. The solution updates the pandoc input format to explicitly skip parsing raw HTML, TeX, and math dollar expressions.

## Changes

- Updated DOCX and PDF parsers to use `markdown-raw_html-raw_tex-tex_math_dollars` input format
- Fixed incorrect metadata format in PDF parser output (was `docx`, now correctly `pdf`)
- Replaced Chinese comments with English documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced DOCX and PDF document parsing with improved support for complex formatting elements. Better handling of raw HTML content, TeX markup, and mathematical expressions within documents. Documents with specialized formatting and mathematical notation are now processed with improved accuracy and content preservation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->