### PR TITLE
Merge back from release/2026-01-15

### DIFF
--- a/packages/web-core/src/pages/cli-auth/index.tsx
+++ b/packages/web-core/src/pages/cli-auth/index.tsx
@@ -19,6 +19,7 @@ import './index.scss';
 import { HiOutlineLightningBolt } from 'react-icons/hi';
 import { GoShieldCheck } from 'react-icons/go';
 import { logEvent, updateUserProperties } from '@refly/telemetry-web';
+import { serverOrigin } from '@refly/ui-kit';
 // ============================================================================
 // Types
 // ============================================================================
@@ -41,18 +42,9 @@ interface DeviceInfo {
 // API Functions
 // ============================================================================
 
-// Get API base URL from window.ENV or use relative path as fallback
-// This allows the page to work both in development (with proxy) and production (with separate API domain)
-const getApiBase = () => {
-  const apiUrl = window.ENV?.API_URL;
-  if (apiUrl) {
-    return `${apiUrl}/v1/auth/cli`;
-  }
-  // Fallback to relative path for development with proxy
-  return '/v1/auth/cli';
-};
-
-const API_BASE = getApiBase();
+// Get API base URL from serverOrigin (consistent with the rest of the app)
+// serverOrigin checks: window.electronEnv > window.ENV.API_URL > VITE_API_URL > ''
+const API_BASE = serverOrigin ? `${serverOrigin}/v1/auth/cli` : '/v1/auth/cli';
 
 async function fetchDeviceInit(
   deviceId: string,


### PR DESCRIPTION
This pull request updates how the API base URL is determined in the `cli-auth` page to use the shared `serverOrigin` utility, ensuring consistency with the rest of the app and simplifying environment handling.

**API base URL handling:**

* Replaced the custom `getApiBase` function with the shared `serverOrigin` utility from `@refly/ui-kit` to determine the API base URL, aligning the logic with the rest of the application and improving maintainability. (`packages/web-core/src/pages/cli-auth/index.tsx`) [[1]](diffhunk://#diff-3e33836722b170b7e830124d21ad96b5d5bcc052302cde82bac64ff87205345eR22) [[2]](diffhunk://#diff-3e33836722b170b7e830124d21ad96b5d5bcc052302cde82bac64ff87205345eL44-R47)…Origin for… (#2070)

feat(cli-auth): update API base URL retrieval to use serverOrigin for consistency