### PR TITLE
  [REF-1336] Enrich Langfuse tool metadata and add debug logging for dataset curation

### DIFF
--- a/apps/api/src/modules/skill/skill-invoker.service.ts
+++ b/apps/api/src/modules/skill/skill-invoker.service.ts
@@ -340,6 +340,53 @@ export class SkillInvokerService {
       },
     };
 
+    const skillMetaName = data.skillName ?? data.result?.actionMeta?.name ?? 'unknown';
+    const metadata: SkillRunnableMeta = { name: skillMetaName };
+    const setMetadata = (key: string, value: unknown) => {
+      if (value !== undefined) {
+        metadata[key] = value;
+      }
+    };
+
+    if (data.result?.actionMeta?.icon) {
+      metadata.icon = data.result.actionMeta.icon;
+    }
+
+    const modelInfo = data.result?.modelInfo;
+    const providerInfo = providerItem?.provider ?? provider;
+    const providerConfig = providerItem?.config as any;
+    const traceparent =
+      typeof data.traceCarrier?.traceparent === 'string'
+        ? data.traceCarrier?.traceparent
+        : undefined;
+    const traceId = traceparent?.split('-')[1];
+
+    setMetadata('runType', 'skill');
+    setMetadata('traceId', traceId);
+    setMetadata('skillName', data.skillName ?? data.result?.actionMeta?.name);
+    setMetadata('query', data.input?.query);
+    setMetadata('originalQuery', data.input?.originalQuery);
+    setMetadata('locale', outputLocale);
+    setMetadata('uiLocale', userPo?.uiLocale);
+    setMetadata('mode', data.mode);
+    setMetadata('resultId', data.result?.resultId);
+    setMetadata('resultVersion', data.result?.version);
+    setMetadata('status', data.result?.status);
+    setMetadata('errorType', data.result?.errorType);
+    setMetadata('modelName', modelInfo?.name ?? providerConfig?.modelName ?? data.modelName);
+    setMetadata(
+      'modelItemId',
+      data.modelItemId ?? modelInfo?.providerItemId ?? data.result?.actualProviderItemId,
+    );
+    setMetadata('providerKey', modelInfo?.provider ?? providerInfo?.providerKey);
+    setMetadata('providerId', providerInfo?.providerId ?? providerItem?.providerId);
+    setMetadata('workflowExecutionId', data.workflowExecutionId);
+    setMetadata('workflowNodeExecutionId', data.workflowNodeExecutionId);
+
+    if (Object.keys(metadata).length > 0) {
+      config.metadata = metadata;
+    }
+
     if (data.copilotSessionId) {
       config.configurable.copilotSessionId = data.copilotSessionId;
     }

--- a/packages/observability/src/filtered-langfuse-callback.ts
+++ b/packages/observability/src/filtered-langfuse-callback.ts
@@ -46,6 +46,182 @@ function filterMetadata(metadata?: Record<string, unknown>): Record<string, unkn
   return Object.keys(filtered).length > 0 ? filtered : undefined;
 }
 
+function compactMetadata(metadata?: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (!metadata) return undefined;
+
+  const compact: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (value !== undefined) {
+      compact[key] = value;
+    }
+  }
+
+  return Object.keys(compact).length > 0 ? compact : undefined;
+}
+
+function mergeMetadata(
+  base?: Record<string, unknown>,
+  extra?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (!base && !extra) return undefined;
+
+  const merged: Record<string, unknown> = {};
+  if (base) {
+    for (const [key, value] of Object.entries(base)) {
+      if (value !== undefined) {
+        merged[key] = value;
+      }
+    }
+  }
+  if (extra) {
+    for (const [key, value] of Object.entries(extra)) {
+      if (value !== undefined) {
+        merged[key] = value;
+      }
+    }
+  }
+
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function safeJsonParse(input: string): unknown | undefined {
+  try {
+    return JSON.parse(input);
+  } catch {
+    return undefined;
+  }
+}
+
+function extractToolInput(input?: string): { toolInput?: string; toolParameters?: unknown } {
+  const toolInput = input?.trim() ? input : undefined;
+  if (!toolInput) {
+    return {};
+  }
+
+  const trimmed = toolInput.trim();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    const parsed = safeJsonParse(trimmed);
+    if (parsed !== undefined) {
+      return { toolInput, toolParameters: parsed };
+    }
+  }
+
+  return { toolInput };
+}
+
+function buildChainMetadata(
+  inputs: ChainValues,
+  runId: string,
+  parentRunId?: string,
+  metadata?: Record<string, unknown>,
+  runType?: string,
+): Record<string, unknown> {
+  const meta = metadata ?? {};
+  const inputRecord = inputs as Record<string, unknown>;
+  const queryFromInputs = (inputRecord as any)?.query ?? (inputRecord as any)?.input?.query;
+  const originalQueryFromInputs =
+    (inputRecord as any)?.originalQuery ?? (inputRecord as any)?.input?.originalQuery;
+
+  return (
+    compactMetadata({
+      runId,
+      parentRunId,
+      runType: runType ?? (meta as any).runType ?? (meta as any).run_type,
+      query: queryFromInputs ?? (meta as any).query,
+      originalQuery: originalQueryFromInputs ?? (meta as any).originalQuery,
+    }) ?? {}
+  );
+}
+
+function buildToolMetadata(
+  tool: Serialized,
+  input: string,
+  runId: string,
+  parentRunId?: string,
+  metadata?: Record<string, unknown>,
+  name?: string,
+): Record<string, unknown> {
+  const toolRecord = tool as unknown as Record<string, unknown>;
+  const meta = metadata ?? {};
+  const { toolInput, toolParameters } = extractToolInput(input);
+
+  const toolName = (meta as any).toolName ?? (meta as any).name ?? (toolRecord as any).name ?? name;
+  const toolsetKey =
+    (meta as any).toolsetKey ?? (meta as any).toolsetId ?? (meta as any).toolset?.key;
+  const toolsetName = (meta as any).toolsetName ?? (meta as any).toolset?.name;
+  const skillName =
+    (meta as any).skillName ?? (meta as any).currentSkill?.name ?? (meta as any).skill?.name;
+  const nodeType = (meta as any).nodeType ?? (meta as any).node_type;
+  const workflowType = (meta as any).workflowType ?? (meta as any).workflow_type;
+  const query = (meta as any).query;
+  const originalQuery = (meta as any).originalQuery ?? (meta as any).original_query;
+  const locale = (meta as any).locale ?? (meta as any).uiLocale;
+  const modelName =
+    (meta as any).modelName ??
+    (meta as any).model?.name ??
+    (meta as any).model ??
+    (meta as any).modelInfo?.name;
+  const modelItemId =
+    (meta as any).modelItemId ??
+    (meta as any).providerItemId ??
+    (meta as any).modelInfo?.providerItemId;
+  const providerKey =
+    (meta as any).providerKey ?? (meta as any).provider ?? (meta as any).modelInfo?.provider;
+  const providerId = (meta as any).providerId;
+  const promptVersion = (meta as any).promptVersion ?? (meta as any).prompt_version;
+  const schemaVersion =
+    (meta as any).schemaVersion ??
+    (meta as any).schema_version ??
+    (toolRecord as any).schemaVersion ??
+    (toolRecord as any).schema?.version;
+  const traceId = (meta as any).traceId ?? (meta as any).trace_id;
+  const runType = 'tool';
+  const status = (meta as any).status;
+  const errorType = (meta as any).errorType ?? (meta as any).error_type;
+  const retryCount = (meta as any).retryCount ?? (meta as any).retry_count;
+  const startTime = new Date().toISOString();
+
+  const resultId = (meta as any).resultId ?? (meta as any).result_id;
+  const resultVersion =
+    (meta as any).resultVersion ?? (meta as any).version ?? (meta as any).result_version;
+  const callId = (meta as any).callId ?? (meta as any).toolCallId ?? runId;
+  const toolCallId = (meta as any).toolCallId ?? callId;
+
+  return (
+    compactMetadata({
+      callId,
+      toolCallId,
+      runId,
+      parentRunId,
+      runType,
+      traceId,
+      toolName,
+      toolsetKey,
+      toolsetName,
+      skillName,
+      nodeType,
+      workflowType,
+      query,
+      originalQuery,
+      locale,
+      modelName,
+      modelItemId,
+      providerKey,
+      providerId,
+      promptVersion,
+      schemaVersion,
+      resultId,
+      resultVersion,
+      status,
+      errorType,
+      retryCount,
+      startTime,
+      toolInput,
+      toolParameters,
+    }) ?? {}
+  );
+}
+
 /**
  * Langfuse CallbackHandler with filtered metadata
  *
@@ -64,13 +240,19 @@ export class FilteredLangfuseCallbackHandler extends CallbackHandler {
     runType?: string,
     name?: string,
   ): Promise<void> {
+    const filteredMetadata = filterMetadata(metadata);
+    const enrichedMetadata = mergeMetadata(
+      filteredMetadata,
+      buildChainMetadata(inputs, runId, parentRunId, filteredMetadata, runType),
+    );
+
     return super.handleChainStart(
       chain,
       inputs,
       runId,
       parentRunId,
       tags,
-      filterMetadata(metadata),
+      enrichedMetadata,
       runType,
       name,
     );
@@ -155,15 +337,13 @@ export class FilteredLangfuseCallbackHandler extends CallbackHandler {
     metadata?: Record<string, unknown>,
     name?: string,
   ): Promise<void> {
-    return super.handleToolStart(
-      tool,
-      input,
-      runId,
-      parentRunId,
-      tags,
-      filterMetadata(metadata),
-      name,
+    const filteredMetadata = filterMetadata(metadata);
+    const enrichedMetadata = mergeMetadata(
+      filteredMetadata,
+      buildToolMetadata(tool, input, runId, parentRunId, filteredMetadata, name),
     );
+
+    return super.handleToolStart(tool, input, runId, parentRunId, tags, enrichedMetadata, name);
   }
 
   // Override handleRetrieverStart to filter metadata


### PR DESCRIPTION
# Summary

    Enrich Langfuse metadata for skill/tool runs to support reliable dataset curation and debugging.

    **Langfuse Callback:**
    - Add structured tool metadata (callId/toolCallId/resultId/toolName/toolsetKey/etc.)
    - Parse and attach tool input/parameters safely
    - Add guarded debug logging via `LANGFUSE_META_DEBUG`

    **Skill Invocation Metadata:**
    - Inject core context fields (query, locale, model/provider, resultId, workflow IDs)
    - Ensure metadata conforms to `SkillRunnableMeta` requirements

    **Stability Fixes:**
    - Align callback signatures with base handler
    - Guard tool end/error when no tool start is tracked

    # Impact Areas

    - [x] Observability / Langfuse tracing
    - [x] Dataset curation pipeline

    # Checklist

    - [ ] I understand that this PR may be closed in case there was no previous discussion or issues.
    - [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single
  atomic change.
    - [ ] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal metadata collection and tracking for improved system observability and monitoring.
  * Optimized metadata enrichment across service components for better diagnostic capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->