### PR TITLE
  [REF-1365] Fix incomplete agent reference ID replacement in workflow plan generation.                                                                    

### DIFF
--- a/packages/canvas-common/src/workflow-plan.test.ts
+++ b/packages/canvas-common/src/workflow-plan.test.ts
@@ -220,6 +220,59 @@ describe('generateCanvasDataFromWorkflowPlan', () => {
     expect(secondQuery).toContain(`@{type=agent,id=${firstEntityId},name=First}`);
   });
 
+  it('should replace agent mentions even when referencing later tasks', () => {
+    // This tests the fix for the bug where agent mentions were not replaced
+    // if a task referenced another task that was defined later in the array
+    const task1 = createTask(
+      'task-1',
+      'First',
+      'Reference later task: @{type=agent,id=task-2,name=Second}',
+    );
+    const task2 = createTask('task-2', 'Second', 'Hello');
+
+    const workflowPlan = createWorkflowPlan([task1, task2]);
+    const result = generateCanvasDataFromWorkflowPlan(workflowPlan, []);
+
+    const firstNode = result.nodes.find((n) => n.data?.title === 'First');
+    const secondNode = result.nodes.find((n) => n.data?.title === 'Second');
+    const secondEntityId = secondNode?.data?.entityId as string;
+    const firstQuery = (firstNode?.data?.metadata as any)?.query ?? '';
+
+    expect(secondEntityId).toBeTruthy();
+    expect(firstQuery).toContain(`@{type=agent,id=${secondEntityId},name=Second}`);
+    expect(firstQuery).not.toContain('task-2'); // Should not contain temporary ID
+  });
+
+  it('should replace multiple agent mentions in a single prompt', () => {
+    const task1 = createTask('task-1', 'First', 'Hello');
+    const task2 = createTask('task-2', 'Second', 'World');
+    const task3 = createTask(
+      'task-3',
+      'Third',
+      'Combine @{type=agent,id=task-1,name=First} and @{type=agent,id=task-2,name=Second}',
+      {
+        dependentTasks: ['task-1', 'task-2'],
+      },
+    );
+
+    const workflowPlan = createWorkflowPlan([task1, task2, task3]);
+    const result = generateCanvasDataFromWorkflowPlan(workflowPlan, []);
+
+    const firstNode = result.nodes.find((n) => n.data?.title === 'First');
+    const secondNode = result.nodes.find((n) => n.data?.title === 'Second');
+    const thirdNode = result.nodes.find((n) => n.data?.title === 'Third');
+    const firstEntityId = firstNode?.data?.entityId as string;
+    const secondEntityId = secondNode?.data?.entityId as string;
+    const thirdQuery = (thirdNode?.data?.metadata as any)?.query ?? '';
+
+    expect(firstEntityId).toBeTruthy();
+    expect(secondEntityId).toBeTruthy();
+    expect(thirdQuery).toContain(`@{type=agent,id=${firstEntityId},name=First}`);
+    expect(thirdQuery).toContain(`@{type=agent,id=${secondEntityId},name=Second}`);
+    expect(thirdQuery).not.toContain('task-1'); // Should not contain temporary IDs
+    expect(thirdQuery).not.toContain('task-2');
+  });
+
   it('should create complex workflow with multiple interconnected tasks', () => {
     // Task 1
     const task1 = createTask('research', 'Research Task', 'Research prompt');


### PR DESCRIPTION
# Summary                                                                                                                                     
                                                                                                                                                
  Fix incomplete agent reference ID replacement in workflow plan generation.                                                                    
                                                                                                                                                
  **Root Cause:**                                                                                                                               
  - In `generateCanvasDataFromWorkflowPlan`, entity IDs were generated incrementally during task processing                                     
  - When a task's prompt referenced a later-defined task, the `taskIdToEntityId` mapping was incomplete                                         
  - This caused temporary IDs (e.g., `@agent:task-1`) to remain unreplaced in some prompts                                                      
                                                                                                                                                
  **Solution:**                                                                                                                                 
  - Added **Phase 0** to pre-generate entity IDs for all tasks before processing                                                                
  - Ensures complete `taskIdToEntityId` mapping is available when replacing agent mentions                                                      
  - All task references now correctly replaced with real entity IDs (e.g., `@agent:ar-xxx`)                                                     
                                                                                                                                                
  **Changes:**                                                                                                                                  
  - `packages/canvas-common/src/workflow-plan.ts`:                                                                                              
    - Added Phase 0 to pre-generate all entity IDs (lines 456-462)                                                                              
    - Modified Phase 1 to use pre-generated entity IDs (line 535)                                                                               
    - Enhanced comments explaining the fix                                                                                                      
                                                                                                                                                
  - `packages/canvas-common/src/workflow-plan.test.ts`:                                                                                         
    - Added test: "should replace agent mentions even when referencing later tasks"                                                             
    - Added test: "should replace multiple agent mentions in a single prompt"                                                                   
                                                                                                                                                
  # Impact Areas                                                                                                                                
                                                                                                                                                
  - [x] Workflow Generation (Copilot)                                                                                                           
  - [x] Canvas Node Creation                                                                                                                    
  - [x] Agent Reference Resolution                                                                                                              
                                                                                                                                                
  # Checklist                                                                                                                                   
                                                                                                                                                
  - [x] I understand that this PR may be closed in case there was no previous discussion or issues.                                             
  - [x] I've added tests for the changes introduced                                                                                             
  - [x] All tests pass (15/15 tests passing)                                                                                                    
  - [x] The fix handles edge cases (forward references, multiple references)                                                                    
                  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests validating agent-mention replacement functionality to ensure accurate reference resolution and that temporary identifiers are not exposed in final output.

* **Improvements**
  * Enhanced workflow processing with better agent-mention resolution for consistent and proper handling of multiple references throughout processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->