### PR TITLE
[REF-1303] fix: remove invite link and share section from voucher email templates

### DIFF
--- a/apps/api/src/modules/voucher/voucher-email-templates.ts
+++ b/apps/api/src/modules/voucher/voucher-email-templates.ts
@@ -7,7 +7,6 @@ export interface VoucherEmailData {
   discountPercent: number;
   discountValue: string; // e.g., "$8" for 40% off of $20/month
   discountedPrice: string; // e.g., "$12"
-  inviteLink: string;
   expirationDays: number;
 }
 
@@ -122,34 +121,6 @@ export function generateVoucherEmailEN(data: VoucherEmailData): { subject: strin
                     <p style="margin: 24px 0 0; font-size: 14px; color: #666666;">
                       Your discount will be automatically applied at Stripe checkout — get full access for just <span style="font-weight: 700; color: #0E9F77;">${data.discountedPrice}/month</span>
                     </p>
-                  </td>
-                </tr>
-              </table>
-
-              <!-- Share Section -->
-              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background: linear-gradient(135deg, rgba(14,159,119,0.1) 0%, rgba(14,159,119,0.05) 100%); border-radius: 16px; border: 1px solid rgba(14,159,119,0.2); margin-bottom: 32px;">
-                <tr>
-                  <td style="padding: 24px;">
-                    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
-                      <tr>
-                        <td width="56" valign="top">
-                          <div style="background-color: rgba(14,159,119,0.2); border-radius: 12px; padding: 12px; display: inline-block;">
-                            <span style="font-size: 24px;">👥</span>
-                          </div>
-                        </td>
-                        <td style="padding-left: 16px;">
-                          <h3 style="margin: 0 0 4px; font-size: 16px; font-weight: 600; color: #1a1a1a;">Share the Love</h3>
-                          <p style="margin: 0 0 12px; font-size: 14px; color: #666666;">Your friends can also enjoy this discount!</p>
-                          <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #ffffff; border-radius: 12px; border: 1px solid #e5e7eb;">
-                            <tr>
-                              <td style="padding: 12px 16px;">
-                                <a href="${data.inviteLink}" style="color: #0E9F77; font-size: 14px; font-weight: 500; text-decoration: none; word-break: break-all;">${data.inviteLink}</a>
-                              </td>
-                            </tr>
-                          </table>
-                        </td>
-                      </tr>
-                    </table>
                   </td>
                 </tr>
               </table>
@@ -356,34 +327,6 @@ export function generateVoucherEmailZH(data: VoucherEmailData): { subject: strin
                     <p style="margin: 24px 0 0; font-size: 14px; color: #666666;">
                       折扣将在 Stripe 结账时自动应用 — 仅需 <span style="font-weight: 700; color: #0E9F77;">${data.discountedPrice}/月</span> 即可获得完整功能
                     </p>
-                  </td>
-                </tr>
-              </table>
-
-              <!-- Share Section -->
-              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background: linear-gradient(135deg, rgba(14,159,119,0.1) 0%, rgba(14,159,119,0.05) 100%); border-radius: 16px; border: 1px solid rgba(14,159,119,0.2); margin-bottom: 32px;">
-                <tr>
-                  <td style="padding: 24px;">
-                    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
-                      <tr>
-                        <td width="56" valign="top">
-                          <div style="background-color: rgba(14,159,119,0.2); border-radius: 12px; padding: 12px; display: inline-block;">
-                            <span style="font-size: 24px;">👥</span>
-                          </div>
-                        </td>
-                        <td style="padding-left: 16px;">
-                          <h3 style="margin: 0 0 4px; font-size: 16px; font-weight: 600; color: #1a1a1a;">分享给朋友</h3>
-                          <p style="margin: 0 0 12px; font-size: 14px; color: #666666;">您的朋友也可以享受这个折扣！</p>
-                          <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #ffffff; border-radius: 12px; border: 1px solid #e5e7eb;">
-                            <tr>
-                              <td style="padding: 12px 16px;">
-                                <a href="${data.inviteLink}" style="color: #0E9F77; font-size: 14px; font-weight: 500; text-decoration: none; word-break: break-all;">${data.inviteLink}</a>
-                              </td>
-                            </tr>
-                          </table>
-                        </td>
-                      </tr>
-                    </table>
                   </td>
                 </tr>
               </table>

--- a/apps/api/src/modules/voucher/voucher.service.ts
+++ b/apps/api/src/modules/voucher/voucher.service.ts
@@ -322,7 +322,7 @@ export class VoucherService implements OnModuleInit {
       );
 
       // 6. Send email notification (async, don't wait)
-      this.sendVoucherEmail(user.uid, voucher.voucherId, discountPercent).catch((err) => {
+      this.sendVoucherEmail(user.uid, discountPercent).catch((err) => {
         this.logger.error(`Failed to send voucher email for user ${user.uid}: ${err.stack}`);
       });
 
@@ -342,11 +342,7 @@ export class VoucherService implements OnModuleInit {
   /**
    * Send voucher notification email to user
    */
-  private async sendVoucherEmail(
-    uid: string,
-    voucherId: string,
-    discountPercent: number,
-  ): Promise<void> {
+  private async sendVoucherEmail(uid: string, discountPercent: number): Promise<void> {
     // Get user info including locale
     const userPo = await this.prisma.user.findUnique({
       where: { uid },
@@ -357,11 +353,6 @@ export class VoucherService implements OnModuleInit {
       this.logger.warn(`Cannot send voucher email: user ${uid} has no email`);
       return;
     }
-
-    // Create invitation for the share link
-    const invitation = await this.createInvitation(uid, voucherId);
-    const origin = this.configService.get('origin') || 'https://refly.ai';
-    const inviteLink = `${origin}/invite?invite=${invitation.invitation.inviteCode}`;
 
     // Calculate discount values
     const { discountValue, discountedPrice } = calculateDiscountValues(discountPercent);
@@ -377,7 +368,6 @@ export class VoucherService implements OnModuleInit {
         discountPercent,
         discountValue,
         discountedPrice,
-        inviteLink,
         expirationDays,
       },
       userPo.uiLocale || undefined,


### PR DESCRIPTION
- Removed the invite link property from the VoucherEmailData interface and eliminated the share section from both English and Chinese voucher email templates.
- Updated the sendVoucherEmail method to reflect changes in parameters by removing the voucherId argument.
- Ensured consistent use of optional chaining and nullish coalescing for safer property access throughout the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed shareable invite link functionality from voucher email notifications. The "Share the Love" section is no longer included in voucher emails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->