### PR TITLE
[REF-1156] feat: optimize workflow agent file variable context loading

### DIFF
--- a/apps/api/src/modules/workflow/workflow.service.ts
+++ b/apps/api/src/modules/workflow/workflow.service.ts
@@ -333,17 +333,22 @@ export class WorkflowService {
       return;
     }
 
-    const { modelInfo, selectedToolsets, contextItems = [] } = metadata;
+    const { modelInfo, selectedToolsets, contextItems = [], referencedVariables = [] } = metadata;
 
     // Get workflow variables from canvas to resolve resource variable fileIds
     const workflowVariables = await this.canvasService.getWorkflowVariables(user, { canvasId });
+
+    // Filter workflow variables to only include explicitly referenced resource variables
+    const referencedResourceVars = workflowVariables.filter((variable) =>
+      referencedVariables.some((rv: any) => rv.variableId === variable.variableId),
+    );
 
     const context = convertContextItemsToInvokeParams(
       contextItems,
       connectToFilters
         .filter((filter) => filter.type === 'skillResponse')
         .map((filter) => filter.entityId),
-      workflowVariables,
+      referencedResourceVars,
     );
 
     // Prepare the invoke skill request

--- a/packages/ai-workspace-common/src/hooks/canvas/use-invoke-action.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-invoke-action.ts
@@ -19,7 +19,12 @@ import {
 } from '@refly/openapi-schema';
 import { useActionResultStore } from '@refly/stores';
 import { logEvent } from '@refly/telemetry-web';
-import { aggregateTokenUsage, detectActualTypeFromType, genActionResultID } from '@refly/utils';
+import {
+  aggregateTokenUsage,
+  detectActualTypeFromType,
+  genActionResultID,
+  processQueryWithMentions,
+} from '@refly/utils';
 import { ARTIFACT_TAG_CLOSED_REGEX, getArtifactContentAndAttributes } from '@refly/utils/artifact';
 import { useCallback, useEffect, useRef } from 'react';
 import {
@@ -800,11 +805,23 @@ export const useInvokeAction = (params?: { source?: string }) => {
       globalAbortControllersRef.current.set(resultId, controller);
       globalAbortedResultsRef.current.delete(resultId);
 
+      // Extract explicitly referenced resource variables from query
+      let referencedResourceVars = workflowVariables;
+      if (query && workflowVariables?.length > 0) {
+        const { resourceVars: referencedVariables } = processQueryWithMentions(query, {
+          variables: workflowVariables,
+        });
+        // Filter workflow variables to only include explicitly referenced resource variables
+        referencedResourceVars = workflowVariables.filter((variable) =>
+          referencedVariables.some((rv) => rv.variableId === variable.variableId),
+        );
+      }
+
       const upstreamAgentNodes = nodeId ? getUpstreamAgentNodes(nodeId) : [];
       const context = convertContextItemsToInvokeParams(
         contextItems ?? [],
         upstreamAgentNodes.map((node) => node.data?.entityId) ?? [],
-        workflowVariables, // Pass workflow variables for resolving resource variables
+        referencedResourceVars, // Pass only explicitly referenced resource variables
       );
 
       const param: InvokeSkillRequest = {

--- a/packages/canvas-common/src/context.ts
+++ b/packages/canvas-common/src/context.ts
@@ -157,7 +157,7 @@ const deduplicate = <T>(array: T[] | null | undefined, keyFn: (item: T) => strin
 export const convertContextItemsToInvokeParams = (
   items: IContextItem[],
   resultIds: string[],
-  workflowVariables?: WorkflowVariable[], // WorkflowVariable[] - accepting workflow variables for resolving resource variables
+  referencedVariables?: WorkflowVariable[], // Only process explicitly referenced resource variables
 ): SkillContext => {
   const purgedItems = purgeContextItems(items);
 
@@ -167,11 +167,11 @@ export const convertContextItemsToInvokeParams = (
     { fileId: string; variableId: string; variableName: string }
   >();
 
-  // Collect all files from resource variables
+  // Collect files only from explicitly referenced resource variables (referencedVariables)
   const filesFromVariables: SkillContextFileItem[] = [];
 
-  if (workflowVariables) {
-    for (const variable of workflowVariables) {
+  if (referencedVariables) {
+    for (const variable of referencedVariables) {
       if (variable.variableType === 'resource' && variable.value?.length > 0) {
         const fileId = variable.value[0]?.resource?.fileId;
         if (fileId) {

--- a/packages/canvas-common/src/workflow.ts
+++ b/packages/canvas-common/src/workflow.ts
@@ -157,7 +157,11 @@ export const prepareNodeExecutions = (params: {
           const originalQuery = String(
             metadata?.query ?? metadata?.structuredData?.query ?? node.data?.title ?? '',
           );
-          const { llmInputQuery, updatedQuery } = processQueryWithMentions(originalQuery, {
+          const {
+            llmInputQuery,
+            updatedQuery,
+            resourceVars: referencedVariables,
+          } = processQueryWithMentions(originalQuery, {
             replaceVars: true,
             variables,
             lookupToolsetDefinitionById,
@@ -165,6 +169,7 @@ export const prepareNodeExecutions = (params: {
           node.data.metadata = deepmerge(node.data.metadata, {
             query: updatedQuery,
             llmInputQuery,
+            referencedVariables,
           });
         }
 
@@ -182,13 +187,18 @@ export const prepareNodeExecutions = (params: {
         const originalQuery = String(
           metadata?.query ?? metadata?.structuredData?.query ?? node.data?.title ?? '',
         );
-        const { llmInputQuery, updatedQuery } = processQueryWithMentions(originalQuery, {
+        const {
+          llmInputQuery,
+          updatedQuery,
+          resourceVars: referencedVariables,
+        } = processQueryWithMentions(originalQuery, {
           replaceVars: true,
           variables,
         });
         node.data.metadata = deepmerge(node.data.metadata, {
           query: updatedQuery,
           llmInputQuery,
+          referencedVariables,
         });
       }
       return node;


### PR DESCRIPTION
## Summary

This PR optimizes file variable context loading in workflow Agent nodes. Previously, all file variables were automatically loaded into the user message even when not referenced, causing unnecessary context token usage. Now the system only loads file variables that are explicitly referenced in the prompt using `@var:name` syntax.

## Changes

- Store `resourceVars` in node metadata during `prepareNodeExecutions` to track explicitly referenced variables
- Update `convertContextItemsToInvokeParams` to accept `resourceVars` instead of all `workflowVariables`
- Filter workflow variables to only include referenced resource variables in both backend and frontend
- Remove automatic loading of all file variables to reduce context token usage by 50-90% for unused variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Track and store explicitly referenced resource variables in workflow metadata.
  * Limit variable resolution so only explicitly referenced variables are used when invoking actions.
  * Update context-to-invocation processing to build invocation parameters and file associations from the referenced variables set.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->