### PR TITLE
[REF-1251]Feat/cli/tool insert

### DIFF
--- a/apps/api/src/modules/tool/tool.service.ts
+++ b/apps/api/src/modules/tool/tool.service.ts
@@ -1467,7 +1467,24 @@ export class ToolService {
       return toolsetPo2GenericToolset(globalToolset, inventoryMap);
     }
 
-    // Step 3: Check inventory (for tools that may need authorization)
+    // Step 3: Check builtin tools by name (like generate_doc, send_email, etc.)
+    const builtinItem = builtinToolsetInventory[normalizedKey];
+    if (builtinItem) {
+      const definition = builtinItem.definition;
+      return {
+        type: ToolsetType.REGULAR,
+        id: normalizedKey,
+        name: (definition.labelDict?.en as string) || normalizedKey,
+        builtin: true,
+        toolset: {
+          toolsetId: normalizedKey,
+          name: (definition.labelDict?.en as string) || normalizedKey,
+          key: normalizedKey,
+        },
+      };
+    }
+
+    // Step 4: Check inventory (for tools that may need authorization)
     const inventoryItem = await this.inventoryService.getInventoryItem(normalizedKey);
     if (!inventoryItem) {
       return null;

--- a/packages/cli/src/commands/workflow/create.ts
+++ b/packages/cli/src/commands/workflow/create.ts
@@ -15,9 +15,13 @@ export const workflowCreateCommand = new Command('create')
   .action(async (options) => {
     try {
       // Parse spec JSON
+      // Supports both formats:
+      // - Array shorthand: [node1, node2] -> { nodes: [node1, node2] }
+      // - Full object: { nodes: [...], edges: [...] } -> as-is
       let spec: unknown;
       try {
-        spec = JSON.parse(options.spec);
+        const parsed = JSON.parse(options.spec);
+        spec = Array.isArray(parsed) ? { nodes: parsed } : parsed;
       } catch {
         fail(ErrorCodes.INVALID_INPUT, 'Invalid JSON in --spec', {
           hint: 'Ensure the spec is valid JSON',


### PR DESCRIPTION
This pull request introduces enhancements to the workflow CLI and API to support a more flexible and user-friendly format for specifying workflows, as well as improved handling of toolset references and node connections. The changes allow for simplified input formats, automatic resolution of toolset keys to full toolset objects, and better connection mapping between nodes based on dependencies.

### Workflow CLI and API input flexibility

* The CLI now supports both array shorthand (`[node1, node2]`) and full object formats (`{ nodes: [...], edges: [...] }`) for workflow specifications, making it easier for users to define workflows in different styles.

### Toolset resolution and metadata enrichment

* When creating a workflow, any `toolsetKeys` provided in node metadata are automatically resolved to full `GenericToolset` objects, ensuring proper authorization and frontend compatibility. These resolved toolsets are added to `selectedToolsets` and removed from `toolsetKeys` in the node metadata. Additionally, toolset mentions are inserted into the query field for improved frontend display.

### Node input and metadata handling

* The `CliNodeInput` interface and transformation logic have been updated to support top-level shorthand fields (`query`, `toolsetKeys`) and prioritize them over nested fields. This streamlines agent/CLI usage and ensures metadata is correctly populated regardless of input format. [[1]](diffhunk://#diff-49efe00f656dfc8503575e3ce862568389601868e955430d6cf2bb3fc0238639R101-R103) [[2]](diffhunk://#diff-49efe00f656dfc8503575e3ce862568389601868e955430d6cf2bb3fc0238639R112) [[3]](diffhunk://#diff-49efe00f656dfc8503575e3ce862568389601868e955430d6cf2bb3fc0238639L156-R177)

### Node connection mapping improvements

* The workflow creation logic now supports building node connection maps from either explicit `edges` or implicit `dependsOn` fields, allowing for more flexible and simplified workflow definitions without requiring full edge specifications.

### Builtin toolset lookup enhancement

* The tool service now checks for builtin tools by name before checking inventory, enabling direct access to builtin tool definitions (e.g., `generate_doc`, `send_email`) and returning their metadata if present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Introduced shorthand syntax for workflow specifications, allowing both array and object formats in CLI workflow commands
- Enhanced toolset configuration with improved metadata field support and prioritization in workflow node setup
- Improved workflow node relationship and dependency resolution for more flexible workflow configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->