### PR TITLE
[REF-1080] fix: Check Gemini model for ChatVertexAI child classes

### DIFF
--- a/packages/providers/src/llm/index.ts
+++ b/packages/providers/src/llm/index.ts
@@ -154,3 +154,4 @@ export const getChatModel = (
 };
 
 export { BaseChatModel };
+export { isGeminiModel } from './vertex';

--- a/packages/providers/src/llm/vertex.ts
+++ b/packages/providers/src/llm/vertex.ts
@@ -79,3 +79,14 @@ export class EnhancedChatVertexAI extends ChatVertexAI {
     );
   }
 }
+
+/**
+ * Check if the given LLM is a Gemini model (Vertex AI)
+ * This includes ChatVertexAI and all its subclasses (e.g., EnhancedChatVertexAI)
+ *
+ * @param llm - The language model to check
+ * @returns true if the model is a Gemini/Vertex AI model
+ */
+export function isGeminiModel(llm: any): boolean {
+  return llm instanceof ChatVertexAI;
+}


### PR DESCRIPTION
## Summary

This PR extracts the `isGeminiModel` function from the Agent skill class into a shared utility function in the providers package. This improves code reusability and makes the model type checking logic available for use across different packages.

## Changes

- Added `isGeminiModel` helper function to `packages/providers/src/llm/vertex.ts` to check if a model is a Gemini/Vertex AI model
- Exported `isGeminiModel` from `packages/providers/src/llm/index.ts` for reuse
- Replaced the private `isGeminiModel` method in Agent skill with the shared utility function
- Updated imports in Agent skill to use the shared function from providers package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved Gemini/Vertex model detection into a shared, exported utility and removed duplicate internal checks.
  * Updated agent code to use the shared helper for model detection.
  * No functional changes; runtime behavior remains the same while reducing duplication and improving maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->