### PR TITLE
[REF-1373] Revert: sandbox skill mode updates

### DIFF
--- a/apps/api/src/modules/config/app.config.ts
+++ b/apps/api/src/modules/config/app.config.ts
@@ -343,26 +343,12 @@ export default () => ({
     whiteList: process.env.SANDBOX_WHITELIST, // 'uid,uid'
     blackList: process.env.SANDBOX_BLACKLIST, // 'uid,uid'
     randomRate: process.env.SANDBOX_RANDOM_RATE, // '20'
-    anthropic: {
-      authToken: process.env.SANDBOX_SKILL_CLAUDE_ANTHROPIC_AUTH_TOKEN,
-      apiKey: process.env.SANDBOX_SKILL_CLAUDE_ANTHROPIC_API_KEY,
-      baseUrl: process.env.SANDBOX_SKILL_CLAUDE_ANTHROPIC_BASE_URL,
-    },
     s3Lib: {
       enabled: process.env.SANDBOX_S3LIB_ENABLED,
       pathPrefix: process.env.SANDBOX_S3LIB_PATH_PREFIX,
       hash: process.env.SANDBOX_S3LIB_HASH,
       cache: process.env.SANDBOX_S3LIB_CACHE,
       reset: process.env.SANDBOX_S3LIB_RESET,
-    },
-    skillLib: {
-      endpoint: process.env.SANDBOX_SKILL_LIB_ENDPOINT,
-      bucket: process.env.SANDBOX_SKILL_LIB_BUCKET,
-      region: process.env.SANDBOX_SKILL_LIB_REGION,
-      accessKey: process.env.SANDBOX_SKILL_LIB_ACCESS_KEY,
-      secretKey: process.env.SANDBOX_SKILL_LIB_SECRET_KEY,
-      pathPrefix: process.env.SANDBOX_SKILL_LIB_PATH_PREFIX,
-      hash: process.env.SANDBOX_SKILL_LIB_HASH,
     },
     s3: {
       overlap: {

--- a/apps/api/src/modules/sandbox/sandbox.client.ts
+++ b/apps/api/src/modules/sandbox/sandbox.client.ts
@@ -17,27 +17,6 @@ export class SandboxClient {
   @Config.string('sandbox.url', SANDBOX_HTTP.DEFAULT_URL)
   private readonly sandboxUrl: string;
 
-  @Config.string('sandbox.skillLib.pathPrefix', '')
-  private readonly skillLibPathPrefix: string;
-
-  @Config.string('sandbox.skillLib.hash', '')
-  private readonly skillLibHash: string;
-
-  @Config.string('sandbox.skillLib.endpoint', '')
-  private readonly skillLibEndpoint: string;
-
-  @Config.string('sandbox.skillLib.bucket', '')
-  private readonly skillLibBucket: string;
-
-  @Config.string('sandbox.skillLib.region', '')
-  private readonly skillLibRegion: string;
-
-  @Config.string('sandbox.skillLib.accessKey', '')
-  private readonly skillLibAccessKey: string;
-
-  @Config.string('sandbox.skillLib.secretKey', '')
-  private readonly skillLibSecretKey: string;
-
   constructor(
     private readonly config: ConfigService,
     private readonly logger: PinoLogger,
@@ -54,25 +33,21 @@ export class SandboxClient {
     const requestId = uuidv4();
     const timeoutMs = timeout || SANDBOX_TIMEOUTS.DEFAULT;
     const startTime = performance.now();
-    const { normalizedParams, skillLibConfig } = this.transformSkillRequestIfNeeded(
-      params,
-      context,
-    );
 
     this.logger.info({
       requestId,
-      language: normalizedParams.language,
+      language: params.language,
       canvasId: context.canvasId,
       uid: context.uid,
-      codeLength: normalizedParams.code?.length,
+      codeLength: params.code?.length,
       envKeys: context.env ? Object.keys(context.env) : [],
     });
 
     const request: WorkerExecuteRequest = {
       requestId,
-      code: normalizedParams.code,
-      language: normalizedParams.language,
-      provider: normalizedParams.provider,
+      code: params.code,
+      language: params.language,
+      provider: params.provider,
       config: {
         s3: context.s3Config,
         s3DrivePath: context.s3DrivePath,
@@ -80,7 +55,6 @@ export class SandboxClient {
         env: context.env,
         timeout: context.timeout || timeoutMs,
         limits: context.limits,
-        ...(skillLibConfig ? { skillLibConfig: skillLibConfig.config } : {}),
       },
       metadata: {
         uid: context.uid,
@@ -133,93 +107,5 @@ export class SandboxClient {
       }
       throw error;
     }
-  }
-
-  private transformSkillRequestIfNeeded(
-    params: SandboxExecuteParams,
-    context: SandboxExecutionContext,
-  ): {
-    normalizedParams: SandboxExecuteParams;
-    skillLibConfig?: { config: Record<string, unknown> };
-  } {
-    if (params.language !== 'skill') {
-      return { normalizedParams: params };
-    }
-
-    const skillLibConfig = this.buildSkillLibConfig(context);
-
-    return {
-      normalizedParams: params,
-      skillLibConfig: { config: skillLibConfig },
-    };
-  }
-
-  private buildSkillLibConfig(context: SandboxExecutionContext): Record<string, unknown> {
-    this.logger.info({ skillLibEndpoint: this.skillLibEndpoint }, 'Skill lib endpoint override');
-    const normalizedPrefix = this.skillLibPathPrefix
-      ? this.skillLibPathPrefix.replace(/\/+$/, '')
-      : '';
-
-    let path = '';
-    let hash = '';
-    if (normalizedPrefix || this.skillLibHash) {
-      if (!normalizedPrefix || !this.skillLibHash) {
-        throw new Error('cc-skill requires skillLibConfig path/hash');
-      }
-      path = `${normalizedPrefix}/${this.skillLibHash}`;
-      hash = this.skillLibHash;
-    } else if (context.s3LibConfig?.path && context.s3LibConfig?.hash) {
-      path = context.s3LibConfig.path;
-      hash = context.s3LibConfig.hash;
-    } else {
-      throw new Error('cc-skill requires skillLibConfig path/hash');
-    }
-
-    const endpoint = this.skillLibEndpoint || this.normalizeEndpoint(context.s3Config);
-    if (!endpoint) {
-      throw new Error('cc-skill requires a valid s3 endpoint for skillLibConfig');
-    }
-
-    const bucket = this.skillLibBucket || context.s3LibConfig?.bucket || context.s3Config.bucket;
-    const region = this.skillLibRegion || context.s3LibConfig?.region || context.s3Config.region;
-    if (!bucket || !region) {
-      throw new Error('cc-skill requires skillLibConfig bucket/region');
-    }
-
-    const accessKey =
-      this.skillLibAccessKey || context.s3LibConfig?.accessKey || context.s3Config.accessKey;
-    const secretKey =
-      this.skillLibSecretKey || context.s3LibConfig?.secretKey || context.s3Config.secretKey;
-
-    return {
-      endpoint,
-      bucket,
-      region,
-      path,
-      hash,
-      ...(accessKey ? { accessKey } : {}),
-      ...(secretKey ? { secretKey } : {}),
-      ...(context.s3LibConfig?.reset !== undefined ? { reset: context.s3LibConfig.reset } : {}),
-    };
-  }
-
-  private normalizeEndpoint(
-    s3Config: Partial<{ endPoint: string; port: number; useSSL: boolean }>,
-  ): string {
-    const endPoint = s3Config.endPoint;
-    if (!endPoint) return '';
-    if (endPoint.startsWith('http://') || endPoint.startsWith('https://')) {
-      return endPoint;
-    }
-
-    const scheme = s3Config.useSSL ? 'https' : 'http';
-    const port = s3Config.port;
-    const includePort =
-      port &&
-      !Number.isNaN(port) &&
-      !(scheme === 'http' && port === 80) &&
-      !(scheme === 'https' && port === 443);
-
-    return includePort ? `${scheme}://${endPoint}:${port}` : `${scheme}://${endPoint}`;
   }
 }

--- a/apps/api/src/modules/sandbox/sandbox.schema.ts
+++ b/apps/api/src/modules/sandbox/sandbox.schema.ts
@@ -24,7 +24,6 @@ export const S3ConfigSchema = z.object({
 export type S3Config = z.infer<typeof S3ConfigSchema>;
 
 export const S3LibConfigSchema = z.object({
-  endpoint: z.string().optional(),
   accessKey: z.string().optional(),
   secretKey: z.string().optional(),
   bucket: z.string(),
@@ -36,19 +35,6 @@ export const S3LibConfigSchema = z.object({
 });
 
 export type S3LibConfig = z.infer<typeof S3LibConfigSchema>;
-
-const SkillLibConfigSchema = z.object({
-  endpoint: z.string(),
-  bucket: z.string(),
-  region: z.string(),
-  path: z.string(),
-  hash: z.string(),
-  accessKey: z.string().optional(),
-  secretKey: z.string().optional(),
-  ak_enc: z.string().optional(),
-  sk_enc: z.string().optional(),
-  reset: z.boolean().optional(),
-});
 
 /**
  * Resource limits for code execution
@@ -71,7 +57,6 @@ const ExecuteConfigSchema = z
     codeSizeThreshold: z.number().int().positive().optional(),
     templateName: z.string().optional(),
     autoPauseDelay: z.number().int().positive().optional(),
-    skillLibConfig: SkillLibConfigSchema.optional(),
   })
   .passthrough();
 
@@ -82,7 +67,7 @@ const ExecuteMetadataSchema = z
   })
   .passthrough();
 
-const LanguageSchema = z.enum(['python', 'javascript', 'shell', 'skill']);
+const LanguageSchema = z.enum(['python', 'javascript', 'shell']);
 
 /**
  * Worker execution request - sent to sandbox-execute-request queue

--- a/packages/agent-tools/src/builtin/sandbox.ts
+++ b/packages/agent-tools/src/builtin/sandbox.ts
@@ -16,7 +16,7 @@ export class BuiltinExecuteCode extends AgentBaseTool<BuiltinSandboxParams> {
   schema = z.object({
     code: z.string().describe('The code to execute'),
     language: z
-      .enum(['python', 'javascript', 'shell', 'skill'])
+      .enum(['python', 'javascript', 'shell'])
       .describe('Programming language for code execution'),
   });
 

--- a/packages/openapi-schema/package.json
+++ b/packages/openapi-schema/package.json
@@ -6,7 +6,7 @@
   "types": "src/index.ts",
   "scripts": {
     "dev": "nodemon",
-    "codegen": "openapi-ts --input ./schema.yml --output ./src --client @hey-api/client-fetch && tsc --build --verbose",
+    "codegen": "openapi-ts && tsc --build --verbose",
     "clean": "rimraf dist && rimraf tsconfig.tsbuildinfo",
     "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "tsc --build --verbose"

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -8189,7 +8189,6 @@ components:
             - python
             - javascript
             - shell
-            - skill
           example: "python"
 
     SandboxExecuteContext:

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -5936,7 +5936,7 @@ export const SandboxExecuteParamsSchema = {
     language: {
       type: 'string',
       description: 'Programming language for code execution',
-      enum: ['python', 'javascript', 'shell', 'skill'],
+      enum: ['python', 'javascript', 'shell'],
       example: 'python',
     },
   },

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -4449,13 +4449,13 @@ export type SandboxExecuteParams = {
   /**
    * Programming language for code execution
    */
-  language: 'python' | 'javascript' | 'shell' | 'skill';
+  language: 'python' | 'javascript' | 'shell';
 };
 
 /**
  * Programming language for code execution
  */
-export type language = 'python' | 'javascript' | 'shell' | 'skill';
+export type language = 'python' | 'javascript' | 'shell';
 
 export type SandboxExecuteContext = {
   /**


### PR DESCRIPTION
Summary:\n- revert [REF-1373] sandbox skill mode updates\n\nReason:\n- rollback integration per request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed 'skill' from supported sandbox execution languages; now supports Python, JavaScript, and Shell only
  * Removed Anthropic and SkillLib configuration options from sandbox service

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->