### PR TITLE
[REF-1247]feat: add abort functionality for node execution and enhance workflow…

### DIFF
--- a/apps/api/src/modules/workflow/workflow-cli.controller.ts
+++ b/apps/api/src/modules/workflow/workflow-cli.controller.ts
@@ -1133,6 +1133,7 @@ export class WorkflowCliController {
         const nodeDetail: NodeExecutionDetail = {
           nodeId: nodeExec.nodeId,
           nodeExecutionId: nodeExec.nodeExecutionId,
+          resultId: nodeExec.entityId ?? undefined, // entityId is used as resultId for action results
           nodeType: nodeExec.nodeType,
           status: nodeExec.status,
           title: nodeExec.title ?? '',

--- a/apps/api/src/modules/workflow/workflow-cli.dto.ts
+++ b/apps/api/src/modules/workflow/workflow-cli.dto.ts
@@ -110,6 +110,7 @@ export interface NodeExecutionStatus {
 // Extended node execution detail for run detail endpoint
 export interface NodeExecutionDetail extends NodeExecutionStatus {
   nodeExecutionId?: string;
+  resultId?: string; // entityId used as resultId for action results, can be used for abort
   query?: string;
   toolCallsCount?: number;
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powerformer/refly-cli",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "description": "Refly CLI - Command-line interface for Refly workflow orchestration",
   "bin": {
     "refly": "./dist/bin/refly.js"

--- a/packages/cli/skill/SKILL.md
+++ b/packages/cli/skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: refly-skill-manager
+name: refly
 description: |
   Base skill for Refly ecosystem: creates, discovers, and runs domain-specific skills bound to workflows.
   Routes user intent to matching domain skills via local registry, delegates execution to Refly backend.
@@ -8,7 +8,7 @@ description: |
   Requires: @refly/cli installed and authenticated.
 ---
 
-# Refly Skill Manager
+# Refly
 
 ## Rules
 

--- a/packages/cli/skill/references/node.md
+++ b/packages/cli/skill/references/node.md
@@ -9,6 +9,22 @@ refly node result <resultId>
 refly node result <resultId> --include-tool-calls
 refly node result <resultId> --include-steps
 refly node result <resultId> --include-messages
+refly node abort <resultId>
+```
+
+## List Nodes in Workflow
+
+```bash
+refly workflow nodes <workflowId>
+refly workflow nodes <workflowId> --include-edges
+refly workflow nodes <workflowId> --include-metadata
+```
+
+## Get Single Node Information
+
+```bash
+refly workflow node <workflowId> <nodeId>
+refly workflow node <workflowId> <nodeId> --include-connections
 ```
 
 ## Interaction
@@ -38,7 +54,8 @@ refly tool get <callId>
 
 - GET /v1/cli/node/types list node types
 - POST /v1/cli/node/run run a single node (not implemented yet)
-- GET /v1/cli/node/result?resultId=<id> get node execution result
+- GET /v1/cli/action/result?resultId=<id> get node execution result
+- POST /v1/cli/action/abort abort node execution
 
 ## Backend API (Tool)
 

--- a/packages/cli/skill/references/workflow.md
+++ b/packages/cli/skill/references/workflow.md
@@ -7,6 +7,9 @@ refly workflow create --name "<name>" --spec '<json>'
 refly workflow generate --query "<natural language description>"
 refly workflow edit <workflowId> --ops '<json>'
 refly workflow get <workflowId>
+woshrefly workflow nodes <workflowId>
+refly workflow nodes <workflowId> --include-edges
+refly workflow nodes <workflowId> --include-metadata
 refly workflow list
 refly workflow delete <workflowId>
 refly workflow run <workflowId> --input '<json>'

--- a/packages/cli/src/commands/node/abort.ts
+++ b/packages/cli/src/commands/node/abort.ts
@@ -1,0 +1,44 @@
+/**
+ * refly node abort - Abort a running node execution
+ */
+
+import { Command } from 'commander';
+import { ok, fail, ErrorCodes } from '../../utils/output.js';
+import { apiRequest } from '../../api/client.js';
+import { CLIError } from '../../utils/errors.js';
+
+interface AbortResult {
+  message: string;
+  resultId: string;
+}
+
+export const nodeAbortCommand = new Command('abort')
+  .description('Abort a running node execution')
+  .argument('<resultId>', 'Node result ID to abort')
+  .option('--version <number>', 'Specific version to abort', Number.parseInt)
+  .action(async (resultId, options) => {
+    try {
+      const body: { resultId: string; version?: number } = { resultId };
+      if (options.version !== undefined) {
+        body.version = options.version;
+      }
+
+      const result = await apiRequest<AbortResult>('/v1/cli/action/abort', {
+        method: 'POST',
+        body,
+      });
+
+      ok('node.abort', {
+        message: result.message,
+        resultId: result.resultId,
+      });
+    } catch (error) {
+      if (error instanceof CLIError) {
+        fail(error.code, error.message, { details: error.details, hint: error.hint });
+      }
+      fail(
+        ErrorCodes.INTERNAL_ERROR,
+        error instanceof Error ? error.message : 'Failed to abort node execution',
+      );
+    }
+  });

--- a/packages/cli/src/commands/node/index.ts
+++ b/packages/cli/src/commands/node/index.ts
@@ -6,9 +6,11 @@ import { Command } from 'commander';
 import { nodeTypesCommand } from './types.js';
 import { nodeRunCommand } from './run.js';
 import { nodeResultCommand } from './result.js';
+import { nodeAbortCommand } from './abort.js';
 
 export const nodeCommand = new Command('node')
-  .description('Node operations: types, run, and execution results')
+  .description('Node operations: types, run, abort, and execution results')
   .addCommand(nodeTypesCommand)
   .addCommand(nodeRunCommand)
-  .addCommand(nodeResultCommand);
+  .addCommand(nodeResultCommand)
+  .addCommand(nodeAbortCommand);

--- a/packages/cli/src/commands/workflow/index.ts
+++ b/packages/cli/src/commands/workflow/index.ts
@@ -14,6 +14,8 @@ import { workflowAbortCommand } from './abort.js';
 import { workflowStatusCommand } from './status.js';
 import { workflowToolsetKeysCommand } from './toolset-keys.js';
 import { workflowLayoutCommand } from './layout.js';
+import { workflowNodesCommand } from './nodes.js';
+import { workflowNodeGetCommand } from './node-get.js';
 
 // The run command is now a command group with subcommands:
 //   refly workflow run <workflowId> - Start a workflow
@@ -33,4 +35,6 @@ export const workflowCommand = new Command('workflow')
   .addCommand(workflowAbortCommand)
   .addCommand(workflowStatusCommand)
   .addCommand(workflowToolsetKeysCommand)
-  .addCommand(workflowLayoutCommand);
+  .addCommand(workflowLayoutCommand)
+  .addCommand(workflowNodesCommand)
+  .addCommand(workflowNodeGetCommand);

--- a/packages/cli/src/commands/workflow/node-get.ts
+++ b/packages/cli/src/commands/workflow/node-get.ts
@@ -1,0 +1,104 @@
+/**
+ * refly workflow node - Get single node information from a workflow
+ */
+
+import { Command } from 'commander';
+import { ok, fail, ErrorCodes } from '../../utils/output.js';
+import { apiRequest } from '../../api/client.js';
+import { CLIError } from '../../utils/errors.js';
+
+interface NodeData {
+  id: string;
+  type: string;
+  data?: {
+    title?: string;
+    metadata?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  position?: { x: number; y: number };
+}
+
+interface EdgeData {
+  id: string;
+  source: string;
+  target: string;
+  sourceHandle?: string;
+  targetHandle?: string;
+}
+
+interface WorkflowData {
+  workflowId: string;
+  name: string;
+  nodes: NodeData[];
+  edges: EdgeData[];
+}
+
+export const workflowNodeGetCommand = new Command('node')
+  .description('Get single node information from a workflow')
+  .argument('<workflowId>', 'Workflow ID')
+  .argument('<nodeId>', 'Node ID')
+  .option('--include-connections', 'Include incoming and outgoing connections')
+  .action(async (workflowId, nodeId, options) => {
+    try {
+      const result = await apiRequest<WorkflowData>(`/v1/cli/workflow/${workflowId}`);
+
+      // Find the specific node
+      const node = result.nodes.find((n) => n.id === nodeId);
+
+      if (!node) {
+        fail(ErrorCodes.NODE_NOT_FOUND, `Node ${nodeId} not found in workflow ${workflowId}`, {
+          hint: `Use 'refly workflow nodes ${workflowId}' to list all nodes`,
+        });
+      }
+
+      // Build output
+      const output: Record<string, unknown> = {
+        workflowId: result.workflowId,
+        workflowName: result.name,
+        node: {
+          id: node.id,
+          type: node.type,
+          title: node.data?.title || node.data?.metadata?.title || undefined,
+          position: node.position,
+          metadata: node.data?.metadata || {},
+          data: node.data,
+        },
+      };
+
+      // Find connections if requested
+      if (options.includeConnections && result.edges?.length) {
+        const incoming = result.edges
+          .filter((e) => e.target === nodeId)
+          .map((e) => ({
+            from: e.source,
+            sourceHandle: e.sourceHandle,
+            targetHandle: e.targetHandle,
+          }));
+
+        const outgoing = result.edges
+          .filter((e) => e.source === nodeId)
+          .map((e) => ({
+            to: e.target,
+            sourceHandle: e.sourceHandle,
+            targetHandle: e.targetHandle,
+          }));
+
+        output.connections = {
+          incoming,
+          outgoing,
+          incomingCount: incoming.length,
+          outgoingCount: outgoing.length,
+        };
+      }
+
+      ok('workflow.node', output);
+    } catch (error) {
+      if (error instanceof CLIError) {
+        fail(error.code, error.message, { details: error.details, hint: error.hint });
+      }
+      fail(
+        ErrorCodes.INTERNAL_ERROR,
+        error instanceof Error ? error.message : 'Failed to get node information',
+      );
+    }
+  });

--- a/packages/cli/src/commands/workflow/nodes.ts
+++ b/packages/cli/src/commands/workflow/nodes.ts
@@ -1,0 +1,93 @@
+/**
+ * refly workflow nodes - List all nodes in a workflow
+ */
+
+import { Command } from 'commander';
+import { ok, fail, ErrorCodes } from '../../utils/output.js';
+import { apiRequest } from '../../api/client.js';
+import { CLIError } from '../../utils/errors.js';
+
+interface NodeData {
+  id: string;
+  type: string;
+  data?: {
+    title?: string;
+    metadata?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  position?: { x: number; y: number };
+}
+
+interface EdgeData {
+  id: string;
+  source: string;
+  target: string;
+  sourceHandle?: string;
+  targetHandle?: string;
+}
+
+interface WorkflowData {
+  workflowId: string;
+  name: string;
+  nodes: NodeData[];
+  edges: EdgeData[];
+}
+
+export const workflowNodesCommand = new Command('nodes')
+  .description('List all nodes in a workflow')
+  .argument('<workflowId>', 'Workflow ID')
+  .option('--include-edges', 'Include edge/connection information')
+  .option('--include-position', 'Include node position coordinates')
+  .option('--include-metadata', 'Include full node metadata')
+  .action(async (workflowId, options) => {
+    try {
+      const result = await apiRequest<WorkflowData>(`/v1/cli/workflow/${workflowId}`);
+
+      // Format nodes for output
+      const nodes = result.nodes.map((node) => {
+        const output: Record<string, unknown> = {
+          id: node.id,
+          type: node.type,
+          title: node.data?.title || node.data?.metadata?.title || undefined,
+        };
+
+        if (options.includePosition && node.position) {
+          output.position = node.position;
+        }
+
+        if (options.includeMetadata && node.data?.metadata) {
+          output.metadata = node.data.metadata;
+        }
+
+        return output;
+      });
+
+      const output: Record<string, unknown> = {
+        workflowId: result.workflowId,
+        workflowName: result.name,
+        nodeCount: nodes.length,
+        nodes,
+      };
+
+      if (options.includeEdges && result.edges?.length) {
+        output.edges = result.edges.map((edge) => ({
+          id: edge.id,
+          source: edge.source,
+          target: edge.target,
+          sourceHandle: edge.sourceHandle,
+          targetHandle: edge.targetHandle,
+        }));
+        output.edgeCount = result.edges.length;
+      }
+
+      ok('workflow.nodes', output);
+    } catch (error) {
+      if (error instanceof CLIError) {
+        fail(error.code, error.message, { details: error.details, hint: error.hint });
+      }
+      fail(
+        ErrorCodes.INTERNAL_ERROR,
+        error instanceof Error ? error.message : 'Failed to get workflow nodes',
+      );
+    }
+  });


### PR DESCRIPTION
This pull request introduces new CLI commands for managing workflow nodes and aborting node executions, along with supporting backend API changes and documentation updates. The main improvements are the ability to abort a running node, list all nodes in a workflow, and retrieve detailed information about individual nodes. These changes enhance the CLI's capabilities for workflow orchestration and improve usability for end users.

**New CLI features for node and workflow management:**

* Added `refly node abort <resultId>` command to abort a running node execution, with backend API support via `POST /v1/cli/action/abort`. [[1]](diffhunk://#diff-7e1188deefe11b54e485da6f7ad830ddd56301de0c7e2d50ff841445b8f0bfcfR1-R44) [[2]](diffhunk://#diff-e461dfb57c166c406d235f89dbfb3183dcd046f4faf65e08f17ef9ff249ff2e0R32-R47) [[3]](diffhunk://#diff-965d818b60ba7ef2e12ba63d11bf3e142918210e6af187454b30fd2666053778R9-R16) [[4]](diffhunk://#diff-e24c74c258748ec7a8ab29da42ad360171be913a28e5c113ba09612fe000b736R12-R27) [[5]](diffhunk://#diff-e24c74c258748ec7a8ab29da42ad360171be913a28e5c113ba09612fe000b736L41-R58)
* Added `refly workflow nodes <workflowId>` command to list all nodes in a workflow, with options to include edges, positions, and metadata. [[1]](diffhunk://#diff-5f16f7ad6ab02223c79a151791cdc13fde6efc068b3fe16eaaae9c298002a2e9R1-R93) [[2]](diffhunk://#diff-1b59cfd40545fe9b423a0b65c87e6c885bd65d64113665c2f4465f1fec8c7c94R17-R18) [[3]](diffhunk://#diff-1b59cfd40545fe9b423a0b65c87e6c885bd65d64113665c2f4465f1fec8c7c94L36-R40) [[4]](diffhunk://#diff-e24c74c258748ec7a8ab29da42ad360171be913a28e5c113ba09612fe000b736R12-R27) [[5]](diffhunk://#diff-15eef56d9b6aa8d789a579bf550fd73871132ac8cada277180beecb192ec9db1R10-R12)
* Added `refly workflow node <workflowId> <nodeId>` command to retrieve detailed information about a single node, including connections if requested. [[1]](diffhunk://#diff-934122a6fc0394944854165686167386f8ea846b2a2769bd96c19624d3bc90d9R1-R104) [[2]](diffhunk://#diff-1b59cfd40545fe9b423a0b65c87e6c885bd65d64113665c2f4465f1fec8c7c94R17-R18) [[3]](diffhunk://#diff-1b59cfd40545fe9b423a0b65c87e6c885bd65d64113665c2f4465f1fec8c7c94L36-R40) [[4]](diffhunk://#diff-e24c74c258748ec7a8ab29da42ad360171be913a28e5c113ba09612fe000b736R12-R27)

**Backend and DTO enhancements:**

* Extended backend DTOs and controllers to support aborting actions and include `resultId` for node executions, enabling richer CLI interactions. [[1]](diffhunk://#diff-e461dfb57c166c406d235f89dbfb3183dcd046f4faf65e08f17ef9ff249ff2e0L6-R6) [[2]](diffhunk://#diff-49efe00f656dfc8503575e3ce862568389601868e955430d6cf2bb3fc0238639R1136) [[3]](diffhunk://#diff-355c761d0c7be33845f8d5e93f5aec4e866286703308d8e82e848d83c2f6f72aR113)

**Documentation and metadata updates:**

* Updated CLI skill documentation and references to reflect new commands and clarify naming conventions. [[1]](diffhunk://#diff-06cd5fde68e6633283fc8777540294b1143f1597162c44af6e68cfe0ca79353bL2-R2) [[2]](diffhunk://#diff-06cd5fde68e6633283fc8777540294b1143f1597162c44af6e68cfe0ca79353bL11-R11) [[3]](diffhunk://#diff-e24c74c258748ec7a8ab29da42ad360171be913a28e5c113ba09612fe000b736R12-R27) [[4]](diffhunk://#diff-15eef56d9b6aa8d789a579bf550fd73871132ac8cada277180beecb192ec9db1R10-R12)
* Bumped CLI package version to `0.1.6` to reflect new feature additions.… node commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `node abort` command to stop running node executions with resultId and optional version parameters.
  * Added `workflow nodes` command to list all nodes in a workflow with optional flags for edges and metadata display.
  * Added `workflow node` command to retrieve individual node details with connection information.

* **Documentation**
  * Updated CLI reference documentation with new commands and API endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->