### PR TITLE
[REF-1213]  Prevent root HTML caching and stabilize user settings fetch

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,16 +1,12 @@
-import { Suspense, useEffect, lazy, useMemo } from 'react';
+import { Suspense, useEffect, useMemo } from 'react';
 import { Route, Routes, useLocation } from 'react-router-dom';
 import { InlineLoading } from '@refly/ui-kit';
-
-const AppLayout = lazy(() =>
-  import('@refly/web-core/src/components/layout').then((m) => ({ default: m.AppLayout })),
-);
+import { AppLayout, LazyErrorBoundary } from '@refly/web-core';
 
 import { RoutesList } from './routes';
 import { InitializationSuspense } from './prepare/InitializationSuspense';
 import { shouldSkipLayout } from './config/layout';
 import { GlobalSEO } from './components/GlobalSEO';
-import { LazyErrorBoundary } from '@refly/web-core';
 
 const AppContent = () => {
   const location = useLocation();

--- a/packages/ai-workspace-common/src/components/pure-copilot/index.tsx
+++ b/packages/ai-workspace-common/src/components/pure-copilot/index.tsx
@@ -78,7 +78,6 @@ export const PureCopilot = memo(({ source, classnames, onFloatingChange }: PureC
   }, []);
 
   const { data, isLoading, refetch } = useGetPromptSuggestions();
-  console.log('data', data);
 
   useEffect(() => {
     if (!showOnboardingFormModal) {


### PR DESCRIPTION

  # Summary
  - Use direct `AppLayout` import from `@refly/web-core` and remove a stray `console.log`.
  - Deduplicate `useGetUserSettings` by per-UID key and guard against stale responses; run modal checks
  asynchronously.
  - Make logout resilient to API failure and reset in-flight settings state on logout.

  # Impact Areas
  - [x] Web App (Service Worker + Runtime Caching)
  - [x] Auth/Session (User Settings + Logout)

  # Checklist
  - [ ] I ran tests (not run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced caching strategy for async JavaScript chunks with 1-year duration
  * Root path excluded from HTML runtime caching rules

* **Bug Fixes**
  * Improved request lifecycle management to prevent stale user settings requests
  * Enhanced logout flow with cross-tab synchronization and graceful error handling

* **Refactoring**
  * Simplified component loading by removing dynamic imports

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->