### PR TITLE
[REF-1381] fix(api): update payment method types for yearly subscription in Stripe session parameters

### DIFF
--- a/apps/api/src/modules/subscription/subscription.service.ts
+++ b/apps/api/src/modules/subscription/subscription.service.ts
@@ -241,7 +241,7 @@ export class SubscriptionService implements OnModuleInit {
     const sessionParams: Stripe.Checkout.SessionCreateParams = {
       mode: 'subscription',
       ...(interval === 'yearly' && {
-        payment_method_types: ['card', 'cashapp', 'klarna'],
+        payment_method_types: ['card'],
       }),
       line_items: [{ price: price.id, quantity: 1 }],
       success_url: this.config.get('stripe.sessionSuccessUrl'),


### PR DESCRIPTION
Remove 'cashapp' and 'klarna' from the payment method types for yearly subscriptions, retaining only 'card'. This change simplifies the payment options available to users during the subscription process.