### PR TITLE
[REF-1182] fix: correct signatures array slicing for Gemini 3 parallel tool calls

### DIFF
--- a/packages/skill-template/src/skills/agent.ts
+++ b/packages/skill-template/src/skills/agent.ts
@@ -351,14 +351,15 @@ export class Agent extends BaseSkill {
             const originalSignatures = (lastMessage as any).additional_kwargs?.signatures;
             const toolCallsCount = lastMessage.tool_calls?.length ?? 0;
 
-            // CRITICAL: Vertex AI (Gemini) requires a 1:1 mapping between tool_calls and signatures.
-            // When the response contains both text content and tool calls, the signatures array
-            // includes parts for text segments (usually empty strings) followed by tool signatures.
-            // If we clear the text content (to avoid 400 INVALID_ARGUMENT from mixed content),
-            // we MUST also remove the corresponding text segment signatures, otherwise the
-            // mismatch in array lengths will cause another 400 error.
+            // CRITICAL: Vertex AI (Gemini) requires the original non-empty signatures passed back
+            // LangChain extracts the first functionCall's signature and promotes it to signatures[0]
+            // When we clear text content (to avoid 400 INVALID_ARGUMENT from mixed content),
+            // we MUST trim the signatures array to remove redundant empty signatures.
             if (Array.isArray(originalSignatures) && originalSignatures.length > toolCallsCount) {
-              lastMessage.additional_kwargs.signatures = originalSignatures.slice(-toolCallsCount);
+              lastMessage.additional_kwargs.signatures = originalSignatures.slice(
+                0,
+                toolCallsCount,
+              );
             }
 
             // Clear content to avoid 400 INVALID_ARGUMENT when AIMessage has both text and tool_calls


### PR DESCRIPTION
## Summary

This PR fixes a bug where Gemini 3 parallel tool calls would return 400 errors due to incorrect signatures array slicing. The previous implementation used `slice(-N)` which removed the first valid signature, causing Vertex AI to reject the request.

## Changes

- Fix signatures array slicing from `slice(-toolCallsCount)` to `slice(0, toolCallsCount)` to preserve the first valid signature
- Update comments to explain LangChain's signature promotion behavior where the first functionCall's signature is promoted to signatures[0]
- Ensures the signatures array length matches tool_calls array length while keeping the required first signature for Vertex AI validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool call handling in Google Vertex AI (Gemini) integration to correctly select and preserve signature entries when processing multiple tool calls from the agent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->