### PR TITLE
[REF-1154] fix(schedule): Update schedule button to use canvas title instead of …

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/schedule-button.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/schedule-button.tsx
@@ -367,7 +367,7 @@ const ScheduleButton = memo(({ canvasId }: ScheduleButtonProps) => {
 
         const requestData = {
           canvasId,
-          name: `Schedule for ${canvasResponse?.data?.title}`,
+          name: canvasResponse?.data?.title ?? '',
           cronExpression,
           scheduleConfig: scheduleConfigStr,
           timezone: userTimezone,


### PR DESCRIPTION
…ID for naming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schedule names now use the canvas title for both new and updated schedules, so scheduled items display meaningful, human-readable titles instead of internal identifiers—making them easier to find and manage in your workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->