### PR TITLE
 [REF-1343] Remove file type restrictions from workflow resource upload

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/workflow-run/resource-upload.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/workflow-run/resource-upload.tsx
@@ -1,15 +1,9 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Button, Upload, Spin, Tooltip } from 'antd';
 import { Attachment } from 'refly-icons';
 import type { UploadFile } from 'antd/es/upload/interface';
 import { useTranslation } from 'react-i18next';
 import cn from 'classnames';
-import {
-  IMAGE_FILE_EXTENSIONS,
-  DOCUMENT_FILE_EXTENSIONS,
-  AUDIO_FILE_EXTENSIONS,
-  VIDEO_FILE_EXTENSIONS,
-} from '../workflow-variables/constants';
 import { ImageFileIcon, RepeatIcon, TrashIcon } from './resource-upload-icons';
 
 interface ResourceUploadProps {
@@ -33,7 +27,6 @@ export const ResourceUpload: React.FC<ResourceUploadProps> = React.memo(
     onUpload,
     onRemove,
     onRefresh,
-    resourceTypes,
     disabled = false,
     maxCount = 1,
     className,
@@ -77,31 +70,6 @@ export const ResourceUpload: React.FC<ResourceUploadProps> = React.memo(
       }
     }, [onRefresh]);
 
-    // Generate accept attribute based on resource types
-    const accept = useMemo(() => {
-      if (!resourceTypes?.length) {
-        return '';
-      }
-
-      return resourceTypes
-        .map((type) => {
-          switch (type) {
-            case 'document':
-              return DOCUMENT_FILE_EXTENSIONS.map((ext) => `.${ext}`).join(',');
-            case 'image':
-              return IMAGE_FILE_EXTENSIONS.map((ext) => `.${ext}`).join(',');
-            case 'audio':
-              return AUDIO_FILE_EXTENSIONS.map((ext) => `.${ext}`).join(',');
-            case 'video':
-              return VIDEO_FILE_EXTENSIONS.map((ext) => `.${ext}`).join(',');
-            default:
-              return '';
-          }
-        })
-        .filter(Boolean)
-        .join(',');
-    }, [resourceTypes]);
-
     return (
       <div className={`space-y-2 ${className || ''}`} data-field-name={dataFieldName}>
         <Upload
@@ -111,7 +79,6 @@ export const ResourceUpload: React.FC<ResourceUploadProps> = React.memo(
           onRemove={handleFileRemove}
           onChange={() => {}} // Handle change is managed by our custom handlers
           multiple={false}
-          accept={accept}
           listType="text"
           disabled={disabled || uploading}
           maxCount={maxCount}


### PR DESCRIPTION
# Summary

  Remove file type restrictions from workflow resource upload component to support uploading any file type.

  **Resource Upload Component:**
  - Removed `accept` prop from Upload component to allow all file types
  - Removed unused `accept` useMemo logic that filtered by resource types
  - Cleaned up unused imports: `useMemo`, file extension constants

  # Impact Areas

  - [x] Free-form Canvas Interface
  - [x] Other (Workflow Variables)

  # Checklist

  - [x] I understand that this PR may be closed in case there was no previous discussion or issues.
  - [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the resource upload component by removing file type validation constraints. The component now accepts all file types without type-based filtering restrictions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->