### PR TITLE
[REF-1256]feat(cli-auth): update API base URL retrieval to use serverOrigin for…

### DIFF
--- a/packages/web-core/src/pages/cli-auth/index.tsx
+++ b/packages/web-core/src/pages/cli-auth/index.tsx
@@ -19,6 +19,7 @@ import './index.scss';
 import { HiOutlineLightningBolt } from 'react-icons/hi';
 import { GoShieldCheck } from 'react-icons/go';
 import { logEvent, updateUserProperties } from '@refly/telemetry-web';
+import { serverOrigin } from '@refly/ui-kit';
 // ============================================================================
 // Types
 // ============================================================================
@@ -41,18 +42,9 @@ interface DeviceInfo {
 // API Functions
 // ============================================================================
 
-// Get API base URL from window.ENV or use relative path as fallback
-// This allows the page to work both in development (with proxy) and production (with separate API domain)
-const getApiBase = () => {
-  const apiUrl = window.ENV?.API_URL;
-  if (apiUrl) {
-    return `${apiUrl}/v1/auth/cli`;
-  }
-  // Fallback to relative path for development with proxy
-  return '/v1/auth/cli';
-};
-
-const API_BASE = getApiBase();
+// Get API base URL from serverOrigin (consistent with the rest of the app)
+// serverOrigin checks: window.electronEnv > window.ENV.API_URL > VITE_API_URL > ''
+const API_BASE = serverOrigin ? `${serverOrigin}/v1/auth/cli` : '/v1/auth/cli';
 
 async function fetchDeviceInit(
   deviceId: string,


### PR DESCRIPTION
This pull request updates the way the API base URL is determined in the `cli-auth` page to ensure consistency with the rest of the application. Instead of using a custom function to get the API URL, it now uses the shared `serverOrigin` utility from `@refly/ui-kit`.

API URL handling improvements:

* Replaced the local `getApiBase` function with the shared `serverOrigin` utility to determine the API base URL, ensuring consistent environment variable resolution across the app (`cli-auth/index.tsx`).
* Imported `serverOrigin` from `@refly/ui-kit` to support the updated API base URL logic (`cli-auth/index.tsx`).… consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI authentication endpoint resolution to reliably determine the correct API base URL based on server configuration, with appropriate fallback handling for enhanced compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->