### PR TITLE
[REF-1243] feat: Add PTC tool execution and definition services

### DIFF
--- a/.cursor/rules/06-api-structure.mdc
+++ b/.cursor/rules/06-api-structure.mdc
@@ -32,3 +32,6 @@ The backend API is organized in a modular structure using NestJS. Each module co
 - Use dependency injection
 - Implement proper error handling
 - Document APIs with OpenAPI
+- Schema-First Development
+    - All API contracts must be defined in [schema.yml](mdc:packages/openapi-schema/schema.yml)
+    - Controllers must use types imported from `@refly/openapi-schema` for Request and Response

--- a/apps/api/src/modules/tool/composio/composio.service.ts
+++ b/apps/api/src/modules/tool/composio/composio.service.ts
@@ -179,10 +179,10 @@ export class ComposioService {
    * @param userId - The user ID (user.uid for OAuth, 'refly_global' for API Key tools)
    * @param integrationId - The integration/toolkit ID
    */
-  async fetchTools(userId: string, integrationId: string): Promise<any[]> {
+  async fetchTools(userId: string, integrationId: string, limit = 100): Promise<any[]> {
     const tools = await this.composio.tools.get(userId, {
       toolkits: [integrationId],
-      limit: 100,
+      limit,
     });
     return tools;
   }

--- a/apps/api/src/modules/tool/inventory/inventory.service.ts
+++ b/apps/api/src/modules/tool/inventory/inventory.service.ts
@@ -74,7 +74,10 @@ export class ToolInventoryService implements OnModuleInit {
     const inventory = new Map<string, ToolsetInventoryItem>();
 
     // First, load static toolset inventory from @refly/agent-tools
-    for (const [key, item] of Object.entries(staticToolsetInventory)) {
+    for (const [key, item] of Object.entries(staticToolsetInventory) as [
+      string,
+      { class: any; definition: ToolsetDefinition },
+    ][]) {
       inventory.set(key, {
         class: item.class,
         definition: item.definition,

--- a/apps/api/src/modules/tool/ptc/index.ts
+++ b/apps/api/src/modules/tool/ptc/index.ts
@@ -1,0 +1,3 @@
+export * from './tool-identify.service';
+export * from './tool-execution.service';
+export * from './tool-definition.service';

--- a/apps/api/src/modules/tool/ptc/tool-definition.service.ts
+++ b/apps/api/src/modules/tool/ptc/tool-definition.service.ts
@@ -1,0 +1,339 @@
+/**
+ * Tool Definition Service
+ * Provides unified schema export for all tool types (Composio, Config-based, Legacy SDK).
+ * Used for generating Python SDK.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import type { ToolsetExportDefinition, ToolExportDefinition } from '@refly/openapi-schema';
+import { ParamsError, ToolsetNotFoundError } from '@refly/errors';
+import { ComposioService } from '../composio/composio.service';
+import { ToolInventoryService } from '../inventory/inventory.service';
+import { ToolIdentifyService } from './tool-identify.service';
+import { PrismaService } from '../../common/prisma.service';
+
+@Injectable()
+export class ToolDefinitionService {
+  private readonly logger = new Logger(ToolDefinitionService.name);
+
+  constructor(
+    private readonly composioService: ComposioService,
+    private readonly inventoryService: ToolInventoryService,
+    private readonly toolIdentifyService: ToolIdentifyService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  /**
+   * Export tool definitions for specified toolset keys.
+   * Returns the original schema without model-specific optimizations.
+   * This is an internal API for generating Python SDK, no user-specific permission checks needed.
+   *
+   * @param toolsetKeys - Optional comma-separated toolset keys to export. If not provided, exports all supported toolsets.
+   * @returns Array of toolset export definitions
+   */
+  async exportToolsetDefinitions(toolsetKeys?: string): Promise<ToolsetExportDefinition[]> {
+    let keys: string[];
+
+    // If no toolsetKeys provided, get all supported toolsets
+    if (!toolsetKeys?.trim()) {
+      keys = await this.getAllSupportedToolsetKeys();
+      this.logger.log(`Exporting all supported toolsets: ${keys.join(', ')}`);
+    } else {
+      // Parse comma-separated keys
+      keys = toolsetKeys
+        .split(',')
+        .map((k) => k.trim())
+        .filter(Boolean);
+      if (keys.length === 0) {
+        throw new ParamsError('At least one valid toolsetKey is required');
+      }
+    }
+
+    const results: ToolsetExportDefinition[] = [];
+
+    // Process each toolset key - fail all if any fails
+    for (const toolsetKey of keys) {
+      const definition = await this.exportSingleToolset(toolsetKey);
+      results.push(definition);
+    }
+
+    return results;
+  }
+
+  /**
+   * Get all supported toolset keys from both toolset_inventory and toolset tables.
+   * Only returns toolsets that can be exported (Composio and Config-based).
+   * Filters out Legacy SDK, MCP, and Builtin tools.
+   *
+   * @returns Array of unique toolset keys
+   */
+  private async getAllSupportedToolsetKeys(): Promise<string[]> {
+    const supportedKeys = new Set<string>();
+
+    // Step 1: Query toolset_inventory table for definition-level toolsets
+    const inventoryItems = await this.prisma.toolsetInventory.findMany({
+      where: {
+        enabled: true,
+        deletedAt: null,
+      },
+      select: {
+        key: true,
+        type: true,
+      },
+      orderBy: {
+        key: 'asc',
+      },
+    });
+
+    // Get static inventory items to check for class definitions
+    const staticInventoryMap = await this.inventoryService.getInventoryMap();
+
+    // Filter to only supported types from toolset_inventory
+    for (const item of inventoryItems) {
+      // Support Composio OAuth and API Key tools
+      if (item.type === 'external_oauth' || item.type === 'external_apikey') {
+        supportedKeys.add(item.key);
+        continue;
+      }
+
+      // Support Config-based tools (those without a class in static inventory)
+      // Legacy SDK tools have a class and are not yet supported
+      const staticItem = staticInventoryMap[item.key];
+      if (!staticItem?.class) {
+        supportedKeys.add(item.key);
+      }
+    }
+
+    // Step 2: Query toolset table for instance-level toolsets
+    // Some toolsets (like github) may only exist in the toolset table
+    const toolsets = await this.prisma.toolset.findMany({
+      where: {
+        enabled: true,
+        deletedAt: null,
+        uninstalled: false,
+      },
+      select: {
+        key: true,
+        authType: true,
+      },
+      distinct: ['key'],
+    });
+
+    // Get all keys from toolset_inventory for validation
+    const inventoryKeySet = new Set(inventoryItems.map((item) => item.key));
+
+    // Add Composio OAuth and API Key tools from toolset table
+    for (const toolset of toolsets) {
+      // Skip if already added from toolset_inventory
+      if (supportedKeys.has(toolset.key)) {
+        continue;
+      }
+
+      // Support Composio OAuth and API Key tools
+      // These can exist in toolset table only (e.g., github)
+      if (toolset.authType === 'oauth' || toolset.authType === 'external_apikey') {
+        supportedKeys.add(toolset.key);
+        continue;
+      }
+
+      // For config_based/credentials auth types:
+      // - Must exist in toolset_inventory to be a valid config-based tool
+      // - Must not have a class in static inventory (otherwise it's Legacy SDK)
+      if (inventoryKeySet.has(toolset.key)) {
+        const staticItem = staticInventoryMap[toolset.key];
+        if (!staticItem?.class) {
+          // Config-based tool: exists in toolset_inventory and has no class
+          supportedKeys.add(toolset.key);
+        }
+        // Otherwise it's Legacy SDK (has a class), not yet supported
+      }
+      // If not in toolset_inventory, skip it (incomplete configuration)
+    }
+
+    return Array.from(supportedKeys).sort();
+  }
+
+  /**
+   * Export a single toolset's definition
+   * No user context needed - this is for internal schema export only
+   *
+   * @param toolsetKey - The toolset key to export
+   * @returns Toolset export definition
+   */
+  private async exportSingleToolset(toolsetKey: string): Promise<ToolsetExportDefinition> {
+    // Identify tool type without user context (supports all enabled toolsets)
+    const toolInfo = await this.toolIdentifyService.identifyToolType(toolsetKey);
+
+    this.logger.log(`Exporting schema for toolset: ${toolsetKey}, type: ${toolInfo.type}`);
+
+    // Route to appropriate schema extractor based on type
+    switch (toolInfo.type) {
+      case 'composio_oauth':
+      case 'composio_apikey':
+        return await this.exportComposioToolset(toolsetKey);
+
+      case 'config_based':
+        return await this.exportConfigBasedToolset(toolsetKey);
+
+      case 'legacy_sdk':
+        // Legacy SDK tools are not yet supported for export
+        throw new ParamsError(
+          `Toolset ${toolsetKey} not supported: legacy_sdk schema export is not implemented.`,
+        );
+
+      case 'mcp':
+        throw new ParamsError(`Toolset ${toolsetKey} not supported: MCP tools cannot be exported.`);
+
+      case 'builtin':
+        throw new ParamsError(
+          `Toolset ${toolsetKey} not supported: builtin tools cannot be exported.`,
+        );
+
+      default: {
+        const exhaustiveCheck: never = toolInfo.type;
+        throw new ParamsError(`Unsupported tool type: ${exhaustiveCheck}`);
+      }
+    }
+  }
+
+  /**
+   * Export Composio toolset definition
+   * Fetches tools from Composio API and extracts function.parameters as inputSchema
+   *
+   * @param toolsetKey - The Composio integration ID
+   * @returns Toolset export definition
+   */
+  private async exportComposioToolset(toolsetKey: string): Promise<ToolsetExportDefinition> {
+    // Get toolset metadata from inventory
+    const inventoryItem = await this.inventoryService.getInventoryItem(toolsetKey);
+    const definition = inventoryItem?.definition;
+
+    // Get toolset name from inventory or use key as fallback
+    const name =
+      (definition?.labelDict?.en as string) ??
+      (definition?.labelDict?.['zh-CN'] as string) ??
+      toolsetKey;
+
+    const description =
+      (definition?.descriptionDict?.en as string) ??
+      (definition?.descriptionDict?.['zh-CN'] as string) ??
+      '';
+
+    // Fetch tools from Composio API
+    // Use 'refly_global' as userId since we're just fetching schemas
+    const composioTools = await this.composioService.fetchTools('refly_global', toolsetKey, 2000);
+
+    // Convert Composio tools to export format
+    const tools: ToolExportDefinition[] = composioTools
+      .filter((tool) => this.isComposioToolValid(tool))
+      .map((tool) => this.convertComposioTool(tool));
+
+    return {
+      key: toolsetKey,
+      name,
+      description,
+      tools,
+    };
+  }
+
+  /**
+   * Export Config-based toolset definition
+   * Loads from database via ToolInventoryService
+   *
+   * @param toolsetKey - The toolset key
+   * @returns Toolset export definition
+   */
+  private async exportConfigBasedToolset(toolsetKey: string): Promise<ToolsetExportDefinition> {
+    // Get full config with methods from database
+    const config = await this.inventoryService.getInventoryWithMethods(toolsetKey);
+
+    if (!config) {
+      throw new ToolsetNotFoundError(`Toolset not found in inventory: ${toolsetKey}`);
+    }
+
+    // Convert methods to export format
+    const tools: ToolExportDefinition[] = config.methods.map((method) => {
+      // Parse requestSchema from JSON string if needed
+      let inputSchema: Record<string, unknown> = {};
+      if (method.schema) {
+        try {
+          inputSchema =
+            typeof method.schema === 'string' ? JSON.parse(method.schema) : method.schema;
+        } catch (e) {
+          this.logger.warn(
+            `Failed to parse requestSchema for method ${method.name}: ${(e as Error).message}`,
+          );
+        }
+      }
+
+      return {
+        name: method.name,
+        description: method.description ?? '',
+        inputSchema,
+      };
+    });
+
+    // Get toolset metadata from inventory
+    const inventoryItem = await this.inventoryService.getInventoryItem(toolsetKey);
+    const definition = inventoryItem?.definition;
+
+    const name = config.name ?? toolsetKey;
+    const description =
+      (definition?.descriptionDict?.en as string) ??
+      (definition?.descriptionDict?.['zh-CN'] as string) ??
+      '';
+
+    return {
+      key: toolsetKey,
+      name,
+      description,
+      tools,
+    };
+  }
+
+  /**
+   * Check if a Composio tool should be included (not deprecated)
+   *
+   * @param tool - Composio tool definition
+   * @returns true if the tool should be included
+   */
+  private isComposioToolValid(tool: {
+    function?: { name?: string; description?: string; parameters?: Record<string, unknown> };
+    description?: string;
+  }): boolean {
+    const fn = tool?.function;
+    if (!fn?.name) return false;
+
+    // Skip deprecated tools
+    const description = fn?.description ?? tool?.description ?? '';
+    if (/deprecated/i.test(description)) {
+      return false;
+    }
+
+    // Skip tools with deprecated properties
+    const params = (fn.parameters ?? {}) as Record<string, unknown>;
+    const properties = (params?.properties ?? {}) as Record<string, Record<string, unknown>>;
+    const hasDeprecatedProps = Object.values(properties).some((prop) => prop?.deprecated === true);
+
+    return !hasDeprecatedProps;
+  }
+
+  /**
+   * Convert Composio tool to export format
+   *
+   * @param tool - Composio tool definition
+   * @returns Tool export definition
+   */
+  private convertComposioTool(tool: {
+    function?: { name?: string; description?: string; parameters?: Record<string, unknown> };
+    description?: string;
+  }): ToolExportDefinition {
+    const fn = tool.function;
+
+    return {
+      name: fn?.name ?? 'unknown_tool',
+      description: fn?.description ?? '',
+      inputSchema: (fn?.parameters ?? {}) as Record<string, unknown>,
+    };
+  }
+}

--- a/apps/api/src/modules/tool/ptc/tool-execution.service.ts
+++ b/apps/api/src/modules/tool/ptc/tool-execution.service.ts
@@ -1,0 +1,121 @@
+/**
+ * Tool Execution Service
+ * Unified service for executing tools via API. Basic components for PTC.
+ *
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import type { User } from '@refly/openapi-schema';
+import type { ExecuteToolRequest } from '@refly/openapi-schema';
+import { ParamsError } from '@refly/errors';
+import { ComposioService } from '../composio/composio.service';
+import { ToolIdentifyService } from './tool-identify.service';
+import type { ToolIdentification } from './tool-identify.service';
+
+@Injectable()
+export class ToolExecutionService {
+  private readonly logger = new Logger(ToolExecutionService.name);
+
+  constructor(
+    private readonly composioService: ComposioService,
+    private readonly toolIdentifyService: ToolIdentifyService,
+  ) {}
+
+  /**
+   * Execute a tool by toolset key and tool name
+   * Routes to the appropriate executor based on tool type
+   *
+   * @param user - The user executing the tool
+   * @param request - The execution request (toolsetKey, toolName, arguments)
+   * @returns Tool execution result
+   */
+  async executeTool(user: User, request: ExecuteToolRequest): Promise<Record<string, unknown>> {
+    const { toolsetKey, toolName, arguments: args } = request;
+
+    if (!toolsetKey) {
+      throw new ParamsError('toolsetKey is required');
+    }
+
+    if (!toolName) {
+      throw new ParamsError('toolName is required');
+    }
+
+    // 1. Identify tool type and get connection info
+    const toolInfo = await this.toolIdentifyService.identifyTool(user, toolsetKey);
+
+    this.logger.log(
+      `Executing tool: ${toolName} from toolset: ${toolsetKey}, type: ${toolInfo.type}`,
+    );
+
+    // 2. Route to appropriate executor based on type
+    switch (toolInfo.type) {
+      case 'composio_oauth':
+      case 'composio_apikey':
+        return await this.executeComposioTool(toolInfo, toolName, args ?? {});
+
+      case 'config_based':
+        throw new ParamsError(
+          `Toolset ${toolsetKey} not supported: config_based tool execution is not implemented.`,
+        );
+
+      case 'legacy_sdk':
+        throw new ParamsError(
+          `Toolset ${toolsetKey} not supported: legacy_sdk tool execution is not implemented.`,
+        );
+
+      case 'mcp':
+        // TODO return a user-friendly error message
+        throw new ParamsError(
+          `Toolset ${toolsetKey} not supported: MCP tool execution is not supported.`,
+        );
+
+      case 'builtin':
+        throw new ParamsError(
+          `Toolset ${toolsetKey} not supported: builtin tool execution is not supported.`,
+        );
+
+      default:
+        throw new ParamsError(`Unsupported tool type: ${toolInfo.type}`);
+    }
+  }
+
+  /**
+   * Execute a Composio tool (OAuth or API Key)
+   *
+   * @param toolInfo - Tool identification info
+   * @param toolName - Tool method name
+   * @param args - Tool arguments
+   * @returns Execution result
+   */
+  private async executeComposioTool(
+    toolInfo: ToolIdentification,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (!toolInfo.connectedAccountId || !toolInfo.userId) {
+      throw new ParamsError('Missing connection info for Composio tool execution');
+    }
+
+    const result = await this.composioService.executeTool(
+      toolInfo.userId,
+      toolInfo.connectedAccountId,
+      toolName,
+      args,
+    );
+
+    // Return the result data
+    // Composio tools return { successful: boolean, data: any, error?: string }
+    if (result.successful) {
+      return {
+        status: 'success',
+        data: result.data,
+      };
+    }
+
+    return {
+      status: 'error',
+      error: result.error ?? 'Tool execution failed',
+      data: result.data,
+    };
+  }
+}

--- a/apps/api/src/modules/tool/ptc/tool-identify.service.ts
+++ b/apps/api/src/modules/tool/ptc/tool-identify.service.ts
@@ -1,0 +1,271 @@
+/**
+ * Tool Identify Service
+ * Identifies tool type based on toolset key for routing to appropriate executor or definition extractor.
+ * Extracted from ToolExecutionService for reuse across execution and definition services.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import type { User } from '@refly/openapi-schema';
+import { ParamsError, ToolsetNotFoundError } from '@refly/errors';
+import { PrismaService } from '../../common/prisma.service';
+import { ComposioService } from '../composio/composio.service';
+import { ToolInventoryService } from '../inventory/inventory.service';
+import { builtinToolsetInventory } from '@refly/agent-tools';
+
+/**
+ * Tool type enumeration for internal routing
+ * Includes unsupported types (mcp, builtin) for explicit error handling
+ */
+export type ToolExecutionType =
+  | 'mcp'
+  | 'composio_oauth'
+  | 'composio_apikey'
+  | 'config_based'
+  | 'legacy_sdk'
+  | 'builtin';
+
+/**
+ * Tool identification result
+ */
+export interface ToolIdentification {
+  type: ToolExecutionType;
+  toolsetKey: string;
+  connectedAccountId?: string;
+  userId?: string;
+}
+
+@Injectable()
+export class ToolIdentifyService {
+  private readonly logger = new Logger(ToolIdentifyService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly composioService: ComposioService,
+    private readonly inventoryService: ToolInventoryService,
+  ) {}
+
+  /**
+   * Identify tool type based on toolset key
+   *
+   * Classification logic:
+   * 1. Check builtin tools first → builtin (not supported)
+   * 2. Check mcp_server table → MCP (not supported)
+   * 3. Check toolset table (instance layer):
+   *    - auth_type = oauth → composio_oauth
+   *    - auth_type = external_apikey → composio_apikey
+   *    - auth_type = config_based/credentials → go to step 4
+   * 4. Compare toolset.key with static inventory:
+   *    - Has class → legacy_sdk
+   *    - Otherwise → config_based
+   *
+   * @param user - The user executing the tool
+   * @param toolsetKey - The toolset key
+   * @returns Tool identification with type and connection info
+   */
+  async identifyTool(user: User, toolsetKey: string): Promise<ToolIdentification> {
+    // Step 1: Check if it's a builtin tool first
+    // Builtin tools exist only in static inventory without database records
+    if (builtinToolsetInventory[toolsetKey]) {
+      return {
+        type: 'builtin',
+        toolsetKey,
+      };
+    }
+
+    // Step 2: Check mcp_server table (MCP tools are not supported via API)
+    const mcpServer = await this.prisma.mcpServer.findFirst({
+      where: {
+        uid: user.uid,
+        name: toolsetKey,
+        enabled: true,
+        deletedAt: null,
+      },
+    });
+
+    if (mcpServer) {
+      return {
+        type: 'mcp',
+        toolsetKey,
+      };
+    }
+
+    // Step 3: Query toolset table (instance layer) for user-specific or global toolset
+    const toolset = await this.prisma.toolset.findFirst({
+      where: {
+        key: toolsetKey,
+        enabled: true,
+        deletedAt: null,
+        uninstalled: false,
+        OR: [{ uid: user.uid }, { isGlobal: true }],
+      },
+      // Prefer user-specific toolset over global
+      orderBy: { isGlobal: 'asc' },
+    });
+
+    if (toolset) {
+      // Step 3.1: Route based on auth_type field (primary classification)
+
+      // OAuth → composio_oauth (requires active Composio connection)
+      if (toolset.authType === 'oauth') {
+        const connection = await this.prisma.composioConnection.findFirst({
+          where: {
+            uid: user.uid,
+            integrationId: toolsetKey,
+            status: 'active',
+            deletedAt: null,
+          },
+        });
+
+        if (!connection?.connectedAccountId) {
+          throw new ParamsError(`OAuth connection not authorized for toolset: ${toolsetKey}`);
+        }
+
+        return {
+          type: 'composio_oauth',
+          toolsetKey,
+          connectedAccountId: connection.connectedAccountId,
+          userId: user.uid,
+        };
+      }
+
+      // External API Key → composio_apikey (global Composio tools with system API keys)
+      if (toolset.authType === 'external_apikey') {
+        const connectedAccountId = await this.composioService.checkApiKeyStatus(toolsetKey);
+
+        return {
+          type: 'composio_apikey',
+          toolsetKey,
+          connectedAccountId,
+          userId: 'refly_global',
+        };
+      }
+
+      // Step 4: For config_based/credentials auth types, distinguish legacy SDK vs config-based
+      // Check if toolset key exists in static inventory with a class definition
+      const inventoryItem = await this.inventoryService.getInventoryItem(toolsetKey);
+
+      // If key has a class in static inventory → legacy_sdk (hardcoded SDK-based tools)
+      if (inventoryItem?.class) {
+        return {
+          type: 'legacy_sdk',
+          toolsetKey,
+        };
+      }
+
+      // Otherwise → config_based (database-driven dynamic tools)
+      return {
+        type: 'config_based',
+        toolsetKey,
+      };
+    }
+
+    // No record found anywhere
+    throw new ToolsetNotFoundError(`Toolset not found: ${toolsetKey}`);
+  }
+
+  /**
+   * Identify tool type without requiring user authentication.
+   * Used for schema export where we only need to determine tool type.
+   * Does not validate OAuth connections or user-specific access.
+   * Supports both global and user-specific toolsets.
+   *
+   * @param toolsetKey - The toolset key
+   * @returns Tool identification with type (without connection info)
+   */
+  async identifyToolType(toolsetKey: string): Promise<ToolIdentification> {
+    // Step 1: Check if it's a builtin tool first
+    if (builtinToolsetInventory[toolsetKey]) {
+      return {
+        type: 'builtin',
+        toolsetKey,
+      };
+    }
+
+    // Step 2: Check toolset_inventory for type information
+    const inventory = await this.prisma.toolsetInventory.findFirst({
+      where: {
+        key: toolsetKey,
+        enabled: true,
+        deletedAt: null,
+      },
+    });
+
+    if (inventory) {
+      // Determine type based on inventory type field
+      if (inventory.type === 'external_oauth') {
+        return {
+          type: 'composio_oauth',
+          toolsetKey,
+        };
+      }
+
+      if (inventory.type === 'external_apikey') {
+        return {
+          type: 'composio_apikey',
+          toolsetKey,
+        };
+      }
+
+      // Check if it has a class in static inventory
+      const inventoryItem = await this.inventoryService.getInventoryItem(toolsetKey);
+      if (inventoryItem?.class) {
+        return {
+          type: 'legacy_sdk',
+          toolsetKey,
+        };
+      }
+
+      // Default to config_based
+      return {
+        type: 'config_based',
+        toolsetKey,
+      };
+    }
+
+    // Step 3: Check toolset table (both global and user-specific)
+    // For schema export, we don't restrict to global only
+    const toolset = await this.prisma.toolset.findFirst({
+      where: {
+        key: toolsetKey,
+        enabled: true,
+        deletedAt: null,
+        uninstalled: false,
+      },
+      // Prefer global toolset over user-specific for consistency
+      orderBy: { isGlobal: 'desc' },
+    });
+
+    if (toolset) {
+      if (toolset.authType === 'oauth') {
+        return {
+          type: 'composio_oauth',
+          toolsetKey,
+        };
+      }
+
+      if (toolset.authType === 'external_apikey') {
+        return {
+          type: 'composio_apikey',
+          toolsetKey,
+        };
+      }
+
+      // Check static inventory for legacy SDK
+      const inventoryItem = await this.inventoryService.getInventoryItem(toolsetKey);
+      if (inventoryItem?.class) {
+        return {
+          type: 'legacy_sdk',
+          toolsetKey,
+        };
+      }
+
+      return {
+        type: 'config_based',
+        toolsetKey,
+      };
+    }
+
+    // No record found anywhere
+    throw new ToolsetNotFoundError(`Toolset not found: ${toolsetKey}`);
+  }
+}

--- a/apps/api/src/modules/tool/tool.controller.ts
+++ b/apps/api/src/modules/tool/tool.controller.ts
@@ -4,6 +4,7 @@ import { LoginedUser } from '../../utils/decorators/user.decorator';
 import { User as UserModel } from '@prisma/client';
 import { buildSuccessResponse } from '../../utils/response';
 import { ToolService } from './tool.service';
+import { ToolExecutionService, ToolDefinitionService } from './ptc';
 import {
   BaseResponse,
   ListToolsResponse,
@@ -14,12 +15,19 @@ import {
   ListToolsetInventoryResponse,
   ListUserToolsResponse,
   GetToolCallResultResponse,
+  ExecuteToolRequest,
+  ExecuteToolResponse,
+  ExportToolsetDefinitionsResponse,
 } from '@refly/openapi-schema';
 import { toolsetPO2DTO } from './tool.dto';
 
 @Controller('v1/tool')
 export class ToolController {
-  constructor(private readonly toolService: ToolService) {}
+  constructor(
+    private readonly toolService: ToolService,
+    private readonly toolExecutionService: ToolExecutionService,
+    private readonly toolDefinitionService: ToolDefinitionService,
+  ) {}
 
   @UseGuards(JwtAuthGuard)
   @Get('/list')
@@ -100,6 +108,15 @@ export class ToolController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @Get('/toolset/exportDefinitions')
+  async exportToolsetDefinitions(
+    @Query('toolsetKey') toolsetKey?: string,
+  ): Promise<ExportToolsetDefinitionsResponse> {
+    const definitions = await this.toolDefinitionService.exportToolsetDefinitions(toolsetKey);
+    return buildSuccessResponse(definitions);
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Get('/call/result')
   async getToolCallResult(
     @LoginedUser() user: UserModel,
@@ -107,5 +124,15 @@ export class ToolController {
   ): Promise<GetToolCallResultResponse> {
     const result = await this.toolService.getToolCallResult(user, toolCallId);
     return buildSuccessResponse({ result });
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('/execute')
+  async executeTool(
+    @LoginedUser() user: UserModel,
+    @Body() request: ExecuteToolRequest,
+  ): Promise<ExecuteToolResponse> {
+    const result = await this.toolExecutionService.executeTool(user, request);
+    return buildSuccessResponse(result);
   }
 }

--- a/apps/api/src/modules/tool/tool.module.ts
+++ b/apps/api/src/modules/tool/tool.module.ts
@@ -25,6 +25,7 @@ import {
   RegularToolPostHandlerService,
   ToolWrapperFactoryService,
 } from './tool-execution';
+import { ToolExecutionService, ToolIdentifyService, ToolDefinitionService } from './ptc';
 import { ToolController } from './tool.controller';
 import { ToolService } from './tool.service';
 
@@ -48,6 +49,12 @@ import { ToolService } from './tool.service';
   controllers: [ToolController],
   providers: [
     ToolService,
+    // Tool identify service for determining tool type
+    ToolIdentifyService,
+    // Tool execution service for API-based tool execution
+    ToolExecutionService,
+    // Tool definition service for schema export
+    ToolDefinitionService,
 
     SyncToolCreditUsageProcessor,
     // Tool inventory service (loads from database)

--- a/packages/ai-workspace-common/src/queries/common.ts
+++ b/packages/ai-workspace-common/src/queries/common.ts
@@ -69,9 +69,11 @@ import {
   duplicateShare,
   emailLogin,
   emailSignup,
+  executeTool,
   executeWorkflowApp,
   exportCanvas,
   exportDocument,
+  exportToolsetDefinitions,
   extractVariables,
   generateAppTemplate,
   generateMedia,
@@ -977,6 +979,18 @@ export const UseListToolsetsKeyFn = (
   clientOptions: Options<unknown, true> = {},
   queryKey?: Array<unknown>,
 ) => [useListToolsetsKey, ...(queryKey ?? [clientOptions])];
+export type ExportToolsetDefinitionsDefaultResponse = Awaited<
+  ReturnType<typeof exportToolsetDefinitions>
+>['data'];
+export type ExportToolsetDefinitionsQueryResult<
+  TData = ExportToolsetDefinitionsDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useExportToolsetDefinitionsKey = 'ExportToolsetDefinitions';
+export const UseExportToolsetDefinitionsKeyFn = (
+  clientOptions: Options<unknown, true> = {},
+  queryKey?: Array<unknown>,
+) => [useExportToolsetDefinitionsKey, ...(queryKey ?? [clientOptions])];
 export type GetToolCallResultDefaultResponse = Awaited<
   ReturnType<typeof getToolCallResult>
 >['data'];
@@ -1729,6 +1743,12 @@ export type DeleteToolsetMutationResult = Awaited<ReturnType<typeof deleteToolse
 export const useDeleteToolsetKey = 'DeleteToolset';
 export const UseDeleteToolsetKeyFn = (mutationKey?: Array<unknown>) => [
   useDeleteToolsetKey,
+  ...(mutationKey ?? []),
+];
+export type ExecuteToolMutationResult = Awaited<ReturnType<typeof executeTool>>;
+export const useExecuteToolKey = 'ExecuteTool';
+export const UseExecuteToolKeyFn = (mutationKey?: Array<unknown>) => [
+  useExecuteToolKey,
   ...(mutationKey ?? []),
 ];
 export type AuthorizeComposioConnectionMutationResult = Awaited<

--- a/packages/ai-workspace-common/src/queries/ensureQueryData.ts
+++ b/packages/ai-workspace-common/src/queries/ensureQueryData.ts
@@ -8,6 +8,7 @@ import {
   downloadExportJobResult,
   exportCanvas,
   exportDocument,
+  exportToolsetDefinitions,
   getActionResult,
   getAuthConfig,
   getAvailableVouchers,
@@ -87,6 +88,7 @@ import {
   DownloadExportJobResultData,
   ExportCanvasData,
   ExportDocumentData,
+  ExportToolsetDefinitionsData,
   GetActionResultData,
   GetCanvasCommissionByCanvasIdData,
   GetCanvasDataData,
@@ -704,6 +706,14 @@ export const ensureUseListToolsetsData = (
   queryClient.ensureQueryData({
     queryKey: Common.UseListToolsetsKeyFn(clientOptions),
     queryFn: () => listToolsets({ ...clientOptions }).then((response) => response.data),
+  });
+export const ensureUseExportToolsetDefinitionsData = (
+  queryClient: QueryClient,
+  clientOptions: Options<ExportToolsetDefinitionsData, true> = {},
+) =>
+  queryClient.ensureQueryData({
+    queryKey: Common.UseExportToolsetDefinitionsKeyFn(clientOptions),
+    queryFn: () => exportToolsetDefinitions({ ...clientOptions }).then((response) => response.data),
   });
 export const ensureUseGetToolCallResultData = (
   queryClient: QueryClient,

--- a/packages/ai-workspace-common/src/queries/prefetch.ts
+++ b/packages/ai-workspace-common/src/queries/prefetch.ts
@@ -8,6 +8,7 @@ import {
   downloadExportJobResult,
   exportCanvas,
   exportDocument,
+  exportToolsetDefinitions,
   getActionResult,
   getAuthConfig,
   getAvailableVouchers,
@@ -87,6 +88,7 @@ import {
   DownloadExportJobResultData,
   ExportCanvasData,
   ExportDocumentData,
+  ExportToolsetDefinitionsData,
   GetActionResultData,
   GetCanvasCommissionByCanvasIdData,
   GetCanvasDataData,
@@ -704,6 +706,14 @@ export const prefetchUseListToolsets = (
   queryClient.prefetchQuery({
     queryKey: Common.UseListToolsetsKeyFn(clientOptions),
     queryFn: () => listToolsets({ ...clientOptions }).then((response) => response.data),
+  });
+export const prefetchUseExportToolsetDefinitions = (
+  queryClient: QueryClient,
+  clientOptions: Options<ExportToolsetDefinitionsData, true> = {},
+) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseExportToolsetDefinitionsKeyFn(clientOptions),
+    queryFn: () => exportToolsetDefinitions({ ...clientOptions }).then((response) => response.data),
   });
 export const prefetchUseGetToolCallResult = (
   queryClient: QueryClient,

--- a/packages/ai-workspace-common/src/queries/queries.ts
+++ b/packages/ai-workspace-common/src/queries/queries.ts
@@ -70,9 +70,11 @@ import {
   duplicateShare,
   emailLogin,
   emailSignup,
+  executeTool,
   executeWorkflowApp,
   exportCanvas,
   exportDocument,
+  exportToolsetDefinitions,
   extractVariables,
   generateAppTemplate,
   generateMedia,
@@ -336,12 +338,16 @@ import {
   EmailLoginError,
   EmailSignupData,
   EmailSignupError,
+  ExecuteToolData,
+  ExecuteToolError,
   ExecuteWorkflowAppData,
   ExecuteWorkflowAppError,
   ExportCanvasData,
   ExportCanvasError,
   ExportDocumentData,
   ExportDocumentError,
+  ExportToolsetDefinitionsData,
+  ExportToolsetDefinitionsError,
   ExtractVariablesData,
   ExtractVariablesError,
   GenerateAppTemplateData,
@@ -1669,6 +1675,23 @@ export const useListToolsets = <
     queryKey: Common.UseListToolsetsKeyFn(clientOptions, queryKey),
     queryFn: () =>
       listToolsets({ ...clientOptions }).then((response) => response.data as TData) as TData,
+    ...options,
+  });
+export const useExportToolsetDefinitions = <
+  TData = Common.ExportToolsetDefinitionsDefaultResponse,
+  TError = ExportToolsetDefinitionsError,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  clientOptions: Options<ExportToolsetDefinitionsData, true> = {},
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, 'queryKey' | 'queryFn'>,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseExportToolsetDefinitionsKeyFn(clientOptions, queryKey),
+    queryFn: () =>
+      exportToolsetDefinitions({ ...clientOptions }).then(
+        (response) => response.data as TData,
+      ) as TData,
     ...options,
   });
 export const useGetToolCallResult = <
@@ -3648,6 +3671,23 @@ export const useDeleteToolset = <
   useMutation<TData, TError, Options<DeleteToolsetData, true>, TContext>({
     mutationKey: Common.UseDeleteToolsetKeyFn(mutationKey),
     mutationFn: (clientOptions) => deleteToolset(clientOptions) as unknown as Promise<TData>,
+    ...options,
+  });
+export const useExecuteTool = <
+  TData = Common.ExecuteToolMutationResult,
+  TError = ExecuteToolError,
+  TQueryKey extends Array<unknown> = unknown[],
+  TContext = unknown,
+>(
+  mutationKey?: TQueryKey,
+  options?: Omit<
+    UseMutationOptions<TData, TError, Options<ExecuteToolData, true>, TContext>,
+    'mutationKey' | 'mutationFn'
+  >,
+) =>
+  useMutation<TData, TError, Options<ExecuteToolData, true>, TContext>({
+    mutationKey: Common.UseExecuteToolKeyFn(mutationKey),
+    mutationFn: (clientOptions) => executeTool(clientOptions) as unknown as Promise<TData>,
     ...options,
   });
 export const useAuthorizeComposioConnection = <

--- a/packages/ai-workspace-common/src/queries/suspense.ts
+++ b/packages/ai-workspace-common/src/queries/suspense.ts
@@ -8,6 +8,7 @@ import {
   downloadExportJobResult,
   exportCanvas,
   exportDocument,
+  exportToolsetDefinitions,
   getActionResult,
   getAuthConfig,
   getAvailableVouchers,
@@ -92,6 +93,8 @@ import {
   ExportCanvasError,
   ExportDocumentData,
   ExportDocumentError,
+  ExportToolsetDefinitionsData,
+  ExportToolsetDefinitionsError,
   GetActionResultData,
   GetActionResultError,
   GetAuthConfigError,
@@ -1306,6 +1309,23 @@ export const useListToolsetsSuspense = <
     queryKey: Common.UseListToolsetsKeyFn(clientOptions, queryKey),
     queryFn: () =>
       listToolsets({ ...clientOptions }).then((response) => response.data as TData) as TData,
+    ...options,
+  });
+export const useExportToolsetDefinitionsSuspense = <
+  TData = Common.ExportToolsetDefinitionsDefaultResponse,
+  TError = ExportToolsetDefinitionsError,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  clientOptions: Options<ExportToolsetDefinitionsData, true> = {},
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, 'queryKey' | 'queryFn'>,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseExportToolsetDefinitionsKeyFn(clientOptions, queryKey),
+    queryFn: () =>
+      exportToolsetDefinitions({ ...clientOptions }).then(
+        (response) => response.data as TData,
+      ) as TData,
     ...options,
   });
 export const useGetToolCallResultSuspense = <

--- a/packages/ai-workspace-common/src/requests/services.gen.ts
+++ b/packages/ai-workspace-common/src/requests/services.gen.ts
@@ -536,6 +536,12 @@ import type {
   DeleteToolsetData,
   DeleteToolsetError,
   DeleteToolsetResponse,
+  ExportToolsetDefinitionsData,
+  ExportToolsetDefinitionsError,
+  ExportToolsetDefinitionsResponse2,
+  ExecuteToolData,
+  ExecuteToolError,
+  ExecuteToolResponse2,
   GetToolCallResultData,
   GetToolCallResultError,
   GetToolCallResultResponse2,
@@ -3525,6 +3531,36 @@ export const deleteToolset = <ThrowOnError extends boolean = false>(
   return (options?.client ?? client).post<DeleteToolsetResponse, DeleteToolsetError, ThrowOnError>({
     ...options,
     url: '/tool/toolset/delete',
+  });
+};
+
+/**
+ * Export toolset definitions
+ * Export tool schemas for specified toolsets. Used for generating Python SDK.
+ */
+export const exportToolsetDefinitions = <ThrowOnError extends boolean = false>(
+  options?: Options<ExportToolsetDefinitionsData, ThrowOnError>,
+) => {
+  return (options?.client ?? client).get<
+    ExportToolsetDefinitionsResponse2,
+    ExportToolsetDefinitionsError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/tool/toolset/exportDefinitions',
+  });
+};
+
+/**
+ * Execute tool
+ * Execute a tool by toolset key and tool name.
+ */
+export const executeTool = <ThrowOnError extends boolean = false>(
+  options: Options<ExecuteToolData, ThrowOnError>,
+) => {
+  return (options?.client ?? client).post<ExecuteToolResponse2, ExecuteToolError, ThrowOnError>({
+    ...options,
+    url: '/tool/execute',
   });
 };
 

--- a/packages/ai-workspace-common/src/requests/types.gen.ts
+++ b/packages/ai-workspace-common/src/requests/types.gen.ts
@@ -7642,6 +7642,69 @@ export type DeleteToolsetRequest = {
   toolsetId: string;
 };
 
+export type ExecuteToolRequest = {
+  /**
+   * Toolset key
+   */
+  toolsetKey: string;
+  /**
+   * Tool method name to execute
+   */
+  toolName: string;
+  /**
+   * Tool arguments
+   */
+  arguments: {
+    [key: string]: unknown;
+  };
+};
+
+export type ExecuteToolResponse = BaseResponse & {
+  /**
+   * Tool execution result data
+   */
+  data?: {
+    [key: string]: unknown;
+  };
+};
+
+export type ExportToolsetDefinitionsResponse = BaseResponse & {
+  data?: Array<ToolsetExportDefinition>;
+};
+
+export type ToolsetExportDefinition = {
+  /**
+   * Toolset unique key
+   */
+  key?: string;
+  /**
+   * Toolset display name
+   */
+  name?: string;
+  /**
+   * Toolset description
+   */
+  description?: string;
+  tools?: Array<ToolExportDefinition>;
+};
+
+export type ToolExportDefinition = {
+  /**
+   * Tool method name
+   */
+  name?: string;
+  /**
+   * Tool description
+   */
+  description?: string;
+  /**
+   * JSON Schema format input parameter definition
+   */
+  inputSchema?: {
+    [key: string]: unknown;
+  };
+};
+
 export type GetToolCallResultResponse = BaseResponse & {
   data?: {
     result?: ToolCallResult;
@@ -12237,6 +12300,27 @@ export type DeleteToolsetData = {
 export type DeleteToolsetResponse = BaseResponse;
 
 export type DeleteToolsetError = unknown;
+
+export type ExportToolsetDefinitionsData = {
+  query?: {
+    /**
+     * Toolset key(s) to export, comma-separated for multiple toolsets. If not provided, exports all supported toolsets.
+     */
+    toolsetKey?: string;
+  };
+};
+
+export type ExportToolsetDefinitionsResponse2 = ExportToolsetDefinitionsResponse;
+
+export type ExportToolsetDefinitionsError = unknown;
+
+export type ExecuteToolData = {
+  body: ExecuteToolRequest;
+};
+
+export type ExecuteToolResponse2 = ExecuteToolResponse;
+
+export type ExecuteToolError = unknown;
 
 export type GetToolCallResultData = {
   query: {

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -4399,6 +4399,51 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseResponse'
+  /tool/toolset/exportDefinitions:
+    get:
+      tags:
+        - tool
+      summary: Export toolset definitions
+      description: Export tool schemas for specified toolsets. Used for generating Python SDK.
+      operationId: exportToolsetDefinitions
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: toolsetKey
+          in: query
+          required: false
+          description: Toolset key(s) to export, comma-separated for multiple toolsets. If not provided, exports all supported toolsets.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportToolsetDefinitionsResponse'
+  /tool/execute:
+    post:
+      tags:
+        - tool
+      summary: Execute tool
+      description: Execute a tool by toolset key and tool name.
+      operationId: executeTool
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExecuteToolRequest'
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExecuteToolResponse'
   /tool/call/result:
     get:
       tags:
@@ -12376,6 +12421,70 @@ components:
         toolsetId:
           type: string
           description: Toolset ID
+    ExecuteToolRequest:
+      type: object
+      required:
+        - toolsetKey
+        - toolName
+        - arguments
+      properties:
+        toolsetKey:
+          type: string
+          description: Toolset key
+        toolName:
+          type: string
+          description: Tool method name to execute
+        arguments:
+          type: object
+          additionalProperties: true
+          description: Tool arguments
+    ExecuteToolResponse:
+      allOf:
+        - $ref: '#/components/schemas/BaseResponse'
+        - type: object
+          properties:
+            data:
+              type: object
+              additionalProperties: true
+              description: Tool execution result data
+    ExportToolsetDefinitionsResponse:
+      allOf:
+        - $ref: '#/components/schemas/BaseResponse'
+        - type: object
+          properties:
+            data:
+              type: array
+              items:
+                $ref: '#/components/schemas/ToolsetExportDefinition'
+    ToolsetExportDefinition:
+      type: object
+      properties:
+        key:
+          type: string
+          description: Toolset unique key
+        name:
+          type: string
+          description: Toolset display name
+        description:
+          type: string
+          description: Toolset description
+        tools:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolExportDefinition'
+    ToolExportDefinition:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Tool method name
+        description:
+          type: string
+          description: Tool description
+        inputSchema:
+          type: object
+          additionalProperties: true
+          description: JSON Schema format input parameter definition
     GetToolCallResultResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -10643,6 +10643,106 @@ export const DeleteToolsetRequestSchema = {
   },
 } as const;
 
+export const ExecuteToolRequestSchema = {
+  type: 'object',
+  required: ['toolsetKey', 'toolName', 'arguments'],
+  properties: {
+    toolsetKey: {
+      type: 'string',
+      description: 'Toolset key',
+    },
+    toolName: {
+      type: 'string',
+      description: 'Tool method name to execute',
+    },
+    arguments: {
+      type: 'object',
+      additionalProperties: true,
+      description: 'Tool arguments',
+    },
+  },
+} as const;
+
+export const ExecuteToolResponseSchema = {
+  allOf: [
+    {
+      $ref: '#/components/schemas/BaseResponse',
+    },
+    {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'object',
+          additionalProperties: true,
+          description: 'Tool execution result data',
+        },
+      },
+    },
+  ],
+} as const;
+
+export const ExportToolsetDefinitionsResponseSchema = {
+  allOf: [
+    {
+      $ref: '#/components/schemas/BaseResponse',
+    },
+    {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'array',
+          items: {
+            $ref: '#/components/schemas/ToolsetExportDefinition',
+          },
+        },
+      },
+    },
+  ],
+} as const;
+
+export const ToolsetExportDefinitionSchema = {
+  type: 'object',
+  properties: {
+    key: {
+      type: 'string',
+      description: 'Toolset unique key',
+    },
+    name: {
+      type: 'string',
+      description: 'Toolset display name',
+    },
+    description: {
+      type: 'string',
+      description: 'Toolset description',
+    },
+    tools: {
+      type: 'array',
+      items: {
+        $ref: '#/components/schemas/ToolExportDefinition',
+      },
+    },
+  },
+} as const;
+
+export const ToolExportDefinitionSchema = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      description: 'Tool method name',
+    },
+    description: {
+      type: 'string',
+      description: 'Tool description',
+    },
+    inputSchema: {
+      type: 'object',
+      additionalProperties: true,
+      description: 'JSON Schema format input parameter definition',
+    },
+  },
+} as const;
+
 export const GetToolCallResultResponseSchema = {
   allOf: [
     {

--- a/packages/openapi-schema/src/services.gen.ts
+++ b/packages/openapi-schema/src/services.gen.ts
@@ -536,6 +536,12 @@ import type {
   DeleteToolsetData,
   DeleteToolsetError,
   DeleteToolsetResponse,
+  ExportToolsetDefinitionsData,
+  ExportToolsetDefinitionsError,
+  ExportToolsetDefinitionsResponse2,
+  ExecuteToolData,
+  ExecuteToolError,
+  ExecuteToolResponse2,
   GetToolCallResultData,
   GetToolCallResultError,
   GetToolCallResultResponse2,
@@ -3525,6 +3531,36 @@ export const deleteToolset = <ThrowOnError extends boolean = false>(
   return (options?.client ?? client).post<DeleteToolsetResponse, DeleteToolsetError, ThrowOnError>({
     ...options,
     url: '/tool/toolset/delete',
+  });
+};
+
+/**
+ * Export toolset definitions
+ * Export tool schemas for specified toolsets. Used for generating Python SDK.
+ */
+export const exportToolsetDefinitions = <ThrowOnError extends boolean = false>(
+  options?: Options<ExportToolsetDefinitionsData, ThrowOnError>,
+) => {
+  return (options?.client ?? client).get<
+    ExportToolsetDefinitionsResponse2,
+    ExportToolsetDefinitionsError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/tool/toolset/exportDefinitions',
+  });
+};
+
+/**
+ * Execute tool
+ * Execute a tool by toolset key and tool name.
+ */
+export const executeTool = <ThrowOnError extends boolean = false>(
+  options: Options<ExecuteToolData, ThrowOnError>,
+) => {
+  return (options?.client ?? client).post<ExecuteToolResponse2, ExecuteToolError, ThrowOnError>({
+    ...options,
+    url: '/tool/execute',
   });
 };
 

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -7642,6 +7642,69 @@ export type DeleteToolsetRequest = {
   toolsetId: string;
 };
 
+export type ExecuteToolRequest = {
+  /**
+   * Toolset key
+   */
+  toolsetKey: string;
+  /**
+   * Tool method name to execute
+   */
+  toolName: string;
+  /**
+   * Tool arguments
+   */
+  arguments: {
+    [key: string]: unknown;
+  };
+};
+
+export type ExecuteToolResponse = BaseResponse & {
+  /**
+   * Tool execution result data
+   */
+  data?: {
+    [key: string]: unknown;
+  };
+};
+
+export type ExportToolsetDefinitionsResponse = BaseResponse & {
+  data?: Array<ToolsetExportDefinition>;
+};
+
+export type ToolsetExportDefinition = {
+  /**
+   * Toolset unique key
+   */
+  key?: string;
+  /**
+   * Toolset display name
+   */
+  name?: string;
+  /**
+   * Toolset description
+   */
+  description?: string;
+  tools?: Array<ToolExportDefinition>;
+};
+
+export type ToolExportDefinition = {
+  /**
+   * Tool method name
+   */
+  name?: string;
+  /**
+   * Tool description
+   */
+  description?: string;
+  /**
+   * JSON Schema format input parameter definition
+   */
+  inputSchema?: {
+    [key: string]: unknown;
+  };
+};
+
 export type GetToolCallResultResponse = BaseResponse & {
   data?: {
     result?: ToolCallResult;
@@ -12237,6 +12300,27 @@ export type DeleteToolsetData = {
 export type DeleteToolsetResponse = BaseResponse;
 
 export type DeleteToolsetError = unknown;
+
+export type ExportToolsetDefinitionsData = {
+  query?: {
+    /**
+     * Toolset key(s) to export, comma-separated for multiple toolsets. If not provided, exports all supported toolsets.
+     */
+    toolsetKey?: string;
+  };
+};
+
+export type ExportToolsetDefinitionsResponse2 = ExportToolsetDefinitionsResponse;
+
+export type ExportToolsetDefinitionsError = unknown;
+
+export type ExecuteToolData = {
+  body: ExecuteToolRequest;
+};
+
+export type ExecuteToolResponse2 = ExecuteToolResponse;
+
+export type ExecuteToolError = unknown;
 
 export type GetToolCallResultData = {
   query: {

--- a/packages/request/src/queries/ensureQueryData.ts
+++ b/packages/request/src/queries/ensureQueryData.ts
@@ -8,6 +8,7 @@ import {
   downloadExportJobResult,
   exportCanvas,
   exportDocument,
+  exportToolsetDefinitions,
   getActionResult,
   getAuthConfig,
   getAvailableVouchers,
@@ -87,6 +88,7 @@ import {
   DownloadExportJobResultData,
   ExportCanvasData,
   ExportDocumentData,
+  ExportToolsetDefinitionsData,
   GetActionResultData,
   GetCanvasCommissionByCanvasIdData,
   GetCanvasDataData,
@@ -704,6 +706,14 @@ export const ensureUseListToolsetsData = (
   queryClient.ensureQueryData({
     queryKey: Common.UseListToolsetsKeyFn(clientOptions),
     queryFn: () => listToolsets({ ...clientOptions }).then((response) => response.data),
+  });
+export const ensureUseExportToolsetDefinitionsData = (
+  queryClient: QueryClient,
+  clientOptions: Options<ExportToolsetDefinitionsData, true> = {},
+) =>
+  queryClient.ensureQueryData({
+    queryKey: Common.UseExportToolsetDefinitionsKeyFn(clientOptions),
+    queryFn: () => exportToolsetDefinitions({ ...clientOptions }).then((response) => response.data),
   });
 export const ensureUseGetToolCallResultData = (
   queryClient: QueryClient,

--- a/packages/request/src/queries/prefetch.ts
+++ b/packages/request/src/queries/prefetch.ts
@@ -8,6 +8,7 @@ import {
   downloadExportJobResult,
   exportCanvas,
   exportDocument,
+  exportToolsetDefinitions,
   getActionResult,
   getAuthConfig,
   getAvailableVouchers,
@@ -87,6 +88,7 @@ import {
   DownloadExportJobResultData,
   ExportCanvasData,
   ExportDocumentData,
+  ExportToolsetDefinitionsData,
   GetActionResultData,
   GetCanvasCommissionByCanvasIdData,
   GetCanvasDataData,
@@ -704,6 +706,14 @@ export const prefetchUseListToolsets = (
   queryClient.prefetchQuery({
     queryKey: Common.UseListToolsetsKeyFn(clientOptions),
     queryFn: () => listToolsets({ ...clientOptions }).then((response) => response.data),
+  });
+export const prefetchUseExportToolsetDefinitions = (
+  queryClient: QueryClient,
+  clientOptions: Options<ExportToolsetDefinitionsData, true> = {},
+) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseExportToolsetDefinitionsKeyFn(clientOptions),
+    queryFn: () => exportToolsetDefinitions({ ...clientOptions }).then((response) => response.data),
   });
 export const prefetchUseGetToolCallResult = (
   queryClient: QueryClient,

--- a/packages/request/src/queries/suspense.ts
+++ b/packages/request/src/queries/suspense.ts
@@ -8,6 +8,7 @@ import {
   downloadExportJobResult,
   exportCanvas,
   exportDocument,
+  exportToolsetDefinitions,
   getActionResult,
   getAuthConfig,
   getAvailableVouchers,
@@ -92,6 +93,8 @@ import {
   ExportCanvasError,
   ExportDocumentData,
   ExportDocumentError,
+  ExportToolsetDefinitionsData,
+  ExportToolsetDefinitionsError,
   GetActionResultData,
   GetActionResultError,
   GetAuthConfigError,
@@ -1306,6 +1309,23 @@ export const useListToolsetsSuspense = <
     queryKey: Common.UseListToolsetsKeyFn(clientOptions, queryKey),
     queryFn: () =>
       listToolsets({ ...clientOptions }).then((response) => response.data as TData) as TData,
+    ...options,
+  });
+export const useExportToolsetDefinitionsSuspense = <
+  TData = Common.ExportToolsetDefinitionsDefaultResponse,
+  TError = ExportToolsetDefinitionsError,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  clientOptions: Options<ExportToolsetDefinitionsData, true> = {},
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, 'queryKey' | 'queryFn'>,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseExportToolsetDefinitionsKeyFn(clientOptions, queryKey),
+    queryFn: () =>
+      exportToolsetDefinitions({ ...clientOptions }).then(
+        (response) => response.data as TData,
+      ) as TData,
     ...options,
   });
 export const useGetToolCallResultSuspense = <

--- a/packages/request/src/requests/services.gen.ts
+++ b/packages/request/src/requests/services.gen.ts
@@ -536,6 +536,12 @@ import type {
   DeleteToolsetData,
   DeleteToolsetError,
   DeleteToolsetResponse,
+  ExportToolsetDefinitionsData,
+  ExportToolsetDefinitionsError,
+  ExportToolsetDefinitionsResponse2,
+  ExecuteToolData,
+  ExecuteToolError,
+  ExecuteToolResponse2,
   GetToolCallResultData,
   GetToolCallResultError,
   GetToolCallResultResponse2,
@@ -3525,6 +3531,36 @@ export const deleteToolset = <ThrowOnError extends boolean = false>(
   return (options?.client ?? client).post<DeleteToolsetResponse, DeleteToolsetError, ThrowOnError>({
     ...options,
     url: '/tool/toolset/delete',
+  });
+};
+
+/**
+ * Export toolset definitions
+ * Export tool schemas for specified toolsets. Used for generating Python SDK.
+ */
+export const exportToolsetDefinitions = <ThrowOnError extends boolean = false>(
+  options?: Options<ExportToolsetDefinitionsData, ThrowOnError>,
+) => {
+  return (options?.client ?? client).get<
+    ExportToolsetDefinitionsResponse2,
+    ExportToolsetDefinitionsError,
+    ThrowOnError
+  >({
+    ...options,
+    url: '/tool/toolset/exportDefinitions',
+  });
+};
+
+/**
+ * Execute tool
+ * Execute a tool by toolset key and tool name.
+ */
+export const executeTool = <ThrowOnError extends boolean = false>(
+  options: Options<ExecuteToolData, ThrowOnError>,
+) => {
+  return (options?.client ?? client).post<ExecuteToolResponse2, ExecuteToolError, ThrowOnError>({
+    ...options,
+    url: '/tool/execute',
   });
 };
 

--- a/packages/request/src/requests/types.gen.ts
+++ b/packages/request/src/requests/types.gen.ts
@@ -7642,6 +7642,69 @@ export type DeleteToolsetRequest = {
   toolsetId: string;
 };
 
+export type ExecuteToolRequest = {
+  /**
+   * Toolset key
+   */
+  toolsetKey: string;
+  /**
+   * Tool method name to execute
+   */
+  toolName: string;
+  /**
+   * Tool arguments
+   */
+  arguments: {
+    [key: string]: unknown;
+  };
+};
+
+export type ExecuteToolResponse = BaseResponse & {
+  /**
+   * Tool execution result data
+   */
+  data?: {
+    [key: string]: unknown;
+  };
+};
+
+export type ExportToolsetDefinitionsResponse = BaseResponse & {
+  data?: Array<ToolsetExportDefinition>;
+};
+
+export type ToolsetExportDefinition = {
+  /**
+   * Toolset unique key
+   */
+  key?: string;
+  /**
+   * Toolset display name
+   */
+  name?: string;
+  /**
+   * Toolset description
+   */
+  description?: string;
+  tools?: Array<ToolExportDefinition>;
+};
+
+export type ToolExportDefinition = {
+  /**
+   * Tool method name
+   */
+  name?: string;
+  /**
+   * Tool description
+   */
+  description?: string;
+  /**
+   * JSON Schema format input parameter definition
+   */
+  inputSchema?: {
+    [key: string]: unknown;
+  };
+};
+
 export type GetToolCallResultResponse = BaseResponse & {
   data?: {
     result?: ToolCallResult;
@@ -12237,6 +12300,27 @@ export type DeleteToolsetData = {
 export type DeleteToolsetResponse = BaseResponse;
 
 export type DeleteToolsetError = unknown;
+
+export type ExportToolsetDefinitionsData = {
+  query?: {
+    /**
+     * Toolset key(s) to export, comma-separated for multiple toolsets. If not provided, exports all supported toolsets.
+     */
+    toolsetKey?: string;
+  };
+};
+
+export type ExportToolsetDefinitionsResponse2 = ExportToolsetDefinitionsResponse;
+
+export type ExportToolsetDefinitionsError = unknown;
+
+export type ExecuteToolData = {
+  body: ExecuteToolRequest;
+};
+
+export type ExecuteToolResponse2 = ExecuteToolResponse;
+
+export type ExecuteToolError = unknown;
 
 export type GetToolCallResultData = {
   query: {


### PR DESCRIPTION
## Summary

This PR adds unified tool execution and definition services for PTC (Python Tool Client). The implementation provides a clean API interface for executing tools and exporting toolset schemas.

## Changes

- Add ToolExecutionService for unified tool execution via API
- Add ToolIdentifyService for tool type identification and routing
- Add ToolDefinitionService for toolset schema export
- Add POST /v1/tool/execute endpoint for executing tools
- Add GET /v1/tool/toolset/exportDefinitions endpoint for schema export
- Update OpenAPI schema with new request/response types
- Add frontend query hooks and request types for new endpoints