### PR TITLE
[REF-1290] feat: Add PTC mode toggle system with user and toolset allowlists

### DIFF
--- a/apps/api/src/modules/config/app.config.ts
+++ b/apps/api/src/modules/config/app.config.ts
@@ -246,6 +246,12 @@ export default () => ({
     // For testing, use smaller values like 7 (7 minutes)
     expirationMinutes: Number(process.env.VOUCHER_EXPIRATION_MINUTES) || 10080,
   },
+  ptc: {
+    mode: process.env.PTC_MODE || 'off',
+    userAllowlist: process.env.PTC_USER_ALLOWLIST || '',
+    toolsetAllowlist: process.env.PTC_TOOLSET_ALLOWLIST || '',
+    toolsetBlocklist: process.env.PTC_TOOLSET_BLOCKLIST || '',
+  },
   schedule: {
     // Rate limiting - controls global and per-user concurrency
     globalMaxConcurrent: Number.parseInt(process.env.SCHEDULE_GLOBAL_MAX_CONCURRENT) || 50,

--- a/apps/api/src/modules/tool/ptc/index.ts
+++ b/apps/api/src/modules/tool/ptc/index.ts
@@ -1,3 +1,4 @@
 export * from './tool-identify.service';
 export * from './tool-execution.service';
 export * from './tool-definition.service';
+export * from './ptc-config';

--- a/apps/api/src/modules/tool/ptc/ptc-config.spec.ts
+++ b/apps/api/src/modules/tool/ptc/ptc-config.spec.ts
@@ -1,0 +1,157 @@
+import { ConfigService } from '@nestjs/config';
+import {
+  PtcMode,
+  getPtcConfig,
+  isPtcEnabledForUser,
+  isPtcEnabledForToolsets,
+  isToolsetAllowed,
+  PtcConfig,
+} from './ptc-config';
+import type { User } from '@refly/openapi-schema';
+
+describe('PtcConfig', () => {
+  let mockConfigService: Partial<ConfigService>;
+  const mockUser: User = { uid: 'u-123', email: 'test@example.com' } as User;
+
+  beforeEach(() => {
+    mockConfigService = {
+      get: jest.fn((key: string) => {
+        const configs: Record<string, string> = {
+          'ptc.mode': 'off',
+          'ptc.userAllowlist': '',
+          'ptc.toolsetAllowlist': '',
+          'ptc.toolsetBlocklist': '',
+        };
+        return configs[key];
+      }),
+    };
+  });
+
+  describe('getPtcConfig', () => {
+    it('should parse default config correctly', () => {
+      const config = getPtcConfig(mockConfigService as ConfigService);
+      expect(config.mode).toBe(PtcMode.OFF);
+      expect(config.userAllowlist.size).toBe(0);
+      expect(config.toolsetAllowlist).toBeNull();
+      expect(config.toolsetBlocklist.size).toBe(0);
+    });
+
+    it('should parse partial mode and allowlists correctly', () => {
+      mockConfigService.get = jest.fn((key: string) => {
+        const configs: Record<string, string> = {
+          'ptc.mode': 'partial',
+          'ptc.userAllowlist': 'u-1, u-2 ',
+          'ptc.toolsetAllowlist': 'google, notion',
+          'ptc.toolsetBlocklist': 'bad-tool',
+        };
+        return configs[key];
+      });
+
+      const config = getPtcConfig(mockConfigService as ConfigService);
+      expect(config.mode).toBe(PtcMode.PARTIAL);
+      expect(config.userAllowlist.has('u-1')).toBe(true);
+      expect(config.userAllowlist.has('u-2')).toBe(true);
+      expect(config.toolsetAllowlist?.has('google')).toBe(true);
+      expect(config.toolsetBlocklist.has('bad-tool')).toBe(true);
+    });
+
+    it('should handle invalid mode by defaulting to OFF', () => {
+      mockConfigService.get = jest.fn(() => 'invalid');
+      const config = getPtcConfig(mockConfigService as ConfigService);
+      expect(config.mode).toBe(PtcMode.OFF);
+    });
+  });
+
+  describe('isPtcEnabledForUser', () => {
+    it('should return false when mode is OFF', () => {
+      const config: PtcConfig = {
+        mode: PtcMode.OFF,
+        userAllowlist: new Set<string>(),
+        toolsetAllowlist: null,
+        toolsetBlocklist: new Set<string>(),
+      };
+      expect(isPtcEnabledForUser(mockUser, config)).toBe(false);
+    });
+
+    it('should return true when mode is ON', () => {
+      const config: PtcConfig = {
+        mode: PtcMode.ON,
+        userAllowlist: new Set<string>(),
+        toolsetAllowlist: null,
+        toolsetBlocklist: new Set<string>(),
+      };
+      expect(isPtcEnabledForUser(mockUser, config)).toBe(true);
+    });
+
+    it('should check allowlist when mode is PARTIAL', () => {
+      const config: PtcConfig = {
+        mode: PtcMode.PARTIAL,
+        userAllowlist: new Set<string>(['u-123']),
+        toolsetAllowlist: null,
+        toolsetBlocklist: new Set<string>(),
+      };
+      expect(isPtcEnabledForUser(mockUser, config)).toBe(true);
+      expect(isPtcEnabledForUser({ uid: 'u-other' } as User, config)).toBe(false);
+    });
+  });
+
+  describe('isToolsetAllowed', () => {
+    const baseConfig: PtcConfig = {
+      mode: PtcMode.ON,
+      userAllowlist: new Set<string>(),
+      toolsetAllowlist: null,
+      toolsetBlocklist: new Set<string>(),
+    };
+
+    it('should return false if toolset is in blocklist', () => {
+      const config: PtcConfig = { ...baseConfig, toolsetBlocklist: new Set<string>(['blocked']) };
+      expect(isToolsetAllowed('blocked', config)).toBe(false);
+    });
+
+    it('should return true if no allowlist is configured', () => {
+      expect(isToolsetAllowed('any', baseConfig)).toBe(true);
+    });
+
+    it('should return true if toolset is in allowlist', () => {
+      const config: PtcConfig = { ...baseConfig, toolsetAllowlist: new Set<string>(['allowed']) };
+      expect(isToolsetAllowed('allowed', config)).toBe(true);
+    });
+
+    it('should return false if allowlist is configured but toolset is not in it', () => {
+      const config: PtcConfig = { ...baseConfig, toolsetAllowlist: new Set<string>(['allowed']) };
+      expect(isToolsetAllowed('other', config)).toBe(false);
+    });
+
+    it('should prioritize blocklist over allowlist', () => {
+      const config: PtcConfig = {
+        ...baseConfig,
+        toolsetAllowlist: new Set<string>(['tool']),
+        toolsetBlocklist: new Set<string>(['tool']),
+      };
+      expect(isToolsetAllowed('tool', config)).toBe(false);
+    });
+  });
+
+  describe('isPtcEnabledForToolsets', () => {
+    const config: PtcConfig = {
+      mode: PtcMode.ON,
+      userAllowlist: new Set<string>(),
+      toolsetAllowlist: new Set<string>(['t1', 't2']),
+      toolsetBlocklist: new Set<string>(['blocked']),
+    };
+
+    it('should return true if user is enabled and all toolsets are allowed', () => {
+      expect(isPtcEnabledForToolsets(mockUser, ['t1', 't2'], config)).toBe(true);
+    });
+
+    it('should return false if user is not enabled', () => {
+      const disabledConfig: PtcConfig = { ...config, mode: PtcMode.OFF };
+      expect(isPtcEnabledForToolsets(mockUser, ['t1'], disabledConfig)).toBe(false);
+    });
+
+    it('should return false if any toolset is not allowed', () => {
+      expect(isPtcEnabledForToolsets(mockUser, ['t1', 'blocked'], config)).toBe(false);
+      expect(isPtcEnabledForToolsets(mockUser, ['t1', 'unknown'], config)).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/modules/tool/ptc/ptc-config.ts
+++ b/apps/api/src/modules/tool/ptc/ptc-config.ts
@@ -1,0 +1,187 @@
+/**
+ * PTC Config
+ * Manages PTC (Programmatic Tool Calling) mode configuration and permission checks.
+ * Supports global toggle, user-level allowlist, and toolset-level allow/block lists.
+ */
+
+import { Logger } from '@nestjs/common';
+import type { ConfigService } from '@nestjs/config';
+import type { User } from '@refly/openapi-schema';
+
+const logger = new Logger('PtcConfig');
+
+/**
+ * PTC mode enum
+ */
+export enum PtcMode {
+  /** Global disable - PTC is disabled for all users */
+  OFF = 'off',
+  /** Global enable - PTC is enabled for all users */
+  ON = 'on',
+  /** Partial mode - PTC is enabled only for users in allowlist */
+  PARTIAL = 'partial',
+}
+
+/**
+ * PTC configuration interface
+ */
+export interface PtcConfig {
+  mode: PtcMode;
+  userAllowlist: Set<string>;
+  toolsetAllowlist: Set<string> | null;
+  toolsetBlocklist: Set<string>;
+}
+
+/**
+ * Get PTC configuration from ConfigService
+ *
+ * @param configService - NestJS ConfigService
+ * @returns Parsed PTC configuration
+ */
+export function getPtcConfig(configService: ConfigService): PtcConfig {
+  const mode = parsePtcMode(configService.get<string>('ptc.mode'));
+  const userAllowlist = parseCommaSeparatedList(configService.get<string>('ptc.userAllowlist'));
+  const toolsetAllowlist = parseOptionalCommaSeparatedList(
+    configService.get<string>('ptc.toolsetAllowlist'),
+  );
+  const toolsetBlocklist = parseCommaSeparatedList(
+    configService.get<string>('ptc.toolsetBlocklist'),
+  );
+
+  return {
+    mode,
+    userAllowlist,
+    toolsetAllowlist,
+    toolsetBlocklist,
+  };
+}
+
+/**
+ * Check if PTC is enabled for a specific user.
+ *
+ * @param user - The user to check
+ * @param config - PTC configuration
+ * @returns true if PTC is enabled for the user
+ */
+export function isPtcEnabledForUser(user: User, config: PtcConfig): boolean {
+  switch (config.mode) {
+    case PtcMode.OFF:
+      return false;
+
+    case PtcMode.ON:
+      return true;
+
+    case PtcMode.PARTIAL:
+      return config.userAllowlist.has(user.uid);
+
+    default:
+      logger.warn(`Unknown PTC mode: ${config.mode}, defaulting to off`);
+      return false;
+  }
+}
+
+/**
+ * Check if PTC is enabled for a specific user and multiple toolsets.
+ * All toolsets must be allowed for the user.
+ *
+ * @param user - The user to check
+ * @param toolsetKeys - Array of toolset keys to check
+ * @param config - PTC configuration
+ * @returns true if PTC is enabled for the user and ALL toolsets
+ */
+export function isPtcEnabledForToolsets(
+  user: User,
+  toolsetKeys: string[],
+  config: PtcConfig,
+): boolean {
+  // Step 1: Check user-level permission
+  if (!isPtcEnabledForUser(user, config)) {
+    return false;
+  }
+
+  // Step 2: Check all toolsets are allowed
+  return toolsetKeys.every((key) => isToolsetAllowed(key, config));
+}
+
+/**
+ * Check if a specific toolset is allowed by PTC configuration.
+ * Toolset blocklist has higher priority than allowlist.
+ *
+ * @param toolsetKey - The toolset key to check
+ * @param config - PTC configuration
+ * @returns true if the toolset is allowed
+ */
+export function isToolsetAllowed(toolsetKey: string, config: PtcConfig): boolean {
+  // Blocklist has highest priority
+  if (config.toolsetBlocklist.has(toolsetKey)) {
+    return false;
+  }
+
+  // If allowlist is configured, only allow toolsets in the list
+  if (config.toolsetAllowlist !== null) {
+    return config.toolsetAllowlist.has(toolsetKey);
+  }
+
+  // No allowlist means all toolsets are allowed (if not blocked)
+  return true;
+}
+
+/**
+ * Parse PTC mode from string
+ *
+ * @param value - Mode string
+ * @returns Parsed PTC mode (defaults to OFF)
+ */
+function parsePtcMode(value?: string): PtcMode {
+  if (!value) {
+    return PtcMode.OFF;
+  }
+
+  const normalizedValue = value.toLowerCase();
+  if (Object.values(PtcMode).includes(normalizedValue as PtcMode)) {
+    return normalizedValue as PtcMode;
+  }
+
+  logger.warn(
+    `Invalid PTC_MODE value: ${value}, valid values are: ${Object.values(PtcMode).join(', ')}. Defaulting to OFF.`,
+  );
+  return PtcMode.OFF;
+}
+
+/**
+ * Parse comma-separated list into a Set
+ *
+ * @param value - Comma-separated string
+ * @returns Set of trimmed values
+ */
+function parseCommaSeparatedList(value?: string): Set<string> {
+  if (!value?.trim()) {
+    return new Set();
+  }
+
+  return new Set(
+    value
+      .split(',')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0),
+  );
+}
+
+/**
+ * Parse optional comma-separated list into a Set or null
+ *
+ * @param value - Comma-separated string
+ * @returns Set of trimmed values, or null if not configured
+ */
+function parseOptionalCommaSeparatedList(value?: string): Set<string> | null {
+  if (!value?.trim()) {
+    return null;
+  }
+
+  return new Set(
+    value
+      .split(',')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0),
+  );
+}

--- a/packages/skill-template/src/base.ts
+++ b/packages/skill-template/src/base.ts
@@ -291,6 +291,10 @@ export interface SkillRunnableConfig extends RunnableConfig {
     copilotSessionId?: string;
     locale?: string;
     uiLocale?: string;
+    builtInTools?: StructuredToolInterface[];
+    nonBuiltInTools?: StructuredToolInterface[];
+    builtInToolsets?: GenericToolset[];
+    nonBuiltInToolsets?: GenericToolset[];
     modelConfigMap?: {
       chat?: LLMModelConfig;
       agent?: LLMModelConfig;
@@ -312,6 +316,7 @@ export interface SkillRunnableConfig extends RunnableConfig {
     selectedTools?: StructuredToolInterface[];
     installedToolsets?: GenericToolset[];
     preprocessResult?: PreprocessResult;
+    ptcEnabled?: boolean;
   };
   metadata?: SkillRunnableMeta;
 }

--- a/packages/skill-template/src/prompts/node-agent.ts
+++ b/packages/skill-template/src/prompts/node-agent.ts
@@ -147,6 +147,22 @@ Now begin!
 
 `.trim();
 
-export const buildNodeAgentSystemPrompt = (): string => {
+export interface PtcConfig {
+  toolsets: {
+    id: string;
+    name: string;
+    key: string;
+  }[];
+}
+
+export interface BuildNodeAgentSystemPromptOptions {
+  ptcEnabled?: boolean;
+  ptcConfig?: PtcConfig;
+}
+
+export const buildNodeAgentSystemPrompt = (
+  _options?: BuildNodeAgentSystemPromptOptions,
+): string => {
+  // TODO: Build PTC mode system prompt
   return SYSTEM_PROMPT;
 };


### PR DESCRIPTION
## Summary

This PR adds a PTC (Programmatic Tool Calling) mode toggle system that allows controlling tool access at multiple levels. The system supports global enable/disable, user-level allowlists, and toolset-level allow/block lists.

## Changes

- Add PTC config module with three modes: OFF (global disable), ON (global enable), and PARTIAL (user allowlist only)
- Implement permission check functions for user-level and toolset-level access control
- Update node-agent system prompt to dynamically include tool definitions when PTC mode is enabled
- Integrate PTC config checks into tool service and skill invoker service
- Add comprehensive unit tests covering all PTC config scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Programmatic Tool Calling (PTC) with OFF/ON/PARTIAL modes, user allowlists, and toolset allow/block controls exposed in config.
  * Tools are categorized into built-in and non-built-in groups with corresponding toolset groupings.
  * PTC enablement is computed and surfaced to agent prompts, runtime metadata, and skill configuration.

* **Tests**
  * Added comprehensive unit tests for PTC parsing and enablement logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->