### PR TITLE
[REF-1341]fix(notification): simplify file ID extraction logic and improve URL …

### DIFF
--- a/apps/api/src/modules/notification/notification.service.ts
+++ b/apps/api/src/modules/notification/notification.service.ts
@@ -152,9 +152,8 @@ export class NotificationService {
       ?.replace(/\/$/, '');
     const payloadMode = this.configService.get<'base64' | 'url'>('email.payloadMode');
 
-    // Try to extract file ID from URL to get proper filename (only for internal URLs)
-    const isInternalUrl = url.startsWith(privateStaticEndpoint);
-    const fileId = isInternalUrl ? extractFileId(url) : null;
+    // Try to extract file ID from URL to get proper filename
+    const fileId = extractFileId(url);
     let filename = url.split('/').pop() ?? 'attachment';
 
     if (fileId) {

--- a/packages/agent-tools/src/builtin/index.ts
+++ b/packages/agent-tools/src/builtin/index.ts
@@ -750,21 +750,18 @@ Each fileId must be an exact match from list_files or file metadata (format: df-
       }),
     );
 
-    // Build maps for both URL types (only include successful results)
-    const shareUrlMap = new Map<string, string>();
+    // Build content URL map (only include successful results)
+    // HTML documents use contentUrl for all file references
     const contentUrlMap = new Map<string, string>();
 
-    for (const { fileId, shareUrl, contentUrl } of urlResults) {
-      if (shareUrl) {
-        shareUrlMap.set(fileId, shareUrl);
-      }
+    for (const { fileId, contentUrl } of urlResults) {
       if (contentUrl) {
         contentUrlMap.set(fileId, contentUrl);
       }
     }
 
     // Use shared utility to replace all file ID patterns in HTML content
-    return replaceAllHtmlFileIds(html, contentUrlMap, shareUrlMap);
+    return replaceAllHtmlFileIds(html, contentUrlMap);
   }
 }
 

--- a/packages/utils/src/file-id.ts
+++ b/packages/utils/src/file-id.ts
@@ -234,10 +234,16 @@ const MARKDOWN_COMBINED_PATTERN =
 
 /**
  * Combined pattern for single-pass HTML replacement
- * Matches: file-content://df-xxx | file://df-xxx | src="df-xxx" | href="df-xxx"
+ * Matches: attr with file URIs | file-content://df-xxx | file://df-xxx | bare file IDs in attributes
+ *
+ * Groups:
+ * 1-3: (src|href)="file-content://..." or (src|href)="file://..." (attribute with URI)
+ * 4: standalone file-content://df-xxx
+ * 5: standalone file://df-xxx
+ * 6-8: src="df-xxx" or href="df-xxx" (bare IDs in attributes)
  */
 const HTML_COMBINED_PATTERN =
-  /file-content:\/\/(df-[a-z0-9]+)|(?<!file-content:)file:\/\/(df-[a-z0-9]+)|((?:src|href)=["'])(df-[a-z0-9]+)(["'])/gi;
+  /((?:src|href)=["'])(?:file-content:\/\/|file:\/\/)(df-[a-z0-9]+)(["'])|file-content:\/\/(df-[a-z0-9]+)|(?<!file-content:)file:\/\/(df-[a-z0-9]+)|((?:src|href)=["'])(df-[a-z0-9]+)(["'])/gi;
 
 /**
  * Replace all file ID patterns in markdown content with URLs (optimized single-pass)
@@ -298,27 +304,15 @@ export function replaceAllMarkdownFileIds(
  * Replace all file ID patterns in HTML content with URLs (optimized single-pass)
  * Handles: file-content://, file://, and bare file IDs in src/href attributes
  *
- * Performance optimizations:
- * - Early exit if no file IDs detected
- * - Single-pass replacement using combined regex
- * - Efficient for large documents (O(n) instead of O(3n))
- *
  * @param content - HTML content to process
- * @param contentUrlMap - Map of fileId to content URL (for images/media)
- * @param shareUrlMap - Map of fileId to share URL (for links)
+ * @param urlMap - Map of fileId to URL (content URL for direct file access)
  * @returns Processed content
  */
-export function replaceAllHtmlFileIds(
-  content: string,
-  contentUrlMap: Map<string, string>,
-  shareUrlMap: Map<string, string>,
-): string {
-  // Early exit: skip processing if no file IDs or empty maps
-  if (!content || (contentUrlMap.size === 0 && shareUrlMap.size === 0)) {
+export function replaceAllHtmlFileIds(content: string, urlMap: Map<string, string>): string {
+  if (!content || urlMap.size === 0) {
     return content;
   }
 
-  // Quick check: skip if no potential file ID patterns
   if (
     !hasFileIds(content) &&
     !content.includes('file-content://') &&
@@ -327,33 +321,35 @@ export function replaceAllHtmlFileIds(
     return content;
   }
 
-  // Single-pass replacement
   return content.replace(
     HTML_COMBINED_PATTERN,
     (
       match,
+      attrWithUriPrefix?: string,
+      attrWithUriFileId?: string,
+      attrWithUriSuffix?: string,
       fileContentId?: string,
       fileShareId?: string,
-      attrPrefix?: string,
-      attrFileId?: string,
-      attrSuffix?: string,
+      bareAttrPrefix?: string,
+      bareAttrFileId?: string,
+      bareAttrSuffix?: string,
     ) => {
-      // file-content://df-xxx → contentUrl
-      if (fileContentId) {
-        return contentUrlMap.get(fileContentId) ?? match;
+      // Attribute-based patterns: (src|href)="file://..." or (src|href)="df-xxx"
+      const prefix = attrWithUriPrefix ?? bareAttrPrefix;
+      const fileId = attrWithUriFileId ?? bareAttrFileId;
+      const suffix = attrWithUriSuffix ?? bareAttrSuffix;
+
+      if (fileId && prefix && suffix) {
+        const url = urlMap.get(fileId);
+        return url ? `${prefix}${url}${suffix}` : match;
       }
-      // file://df-xxx → shareUrl
-      if (fileShareId) {
-        return shareUrlMap.get(fileShareId) ?? match;
+
+      // Standalone file-content://df-xxx or file://df-xxx
+      const standaloneId = fileContentId ?? fileShareId;
+      if (standaloneId) {
+        return urlMap.get(standaloneId) ?? match;
       }
-      // src="df-xxx" or href="df-xxx" → src="contentUrl" or href="shareUrl"
-      if (attrFileId && attrPrefix && attrSuffix) {
-        const isHref = attrPrefix.startsWith('href=');
-        const url = isHref
-          ? (shareUrlMap.get(attrFileId) ?? contentUrlMap.get(attrFileId))
-          : (contentUrlMap.get(attrFileId) ?? shareUrlMap.get(attrFileId));
-        return url ? `${attrPrefix}${url}${attrSuffix}` : match;
-      }
+
       return match;
     },
   );


### PR DESCRIPTION
This pull request refactors how file ID patterns in HTML are replaced with URLs, simplifying the logic to use a single URL map and updating the regex to handle more patterns in a single pass. It also removes the distinction between content and share URLs for replacements, streamlining the code and making it more maintainable.

**Refactoring and Simplification of File ID Replacement:**

* The `replaceAllHtmlFileIds` function now takes a single `urlMap` instead of separate `contentUrlMap` and `shareUrlMap`, simplifying the API and internal logic. [[1]](diffhunk://#diff-488ad209c4a2bfa87702a63563da97647156338b6f6caed07a23caf98f5201c4L301-L321) [[2]](diffhunk://#diff-754e41c5ab5b2e13270e7bcec2f4d58b4383d0ace70d7dde7437dcc9ab6dee13L753-R764)
* The internal replacement logic in `replaceAllHtmlFileIds` has been updated to use the new combined regex groups, handling attribute-based and standalone file IDs consistently with the single URL map.

**Regex and Pattern Matching Improvements:**

* The combined regex pattern (`HTML_COMBINED_PATTERN`) has been updated to match more cases in a single pass, including attributes with file URIs and bare file IDs, improving performance and coverage.

**Minor Logic Adjustments:**

* In the notification service, the extraction of file IDs from URLs no longer checks if the URL is internal before attempting extraction, ensuring file IDs are always extracted when possible.…handling in email attachments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in file ID extraction and URL handling across services.

* **Refactor**
  * Consolidated internal URL replacement mechanisms for streamlined processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->