### PR TITLE
feat(subscription): add customer_email to Stripe metadata

### DIFF
--- a/apps/api/src/modules/subscription/subscription.service.ts
+++ b/apps/api/src/modules/subscription/subscription.service.ts
@@ -249,14 +249,20 @@ export class SubscriptionService implements OnModuleInit {
       consent_collection: {
         terms_of_service: 'required',
       },
-      metadata: validatedVoucherId
-        ? {
-            voucherId: validatedVoucherId,
-            voucherDiscountPercent: voucherDiscountPercent?.toString(),
-            voucherEntryPoint,
-            voucherUserType,
-          }
-        : undefined,
+      metadata: {
+        ...(userPo?.email && { customer_email: userPo.email }),
+        ...(validatedVoucherId && {
+          voucherId: validatedVoucherId,
+          voucherDiscountPercent: voucherDiscountPercent?.toString(),
+          voucherEntryPoint,
+          voucherUserType,
+        }),
+      },
+      subscription_data: {
+        metadata: {
+          ...(userPo?.email && { customer_email: userPo.email }),
+        },
+      },
     };
 
     // Apply voucher promotion code or allow promotion codes (not both)
@@ -282,7 +288,9 @@ export class SubscriptionService implements OnModuleInit {
 
         // Remove discount and allow manual promotion code entry instead
         sessionParams.discounts = undefined;
-        sessionParams.metadata = undefined;
+        sessionParams.metadata = {
+          ...(userPo?.email && { customer_email: userPo.email }),
+        };
         sessionParams.allow_promotion_codes = true;
 
         session = await this.stripeClient.checkout.sessions.create(sessionParams);
@@ -371,6 +379,7 @@ export class SubscriptionService implements OnModuleInit {
         terms_of_service: 'required',
       },
       metadata: {
+        ...(userPo?.email && { customer_email: userPo.email }),
         purpose: 'credit_pack',
         packId: param.packId,
         lookupKey,


### PR DESCRIPTION
Adds the user's email address to both Checkout Session and Subscription metadata. This enables better identification of customers in Stripe webhook notifications (e.g., Feishu/Lark alerts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in payment session data handling to ensure customer information is properly retained across all checkout flows.
  * Fixed metadata preservation during checkout error scenarios.

* **Chores**
  * Enhanced Stripe payment integration data consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->