### PR TITLE
[REF-794]: feat: Fetch the label text for mention tags in real-time

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/launchpad/rich-chat-input/mention-node-view.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/launchpad/rich-chat-input/mention-node-view.tsx
@@ -6,6 +6,8 @@ import { NodeIcon } from '@refly-packages/ai-workspace-common/components/canvas/
 import { X } from 'refly-icons';
 import type { CanvasNodeType } from '@refly/openapi-schema';
 import { ToolsetIcon } from '@refly-packages/ai-workspace-common/components/canvas/common/toolset-icon';
+import { useFindLatestVariableMetions } from '@refly-packages/ai-workspace-common/hooks/canvas';
+import type { MentionCommonData } from '@refly/utils/query-processor';
 import { MentionItemSource } from './const';
 import { AGENT_CONFIG_KEY_CLASSNAMES } from '@refly-packages/ai-workspace-common/components/canvas/nodes/shared/colors';
 
@@ -61,9 +63,26 @@ const getMentionClassName = (source: MentionItemSource) => {
 
 function MentionNodeViewBase(props: NodeViewProps) {
   const { node } = props;
-  const labelText = (node?.attrs?.label as string) ?? (node?.attrs?.id as string) ?? '';
+  const initialLabel = (node?.attrs?.label as string) ?? (node?.attrs?.id as string) ?? '';
   const source = node?.attrs?.source as MentionItemSource;
+  const variableId = node?.attrs?.id as string;
   const variableType = node?.attrs?.variableType as string;
+
+  const variableMentions = React.useMemo(() => {
+    if (source === 'variables' && variableId) {
+      return [
+        {
+          id: variableId,
+          type: 'var',
+          name: initialLabel,
+        },
+      ] as MentionCommonData[];
+    }
+    return [];
+  }, [source, variableId, initialLabel]);
+
+  const latestVariables = useFindLatestVariableMetions(variableMentions);
+  const labelText = (source === 'variables' && latestVariables?.[0]?.name) || initialLabel;
 
   return (
     <NodeViewWrapper

--- a/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/config-info-display.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/node-preview/skill-response/config-info-display.tsx
@@ -13,6 +13,7 @@ import { useCanvasNodesStoreShallow } from '@refly/stores';
 import { NodeIcon } from '@refly-packages/ai-workspace-common/components/canvas/nodes/shared/node-icon';
 import { AGENT_CONFIG_KEY_CLASSNAMES } from '@refly-packages/ai-workspace-common/components/canvas/nodes/shared/colors';
 import { useToolsetDefinition } from '@refly-packages/ai-workspace-common/hooks/use-toolset-definition';
+import { useFindLatestVariableMetions } from '@refly-packages/ai-workspace-common/hooks/canvas';
 
 interface ConfigInfoDisplayProps {
   readonly?: boolean;
@@ -80,6 +81,9 @@ export const ConfigInfoDisplay = memo(
       const mentions = parseMentionsFromQuery(prompt);
       return mentions.filter((item) => item.type === 'var');
     }, [prompt]);
+
+    const latestVariables = useFindLatestVariableMetions(variables);
+
     const escapeRegExp = useCallback(
       (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
       [],
@@ -172,7 +176,7 @@ export const ConfigInfoDisplay = memo(
             {t('agent.config.inputs')}
           </SectionTitle>
           <div className="flex flex-wrap gap-2">
-            {variables.map((variable: MentionCommonData, index) => (
+            {latestVariables.map((variable: MentionCommonData, index) => (
               <LabelItem
                 readonly={readonly}
                 key={`${variable.id}-${index}`}

--- a/packages/ai-workspace-common/src/components/canvas/nodes/shared/skill-response-content-preview.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/nodes/shared/skill-response-content-preview.tsx
@@ -14,6 +14,7 @@ import { useCanvasNodesStoreShallow } from '@refly/stores';
 import { NodeIcon } from './node-icon';
 import { useToolsetDefinition } from '@refly-packages/ai-workspace-common/hooks/use-toolset-definition';
 import { useQueryProcessor } from '@refly-packages/ai-workspace-common/hooks/use-query-processor';
+import { useFindLatestVariableMetions } from '@refly-packages/ai-workspace-common/hooks/canvas';
 
 interface SkillResponseContentPreviewProps {
   nodeId: string;
@@ -83,6 +84,7 @@ export const SkillResponseContentPreview = memo(
 
     // Extract input variable names from contextItems
     const variableMentions = parseMentionsFromQuery(query)?.filter((item) => item.type === 'var');
+    const latestVariables = useFindLatestVariableMetions(variableMentions);
 
     return (
       <div className={`flex flex-col gap-2 ${className}`}>
@@ -109,7 +111,7 @@ export const SkillResponseContentPreview = memo(
 
         <LabelDisplay
           title={t('canvas.skillResponse.config.input')}
-          labels={variableMentions.map((varName) => ({
+          labels={latestVariables.map((varName) => ({
             labeltext: varName.name,
             icon: <X size={12} className="flex-shrink-0" />,
           }))}

--- a/packages/ai-workspace-common/src/hooks/canvas/index.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/index.ts
@@ -15,6 +15,7 @@ export * from './use-find-website';
 export * from './use-find-images';
 export * from './use-find-code-artifact';
 export * from './use-find-thread-history';
+export * from './use-find-latest-variable-mentions';
 
 // Actions
 export * from './use-invoke-action';

--- a/packages/ai-workspace-common/src/hooks/canvas/use-find-latest-variable-mentions.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-find-latest-variable-mentions.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+import { useCanvasContext } from '@refly-packages/ai-workspace-common/context/canvas';
+import { useVariablesManagement } from '@refly-packages/ai-workspace-common/hooks/use-variables-management';
+import type { WorkflowVariable } from '@refly/openapi-schema';
+import { MentionCommonData } from '@refly/utils/query-processor';
+
+/**
+ * Hook to find a variable by its variableId from the workflow variables.
+ *
+ * @param variableId The ID of the variable to find
+ * @returns The found WorkflowVariable or undefined
+ */
+export const useFindLatestVariableMetions = (variableMentions?: MentionCommonData[]) => {
+  const { canvasId, shareData } = useCanvasContext();
+  const { data: variables } = useVariablesManagement(canvasId);
+
+  // Get workflow variables from shareData if available (for share page),
+  // otherwise fallback to variables from variables management
+  const workflowVariables = useMemo(
+    () => (shareData?.variables ?? variables) as WorkflowVariable[],
+    [shareData?.variables, variables],
+  );
+
+  return useMemo(() => {
+    if (!variableMentions || variableMentions.length === 0) return [];
+    const latestVariables = variableMentions.map((v) => {
+      const variable = workflowVariables.find((variable) => variable.variableId === v.id);
+      return variable ? { ...v, name: variable.name } : v;
+    });
+    return latestVariables;
+  }, [workflowVariables, variableMentions]);
+};


### PR DESCRIPTION
…play

- Integrated `useFindLatestVariableMentions` hook to retrieve the latest variable mentions in `MentionNodeViewBase`, improving label text accuracy.
- Updated `ConfigInfoDisplay` and `SkillResponseContentPreview` components to utilize the latest variable mentions for rendering, ensuring consistent display of variable data.
- Refactored variable mention logic to use memoization for performance optimization and prevent unnecessary re-renders.
- Ensured proper handling of optional chaining and default values throughout the components for robustness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Variable mentions and references now consistently display with their latest, current names throughout the application, including in chat input, skill response configurations, and variable previews.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->