### PR TITLE
[REF-1250]feat(cli): enhance upgrade command with version checking and improved…

### DIFF
--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -1,24 +1,197 @@
 /**
- * refly upgrade - Reinstall/upgrade skill files
+ * refly upgrade - Upgrade CLI and reinstall skill files
  */
 
 import { Command } from 'commander';
-import { ok, fail, ErrorCodes } from '../utils/output.js';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { ok, fail, print, ErrorCodes } from '../utils/output.js';
 import { installSkill, isSkillInstalled } from '../skill/installer.js';
+import { logger } from '../utils/logger.js';
+
+// Package name on npm
+const PACKAGE_NAME = '@powerformer/refly-cli';
+
+interface VersionInfo {
+  current: string;
+  latest: string | null;
+  updateAvailable: boolean;
+}
+
+/**
+ * Get current CLI version from package.json
+ */
+function getCurrentVersion(): string {
+  // This is injected at build time or read from package
+  try {
+    // Try to get version from the running package
+    const pkgPath = path.join(__dirname, '..', '..', 'package.json');
+    const pkgContent = fs.readFileSync(pkgPath, { encoding: 'utf-8' });
+    const pkg = JSON.parse(pkgContent);
+    return pkg.version;
+  } catch {
+    return '0.1.0';
+  }
+}
+
+/**
+ * Get latest version from npm registry
+ */
+async function getLatestVersion(): Promise<string | null> {
+  try {
+    const result = execSync(`npm view ${PACKAGE_NAME} version 2>/dev/null`, {
+      encoding: 'utf-8',
+      timeout: 10000,
+    });
+    return result.trim();
+  } catch (error) {
+    logger.debug('Failed to get latest version from npm:', error);
+    return null;
+  }
+}
+
+/**
+ * Check version info
+ */
+async function checkVersion(): Promise<VersionInfo> {
+  const current = getCurrentVersion();
+  const latest = await getLatestVersion();
+
+  return {
+    current,
+    latest,
+    updateAvailable: latest !== null && latest !== current,
+  };
+}
+
+/**
+ * Upgrade CLI package via npm
+ */
+function upgradeCli(): { success: boolean; error?: string } {
+  try {
+    logger.info('Upgrading CLI via npm...');
+
+    // Use npm to install the latest version globally
+    execSync(`npm install -g ${PACKAGE_NAME}@latest`, {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      timeout: 120000, // 2 minutes
+    });
+
+    return { success: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    logger.error('Failed to upgrade CLI:', message);
+    return { success: false, error: message };
+  }
+}
 
 export const upgradeCommand = new Command('upgrade')
-  .description('Reinstall or upgrade skill files')
-  .action(async () => {
+  .description('Upgrade CLI to latest version and reinstall skill files')
+  .option('--check', 'Only check for updates without installing')
+  .option('--skill-only', 'Only reinstall skill files without upgrading CLI')
+  .option('--cli-only', 'Only upgrade CLI without reinstalling skill files')
+  .action(async (options) => {
     try {
-      const beforeStatus = isSkillInstalled();
-      const result = installSkill();
+      const { check, skillOnly, cliOnly } = options;
+
+      // Check for updates
+      const versionInfo = await checkVersion();
+
+      // Check only mode
+      if (check) {
+        return ok('upgrade.check', {
+          currentVersion: versionInfo.current,
+          latestVersion: versionInfo.latest,
+          updateAvailable: versionInfo.updateAvailable,
+          message: versionInfo.updateAvailable
+            ? `Update available: ${versionInfo.current} → ${versionInfo.latest}`
+            : 'Already on latest version',
+        });
+      }
+
+      // Skill only mode
+      if (skillOnly) {
+        const beforeStatus = isSkillInstalled();
+        const result = installSkill();
+
+        return ok('upgrade', {
+          message: 'Skill files updated successfully',
+          cliUpgraded: false,
+          skillUpdated: true,
+          previousVersion: beforeStatus.currentVersion ?? null,
+          newVersion: result.version,
+          skillPath: result.skillPath,
+          commandsInstalled: result.commandsInstalled,
+        });
+      }
+
+      // CLI upgrade
+      let cliUpgraded = false;
+      let cliError: string | undefined;
+
+      if (!cliOnly) {
+        // Show current status
+        print('upgrade.progress', {
+          step: 'checking',
+          currentVersion: versionInfo.current,
+          latestVersion: versionInfo.latest,
+        });
+      }
+
+      if (!skillOnly) {
+        if (versionInfo.updateAvailable) {
+          print('upgrade.progress', {
+            step: 'upgrading',
+            from: versionInfo.current,
+            to: versionInfo.latest,
+          });
+
+          const upgradeResult = upgradeCli();
+          cliUpgraded = upgradeResult.success;
+          cliError = upgradeResult.error;
+
+          if (!cliUpgraded) {
+            return fail(ErrorCodes.INTERNAL_ERROR, 'Failed to upgrade CLI', {
+              hint: cliError || 'Try running: npm install -g @powerformer/refly-cli@latest',
+            });
+          }
+        } else {
+          logger.info('CLI is already on latest version');
+        }
+      }
+
+      // Reinstall skill files (unless cli-only)
+      let skillResult = null;
+      if (!cliOnly) {
+        skillResult = installSkill();
+      }
+
+      // Final output
+      const newVersionInfo = await checkVersion();
+
+      // Determine message based on what was updated
+      let message: string;
+      if (cliUpgraded && skillResult) {
+        message = 'CLI and skill files updated successfully';
+      } else if (cliUpgraded) {
+        message = 'CLI updated successfully';
+      } else if (skillResult) {
+        message = 'Skill files updated (CLI already on latest version)';
+      } else {
+        message = 'Already on latest version';
+      }
 
       ok('upgrade', {
-        message: 'Skill files upgraded successfully',
-        previousVersion: beforeStatus.currentVersion ?? null,
-        newVersion: result.version,
-        skillPath: result.skillPath,
-        commandsInstalled: result.commandsInstalled,
+        message,
+        cliUpgraded,
+        skillUpdated: !!skillResult,
+        previousVersion: versionInfo.current,
+        currentVersion: newVersionInfo.current,
+        latestVersion: newVersionInfo.latest,
+        skillPath: skillResult?.skillPath ?? null,
+        commandsInstalled: skillResult?.commandsInstalled ?? false,
       });
     } catch (error) {
       return fail(


### PR DESCRIPTION
This pull request introduces significant improvements to both the workflow canvas initialization logic in the API and the CLI's upgrade command. The API changes provide more flexible handling of workflow nodes, especially regarding the initialization of start nodes and the mapping of node types and metadata. The CLI upgrade command is enhanced to support self-upgrading, more granular update options, and better version checking.

**Workflow API Improvements:**

- **Flexible Canvas Node Initialization:**
  - The workflow creation logic now checks whether user-provided nodes include a `start` node. If not, it automatically adds a start node and connects it to the user's first node. If no nodes are provided, it falls back to adding default nodes (`start` and `skillResponse`). [[1]](diffhunk://#diff-49efe00f656dfc8503575e3ce862568389601868e955430d6cf2bb3fc0238639L351-R395) [[2]](diffhunk://#diff-49efe00f656dfc8503575e3ce862568389601868e955430d6cf2bb3fc0238639L364-R457)
  - Added a mapping function to convert CLI node types (like `agent`) to their corresponding canvas node types (like `skillResponse`).
  - Improved metadata handling: fields such as `query`, `selectedToolsets`, and `modelInfo` are now consistently moved into the node's metadata, regardless of their original location.
  - Added default metadata and titles for the new `start` node type. [[1]](diffhunk://#diff-49efe00f656dfc8503575e3ce862568389601868e955430d6cf2bb3fc0238639R196-R197) [[2]](diffhunk://#diff-49efe00f656dfc8503575e3ce862568389601868e955430d6cf2bb3fc0238639R236-R237)

**CLI Upgrade Command Enhancements:**

- **Self-Upgrading and Version Checking:**
  - The `upgrade` command now supports upgrading the CLI itself by checking the latest version on npm and installing it globally if an update is available.
  - Added options to check for updates without upgrading (`--check`), upgrade only the CLI (`--cli-only`), or only reinstall skill files (`--skill-only`).
  - Improved output and error handling, providing clear messages about what was updated and any issues encountered.

**Most Important Changes:**

**Workflow API:**
- Flexible workflow node initialization: Automatically adds and connects a `start` node if user nodes don't include one, and uses default nodes only when no user nodes are provided. [[1]](diffhunk://#diff-49efe00f656dfc8503575e3ce862568389601868e955430d6cf2bb3fc0238639L351-R395) [[2]](diffhunk://#diff-49efe00f656dfc8503575e3ce862568389601868e955430d6cf2bb3fc0238639L364-R457)
- Added type mapping for CLI node types to canvas node types and improved metadata migration for fields like `query`, `selectedToolsets`, and `modelInfo`. [[1]](diffhunk://#diff-49efe00f656dfc8503575e3ce862568389601868e955430d6cf2bb3fc0238639R106-R146) [[2]](diffhunk://#diff-49efe00f656dfc8503575e3ce862568389601868e955430d6cf2bb3fc0238639L135-R173)
- Added support for default metadata and titles for the `start` node type. [[1]](diffhunk://#diff-49efe00f656dfc8503575e3ce862568389601868e955430d6cf2bb3fc0238639R196-R197) [[2]](diffhunk://#diff-49efe00f656dfc8503575e3ce862568389601868e955430d6cf2bb3fc0238639R236-R237)

**CLI:**
- Enhanced `upgrade` command to support self-upgrading, version checking, and more granular update controls (`--check`, `--skill-only`, `--cli-only`).
- Improved user feedback and error handling during the upgrade process.… functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI upgrade command now supports `--check` to verify available updates, `--skill-only` to reinstall skills only, and `--cli-only` to upgrade the CLI independently
  * Enhanced workflow creation from CLI with improved node transformation and metadata handling for custom workflow definitions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->