### PR TITLE
[REF-1370] feat(api): add payment method types for yearly subscription in Stripe…

### DIFF
--- a/apps/api/src/modules/subscription/subscription.service.ts
+++ b/apps/api/src/modules/subscription/subscription.service.ts
@@ -240,6 +240,9 @@ export class SubscriptionService implements OnModuleInit {
     const price = prices.data[0];
     const sessionParams: Stripe.Checkout.SessionCreateParams = {
       mode: 'subscription',
+      ...(interval === 'yearly' && {
+        payment_method_types: ['card', 'cashapp', 'klarna'],
+      }),
       line_items: [{ price: price.id, quantity: 1 }],
       success_url: this.config.get('stripe.sessionSuccessUrl'),
       cancel_url: this.config.get('stripe.sessionCancelUrl'),


### PR DESCRIPTION
… session parameters

Enhance the subscription service to include additional payment method types ('card', 'cashapp', 'klarna') when the subscription interval is set to 'yearly'. This change improves payment flexibility for users opting for annual subscriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded payment methods for yearly subscription plans to include Cash App and Klarna alongside card payments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->