### PR TITLE
fix(canvas): auto-resolve conflict when no local changes

### DIFF
--- a/packages/ai-workspace-common/src/context/canvas.tsx
+++ b/packages/ai-workspace-common/src/context/canvas.tsx
@@ -281,6 +281,16 @@ export const CanvasProvider = ({
     (canvasId: string, conflict: VersionConflict): Promise<'local' | 'remote'> => {
       const { localState, remoteState } = conflict;
 
+      // Check if local has unsynced changes (transactions that haven't been synced to server)
+      const localTransactions = localState.transactions ?? [];
+      const hasLocalChanges = localTransactions.length > 0;
+
+      // If no local changes, automatically use remote version (e.g., CLI updated the canvas)
+      if (!hasLocalChanges) {
+        return Promise.resolve('remote');
+      }
+
+      // Local has changes, show conflict dialog for user to choose
       const localModifiedTs = getLastTransaction(localState)?.createdAt ?? localState.updatedAt;
       const remoteModifiedTs = getLastTransaction(remoteState)?.createdAt ?? remoteState.updatedAt;
 


### PR DESCRIPTION
When a version conflict is detected but local has no unsynced changes (e.g., CLI updated the canvas remotely), automatically use the remote version instead of showing a conflict dialog.

This improves UX when using CLI to edit workflows - the web client will seamlessly accept CLI updates without prompting the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced conflict resolution by automatically resolving to the remote version when no local changes are pending, while preserving manual conflict resolution options when local modifications exist.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->