### PR TITLE
[REF-1334] feat(utils): add unified file-id utilities and fix URL replacement logic

### DIFF
--- a/apps/api/src/modules/tool/utils/schema-utils.ts
+++ b/apps/api/src/modules/tool/utils/schema-utils.ts
@@ -189,69 +189,8 @@ export function fillDefaultValues(
 // FileId Validation & Extraction
 // ============================================================================
 
-/**
- * Validate if a value is a valid fileId
- * FileId can be in formats:
- * - Direct: 'df-xxx'
- * - URI format: 'fileId://df-xxx'
- * - Mention format: '@file:df-xxx'
- * - Path format: 'files/df-xxx'
- * - URL format: 'https://files.refly.ai/df-xxx'
- *
- * @param value - Value to validate (can be string or object with fileId property)
- * @returns True if the value is a valid fileId
- */
-export function isValidFileId(value: unknown): boolean {
-  return extractFileId(value) !== null;
-}
-
-/**
- * Extract fileId from various formats
- * @param value - Value that may contain a fileId (string or object with fileId property)
- * @returns The extracted fileId (df-xxx format) or null if not found
- */
-export function extractFileId(value: unknown): string | null {
-  if (typeof value === 'string') {
-    return extractFileIdFromString(value);
-  }
-  if (value && typeof value === 'object' && 'fileId' in value) {
-    const fileId = (value as { fileId: unknown }).fileId;
-    return typeof fileId === 'string' ? extractFileIdFromString(fileId) : null;
-  }
-  return null;
-}
-
-/**
- * Extract fileId from a string in various formats
- * @param value - String value that may contain a fileId
- * @returns The extracted fileId (df-xxx format) or null if not found
- */
-function extractFileIdFromString(value: string): string | null {
-  // Direct format: 'df-xxx'
-  if (value.startsWith('df-')) {
-    return value;
-  }
-  // URI format: 'fileId://df-xxx'
-  if (value.startsWith('fileId://df-')) {
-    return value.slice('fileId://'.length);
-  }
-  // Mention format: '@file:df-xxx'
-  if (value.startsWith('@file:df-')) {
-    return value.slice('@file:'.length);
-  }
-  // Path format: 'files/df-xxx'
-  if (value.startsWith('files/df-')) {
-    return value.slice('files/'.length);
-  }
-  // URL format or fallback: extract 'df-xxx' pattern from anywhere in the string
-  // Use lookbehind to ensure 'df-' is not preceded by alphanumeric (avoid matching 'pdf-xxx', 'abcdf-xxx')
-  // This handles URLs like 'https://files.refly.ai/.../df-xxx' and any other format
-  const match = value.match(/(?<![a-z0-9])(df-[a-z0-9]+)\b/i);
-  if (match) {
-    return match[1];
-  }
-  return null;
-}
+// Re-export from shared utils package for backward compatibility
+export { extractFileId, isValidFileId } from '@refly/utils';
 
 // ============================================================================
 // Field Removal

--- a/packages/utils/src/file-id.ts
+++ b/packages/utils/src/file-id.ts
@@ -1,0 +1,360 @@
+/**
+ * File ID Utilities
+ *
+ * Unified module for file ID validation, extraction, and replacement.
+ * FileId format: df-[a-z0-9]+ (e.g., df-abc123xyz)
+ *
+ * This is a shared utility used across multiple packages:
+ *
+ * 1. packages/agent-tools/src/builtin/index.ts
+ *    - BuiltinGenerateDoc.replaceFilePlaceholders() uses replaceAllMarkdownFileIds()
+ *    - BuiltinGenerateCodeArtifact.replaceFilePlaceholders() uses replaceAllMarkdownFileIds()
+ *    - BuiltinSendEmail.replaceFilePlaceholders() uses replaceAllHtmlFileIds()
+ *    - All three use extractAllFileIds() and hasFileIds() for file ID detection
+ *
+ * 2. apps/api/src/modules/tool/utils/schema-utils.ts
+ *    - Re-exports isValidFileId() and extractFileId() for tool parameter validation
+ *
+ * When adding new file ID handling logic, prefer using these shared utilities
+ * to ensure consistent behavior across the codebase.
+ */
+
+// ============================================================================
+// Core Patterns
+// ============================================================================
+
+/**
+ * Regex pattern for matching file IDs.
+ * Uses negative lookbehind to prevent matching invalid patterns like 'pdf-xxx'.
+ * The pattern matches 'df-' followed by alphanumeric characters.
+ */
+export const FILE_ID_PATTERN = /(?<![a-z0-9])(df-[a-z0-9]+)\b/i;
+
+/**
+ * Global regex pattern for finding all file IDs in a string.
+ * Same as FILE_ID_PATTERN but with global flag.
+ */
+export const FILE_ID_PATTERN_GLOBAL = /(?<![a-z0-9])(df-[a-z0-9]+)\b/gi;
+
+// ============================================================================
+// Context-Specific Patterns for Replacement
+// ============================================================================
+
+/**
+ * Pattern for file-content:// URI format (for images, embedded media)
+ * Matches: file-content://df-xxx
+ */
+export const FILE_CONTENT_URI_PATTERN = /file-content:\/\/(df-[a-z0-9]+)/gi;
+
+/**
+ * Pattern for file:// URI format (for share links)
+ * Matches: file://df-xxx (but not file-content://)
+ */
+export const FILE_SHARE_URI_PATTERN = /file:\/\/(df-[a-z0-9]+)/gi;
+
+/**
+ * Pattern for bare file IDs in markdown image/link syntax
+ * Matches: ](df-xxx) in ![alt](df-xxx) or [text](df-xxx)
+ */
+export const MARKDOWN_FILE_ID_PATTERN = /\]\((df-[a-z0-9]+)\)/gi;
+
+/**
+ * Pattern for bare file IDs in HTML src/href attributes
+ * Matches: src="df-xxx" or href="df-xxx"
+ */
+export const HTML_ATTR_FILE_ID_PATTERN = /((?:src|href)=["'])(df-[a-z0-9]+)(["'])/gi;
+
+/**
+ * Validate if a value is a valid fileId
+ * FileId can be in formats:
+ * - Direct: 'df-xxx'
+ * - URI format: 'fileId://df-xxx'
+ * - Mention format: '@file:df-xxx'
+ * - Path format: 'files/df-xxx'
+ * - URL format: 'https://files.refly.ai/df-xxx'
+ *
+ * @param value - Value to validate (can be string or object with fileId property)
+ * @returns True if the value is a valid fileId
+ */
+export function isValidFileId(value: unknown): boolean {
+  return extractFileId(value) !== null;
+}
+
+/**
+ * Extract fileId from various formats
+ * @param value - Value that may contain a fileId (string or object with fileId property)
+ * @returns The extracted fileId (df-xxx format) or null if not found
+ */
+export function extractFileId(value: unknown): string | null {
+  if (typeof value === 'string') {
+    return extractFileIdFromString(value);
+  }
+  if (value && typeof value === 'object' && 'fileId' in value) {
+    const fileId = (value as { fileId: unknown }).fileId;
+    return typeof fileId === 'string' ? extractFileIdFromString(fileId) : null;
+  }
+  return null;
+}
+
+/**
+ * Extract fileId from a string in various formats
+ * @param value - String value that may contain a fileId
+ * @returns The extracted fileId (df-xxx format) or null if not found
+ */
+function extractFileIdFromString(value: string): string | null {
+  // Direct format: 'df-xxx'
+  if (value.startsWith('df-')) {
+    const match = value.match(/^(df-[a-z0-9]+)/i);
+    return match ? match[1] : null;
+  }
+  // URI format: 'fileId://df-xxx'
+  if (value.startsWith('fileId://')) {
+    const match = value.match(/^fileId:\/\/(df-[a-z0-9]+)/i);
+    return match ? match[1] : null;
+  }
+  // Mention format: '@file:df-xxx'
+  if (value.startsWith('@file:')) {
+    const match = value.match(/^@file:(df-[a-z0-9]+)/i);
+    return match ? match[1] : null;
+  }
+  // Path format: 'files/df-xxx'
+  if (value.startsWith('files/')) {
+    const match = value.match(/^files\/(df-[a-z0-9]+)/i);
+    return match ? match[1] : null;
+  }
+  // URL format or fallback: extract 'df-xxx' pattern from anywhere in the string
+  // Use lookbehind to ensure 'df-' is not preceded by alphanumeric (avoid matching 'pdf-xxx', 'abcdf-xxx')
+  // This handles URLs like 'https://files.refly.ai/.../df-xxx' and any other format
+  const match = value.match(FILE_ID_PATTERN);
+  if (match) {
+    return match[1];
+  }
+  return null;
+}
+
+/**
+ * Extract all fileIds from a string content (e.g., markdown, HTML)
+ * @param content - String content that may contain multiple fileIds
+ * @returns Array of unique fileIds found in the content
+ */
+export function extractAllFileIds(content: string): string[] {
+  if (!content) {
+    return [];
+  }
+
+  const matches = content.matchAll(FILE_ID_PATTERN_GLOBAL);
+  const fileIds = new Set<string>();
+
+  for (const match of matches) {
+    fileIds.add(match[1]);
+  }
+
+  return Array.from(fileIds);
+}
+
+/**
+ * Check if content contains any file IDs
+ * @param content - String content to check
+ * @returns True if content contains at least one file ID
+ */
+export function hasFileIds(content: string): boolean {
+  if (!content) {
+    return false;
+  }
+  return FILE_ID_PATTERN.test(content);
+}
+
+// ============================================================================
+// Replacement Utilities
+// ============================================================================
+
+/**
+ * Replace file-content://df-xxx with actual URLs
+ * @param content - Content to process
+ * @param urlMap - Map of fileId to URL
+ * @returns Processed content
+ */
+export function replaceFileContentUris(content: string, urlMap: Map<string, string>): string {
+  return content.replace(FILE_CONTENT_URI_PATTERN, (match, fileId: string) => {
+    return urlMap.get(fileId) ?? match;
+  });
+}
+
+/**
+ * Replace file://df-xxx with actual URLs
+ * @param content - Content to process
+ * @param urlMap - Map of fileId to URL
+ * @returns Processed content
+ */
+export function replaceFileShareUris(content: string, urlMap: Map<string, string>): string {
+  return content.replace(FILE_SHARE_URI_PATTERN, (match, fileId: string) => {
+    return urlMap.get(fileId) ?? match;
+  });
+}
+
+/**
+ * Replace bare file IDs in markdown syntax: ](df-xxx) → ](url)
+ * @param content - Markdown content to process
+ * @param urlMap - Map of fileId to URL
+ * @returns Processed content
+ */
+export function replaceMarkdownFileIds(content: string, urlMap: Map<string, string>): string {
+  return content.replace(MARKDOWN_FILE_ID_PATTERN, (match, fileId: string) => {
+    const url = urlMap.get(fileId);
+    return url ? `](${url})` : match;
+  });
+}
+
+/**
+ * Replace bare file IDs in HTML attributes: src="df-xxx" → src="url"
+ * @param content - HTML content to process
+ * @param urlMap - Map of fileId to URL
+ * @returns Processed content
+ */
+export function replaceHtmlAttrFileIds(content: string, urlMap: Map<string, string>): string {
+  return content.replace(
+    HTML_ATTR_FILE_ID_PATTERN,
+    (match, prefix: string, fileId: string, suffix: string) => {
+      const url = urlMap.get(fileId);
+      return url ? `${prefix}${url}${suffix}` : match;
+    },
+  );
+}
+
+// ============================================================================
+// Optimized Single-Pass Replacement (for large documents)
+// ============================================================================
+
+/**
+ * Combined pattern for single-pass markdown replacement
+ * Matches: file-content://df-xxx | file://df-xxx | ](df-xxx)
+ */
+const MARKDOWN_COMBINED_PATTERN =
+  /file-content:\/\/(df-[a-z0-9]+)|(?<!file-content:)file:\/\/(df-[a-z0-9]+)|\]\((df-[a-z0-9]+)\)/gi;
+
+/**
+ * Combined pattern for single-pass HTML replacement
+ * Matches: file-content://df-xxx | file://df-xxx | src="df-xxx" | href="df-xxx"
+ */
+const HTML_COMBINED_PATTERN =
+  /file-content:\/\/(df-[a-z0-9]+)|(?<!file-content:)file:\/\/(df-[a-z0-9]+)|((?:src|href)=["'])(df-[a-z0-9]+)(["'])/gi;
+
+/**
+ * Replace all file ID patterns in markdown content with URLs (optimized single-pass)
+ * Handles: file-content://, file://, and bare file IDs in ](df-xxx)
+ *
+ * Performance optimizations:
+ * - Early exit if no file IDs detected
+ * - Single-pass replacement using combined regex
+ * - Efficient for large documents (O(n) instead of O(3n))
+ *
+ * @param content - Markdown content to process
+ * @param contentUrlMap - Map of fileId to content URL (for images/media)
+ * @param shareUrlMap - Map of fileId to share URL (for links)
+ * @returns Processed content
+ */
+export function replaceAllMarkdownFileIds(
+  content: string,
+  contentUrlMap: Map<string, string>,
+  shareUrlMap: Map<string, string>,
+): string {
+  // Early exit: skip processing if no file IDs or empty maps
+  if (!content || (contentUrlMap.size === 0 && shareUrlMap.size === 0)) {
+    return content;
+  }
+
+  // Quick check: skip if no potential file ID patterns
+  if (
+    !hasFileIds(content) &&
+    !content.includes('file-content://') &&
+    !content.includes('file://')
+  ) {
+    return content;
+  }
+
+  // Single-pass replacement
+  return content.replace(
+    MARKDOWN_COMBINED_PATTERN,
+    (match, fileContentId?: string, fileShareId?: string, markdownId?: string) => {
+      // file-content://df-xxx → contentUrl
+      if (fileContentId) {
+        return contentUrlMap.get(fileContentId) ?? match;
+      }
+      // file://df-xxx → shareUrl
+      if (fileShareId) {
+        return shareUrlMap.get(fileShareId) ?? match;
+      }
+      // ](df-xxx) → ](contentUrl) with shareUrl fallback
+      if (markdownId) {
+        const url = contentUrlMap.get(markdownId) ?? shareUrlMap.get(markdownId);
+        return url ? `](${url})` : match;
+      }
+      return match;
+    },
+  );
+}
+
+/**
+ * Replace all file ID patterns in HTML content with URLs (optimized single-pass)
+ * Handles: file-content://, file://, and bare file IDs in src/href attributes
+ *
+ * Performance optimizations:
+ * - Early exit if no file IDs detected
+ * - Single-pass replacement using combined regex
+ * - Efficient for large documents (O(n) instead of O(3n))
+ *
+ * @param content - HTML content to process
+ * @param contentUrlMap - Map of fileId to content URL (for images/media)
+ * @param shareUrlMap - Map of fileId to share URL (for links)
+ * @returns Processed content
+ */
+export function replaceAllHtmlFileIds(
+  content: string,
+  contentUrlMap: Map<string, string>,
+  shareUrlMap: Map<string, string>,
+): string {
+  // Early exit: skip processing if no file IDs or empty maps
+  if (!content || (contentUrlMap.size === 0 && shareUrlMap.size === 0)) {
+    return content;
+  }
+
+  // Quick check: skip if no potential file ID patterns
+  if (
+    !hasFileIds(content) &&
+    !content.includes('file-content://') &&
+    !content.includes('file://')
+  ) {
+    return content;
+  }
+
+  // Single-pass replacement
+  return content.replace(
+    HTML_COMBINED_PATTERN,
+    (
+      match,
+      fileContentId?: string,
+      fileShareId?: string,
+      attrPrefix?: string,
+      attrFileId?: string,
+      attrSuffix?: string,
+    ) => {
+      // file-content://df-xxx → contentUrl
+      if (fileContentId) {
+        return contentUrlMap.get(fileContentId) ?? match;
+      }
+      // file://df-xxx → shareUrl
+      if (fileShareId) {
+        return shareUrlMap.get(fileShareId) ?? match;
+      }
+      // src="df-xxx" or href="df-xxx" → src="contentUrl" or href="shareUrl"
+      if (attrFileId && attrPrefix && attrSuffix) {
+        const isHref = attrPrefix.startsWith('href=');
+        const url = isHref
+          ? (shareUrlMap.get(attrFileId) ?? contentUrlMap.get(attrFileId))
+          : (contentUrlMap.get(attrFileId) ?? shareUrlMap.get(attrFileId));
+        return url ? `${attrPrefix}${url}${attrSuffix}` : match;
+      }
+      return match;
+    },
+  );
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -32,3 +32,4 @@ export * from './guard';
 // Note: token.ts uses tiktoken (WASM) which is not compatible with frontend bundlers
 // Backend should import directly: import { countToken } from '@refly/utils/src/token'
 export * from './on-module-init';
+export * from './file-id';


### PR DESCRIPTION
- Add packages/utils/src/file-id.ts with unified file ID handling:
  - Core patterns: FILE_ID_PATTERN with negative lookbehind
  - Validation: isValidFileId(), extractFileId(), extractAllFileIds()
  - Replacement: replaceAllMarkdownFileIds(), replaceAllHtmlFileIds()
  - Optimized single-pass replacement for large documents

- Update replacement rules:
  - file-content://df-xxx → contentUrl (embedded media)
  - file://df-xxx → shareUrl (share links)
  - Markdown ](df-xxx) → contentUrl priority, shareUrl fallback
  - HTML src="df-xxx" → contentUrl priority, shareUrl fallback
  - HTML href="df-xxx" → shareUrl priority, contentUrl fallback

- Fix send_email URL map building:
  - Write shareUrl and contentUrl independently to maps
  - Support files with only shareUrl or only contentUrl

- Refactor schema-utils.ts to re-export from @refly/utils

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized file ID utilities into a shared module to improve consistency and maintainability across the application.
  * Consolidated validation, extraction, and replacement logic for file references to eliminate duplicate implementations and ensure reliable handling across all modules.
  * Refactored file ID processing to use unified utilities, reducing code duplication and improving overall code quality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->