### PR TITLE
[REF-1386] feat: Add self-deploy docker compose and deploy type support

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -126,6 +126,29 @@ jobs:
       ref: ${{ needs.prepare-prod-deploy.outputs.release_branch }}
     secrets: inherit
 
+  release-docker-images:
+    name: Trigger Release Docker Images
+    runs-on: ubuntu-latest
+    needs: [prepare-prod-deploy, deploy-api-prod, deploy-web-prod]
+    if: success() && needs.prepare-prod-deploy.outputs.should_deploy == 'true'
+    continue-on-error: true
+    steps:
+      - name: Trigger release-image workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_BRANCH: ${{ needs.prepare-prod-deploy.outputs.release_branch }}
+        run: |
+          # Convert release/2026-01-28 to release-2026-01-28
+          VERSION=$(echo "$RELEASE_BRANCH" | sed 's|/|-|g')
+          echo "Triggering Release Docker Images with version: $VERSION on ref: $RELEASE_BRANCH"
+
+          gh workflow run release-image.yml \
+            --repo "${{ github.repository }}" \
+            --ref "$RELEASE_BRANCH" \
+            -f version="$VERSION"
+
+          echo "Release Docker Images workflow triggered (async)"
+
   update-project-status:
     name: Update Project Status to Done
     runs-on: ubuntu-latest

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g. 0.3.1)'
+        description: 'Release version'
         required: true
         type: string
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -187,6 +187,10 @@ LANGFUSE_SECRET_KEY=sk-lf-dev
 # Get your DSN from https://sentry.io/
 # SENTRY_DSN=https://xxx@xxx.ingest.sentry.io/xxx
 
+# Deploy Type Configuration
+# Options: cloud (default), self-hosted
+# DEPLOY_TYPE=cloud
+
 # Statsig Configuration (Feature Flags & Analytics)
 # Get your key from https://console.statsig.com/
 # STATSIG_SECRET_KEY=secret-xxx

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -27,3 +27,6 @@ VITE_RUNTIME=
 
 # Env tags. None or test/staging.
 VITE_ENV_TAG=
+
+# Deploy type: cloud (default) or self-hosted
+# VITE_DEPLOY_TYPE=cloud

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -50,6 +50,7 @@ window.ENV = {
   CANVAS_TEMPLATE_ENABLED: "$CANVAS_TEMPLATE_ENABLED" === "true",
   SENTRY_ENABLED: "$SENTRY_ENABLED" === "true",
   ENV_TAG: "$ENV_TAG" || undefined,
+  DEPLOY_TYPE: "$DEPLOY_TYPE" || undefined,
 };
 EOF
 

--- a/apps/web/Dockerfile.dev
+++ b/apps/web/Dockerfile.dev
@@ -31,6 +31,7 @@ window.ENV = {
   CANVAS_TEMPLATE_ENABLED: "$CANVAS_TEMPLATE_ENABLED" === "true",
   SENTRY_ENABLED: "$SENTRY_ENABLED" === "true",
   ENV_TAG: "$ENV_TAG" || undefined,
+  DEPLOY_TYPE: "$DEPLOY_TYPE" || undefined,
 };
 EOF
 

--- a/deploy/docker/docker-compose.services.yml
+++ b/deploy/docker/docker-compose.services.yml
@@ -31,6 +31,7 @@ services:
       - ENDPOINT=/api
       - STATIC_PUBLIC_ENDPOINT=/api/v1/misc/public
       - STATIC_PRIVATE_ENDPOINT=/api/v1/misc
+      - DEPLOY_TYPE=self-hosted
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5800"]
       interval: 30s
@@ -50,6 +51,7 @@ services:
       - STATIC_PUBLIC_ENDPOINT=/api/v1/misc/public
       - STATIC_PRIVATE_ENDPOINT=/api/v1/misc
       - VITE_SUBSCRIPTION_ENABLED=false
+      - DEPLOY_TYPE=self-hosted
     volumes:
       - ./nginx-proxy.conf:/etc/nginx/conf.d/default.conf:ro
     healthcheck:

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1,3 +1,10 @@
+# Usage
+#   Start:              docker compose up
+#   Stop:               docker compose down
+#   Destroy:            docker compose down -v --remove-orphans
+
+name: refly
+
 include:
   - path: docker-compose.base.yml
 

--- a/packages/ai-workspace-common/src/components/canvas/front-page/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/front-page/index.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from 'motion/react';
 import { useTranslation } from 'react-i18next';
 import { Button } from 'antd';
 import { TemplateCardSkeleton } from '@refly-packages/ai-workspace-common/components/canvas-template/template-card-skeleton';
-import { canvasTemplateEnabled } from '@refly/ui-kit';
+import { canvasTemplateEnabled, isSelfHosted } from '@refly/ui-kit';
 import { useSiderStoreShallow } from '@refly/stores';
 import cn from 'classnames';
 import { useListCanvasTemplateCategories } from '@refly-packages/ai-workspace-common/queries/queries';
@@ -456,7 +456,7 @@ export const FrontPage = memo(() => {
         </Suspense>
       </ModuleContainer>
 
-      {canvasTemplateEnabled && (
+      {canvasTemplateEnabled && !isSelfHosted && (
         <ModuleContainer
           className="mt-[50px]"
           title={t('frontPage.template.title')}

--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/index.tsx
@@ -20,6 +20,7 @@ import { logEvent } from '@refly/telemetry-web';
 import { ActionsInCanvasDropdown } from '@refly-packages/ai-workspace-common/components/canvas/top-toolbar/actions-in-canvas-dropdown';
 import { SettingItem } from '@refly-packages/ai-workspace-common/components/canvas/front-page';
 import { GithubStar } from '@refly-packages/ai-workspace-common/components/common/github-star';
+import { isSelfHosted } from '@refly/ui-kit';
 
 interface TopToolbarProps {
   canvasId: string;
@@ -151,8 +152,10 @@ export const TopToolbar: FC<TopToolbarProps> = memo(({ canvasId, hideLogoButton,
           ) : (
             <>
               {/* <ShareSettings canvasId={canvasId} canvasTitle={canvasTitle} /> */}
-              <ScheduleButton canvasId={canvasId} />
-              <PublishTemplateButton canvasId={canvasId} canvasTitle={canvasTitle} />
+              {!isSelfHosted && <ScheduleButton canvasId={canvasId} />}
+              {!isSelfHosted && (
+                <PublishTemplateButton canvasId={canvasId} canvasTitle={canvasTitle} />
+              )}
             </>
           )}
           {!isRunDetail && (

--- a/packages/ai-workspace-common/src/components/sider/layout.tsx
+++ b/packages/ai-workspace-common/src/components/sider/layout.tsx
@@ -7,7 +7,7 @@ import {
 } from '@refly-packages/ai-workspace-common/utils/router';
 
 import cn from 'classnames';
-import { subscriptionEnabled } from '@refly/ui-kit';
+import { subscriptionEnabled, isSelfHosted } from '@refly/ui-kit';
 import { Logo } from '@refly-packages/ai-workspace-common/components/common/logo';
 // components - Lazy load Modal components to reduce initial bundle size
 import { useTranslation } from 'react-i18next';
@@ -403,46 +403,48 @@ const SiderLoggedIn = (props: { source: 'sider' | 'popover' }) => {
 
   // Menu items configuration
   const menuItems = useMemo(
-    () => [
-      {
-        icon: <File key="home" style={{ fontSize: 20 }} />,
-        title: t('loggedHomePage.siderMenu.home'),
-        onActionClick: () => navigate('/'),
-        key: 'home',
-      },
-      {
-        icon: <Flow key="canvas" style={{ fontSize: 20 }} />,
-        title: t('loggedHomePage.siderMenu.canvas'),
-        onActionClick: () => navigate('/workflow-list'),
-        key: 'canvas',
-      },
-      {
-        icon: <Project key="appManager" style={{ fontSize: 20 }} />,
-        title: t('loggedHomePage.siderMenu.appManager'),
-        onActionClick: () => navigate('/app-manager'),
-        key: 'appManager',
-      },
-      {
-        icon: <MarketPlace key="marketplace" style={{ fontSize: 20 }} />,
-        title: t('loggedHomePage.siderMenu.marketplace'),
-        onActionClick: () => navigate('/marketplace'),
-        key: 'marketplace',
-      },
-    ],
-    [t, navigate],
+    () =>
+      [
+        {
+          icon: <File key="home" style={{ fontSize: 20 }} />,
+          title: t('loggedHomePage.siderMenu.home'),
+          onActionClick: () => navigate('/'),
+          key: 'home',
+        },
+        {
+          icon: <Flow key="canvas" style={{ fontSize: 20 }} />,
+          title: t('loggedHomePage.siderMenu.canvas'),
+          onActionClick: () => navigate('/workflow-list'),
+          key: 'canvas',
+        },
+        {
+          icon: <Project key="appManager" style={{ fontSize: 20 }} />,
+          title: t('loggedHomePage.siderMenu.appManager'),
+          onActionClick: () => navigate('/app-manager'),
+          key: 'appManager',
+        },
+        {
+          icon: <MarketPlace key="marketplace" style={{ fontSize: 20 }} />,
+          title: t('loggedHomePage.siderMenu.marketplace'),
+          onActionClick: () => navigate('/marketplace'),
+          key: 'marketplace',
+        },
+      ].filter((item) => !isSelfHosted || !['appManager', 'marketplace'].includes(item?.key)),
+    [t, navigate, isSelfHosted],
   );
 
   // Secondary menu items (below divider)
   const secondaryMenuItems = useMemo(
-    () => [
-      {
-        icon: <History key="runHistory" style={{ fontSize: 20 }} />,
-        title: t('loggedHomePage.siderMenu.runHistory'),
-        onActionClick: () => navigate('/run-history'),
-        key: 'runHistory',
-      },
-    ],
-    [t, navigate],
+    () =>
+      [
+        {
+          icon: <History key="runHistory" style={{ fontSize: 20 }} />,
+          title: t('loggedHomePage.siderMenu.runHistory'),
+          onActionClick: () => navigate('/run-history'),
+          key: 'runHistory',
+        },
+      ].filter((item) => !isSelfHosted || item.key !== 'runHistory'),
+    [t, navigate, isSelfHosted],
   );
 
   const bottomMenuItems = useMemo(

--- a/packages/ai-workspace-common/src/components/workflow-list/index.tsx
+++ b/packages/ai-workspace-common/src/components/workflow-list/index.tsx
@@ -24,6 +24,7 @@ import defaultAvatar from '../../assets/refly_default_avatar_v2.webp';
 import { useDebouncedCallback } from 'use-debounce';
 import { useSiderStoreShallow, useSubscriptionStoreShallow } from '@refly/stores';
 import { SettingItem } from '@refly-packages/ai-workspace-common/components/canvas/front-page';
+import { isSelfHosted } from '@refly/ui-kit';
 
 const WorkflowList = memo(() => {
   const { t, i18n } = useTranslation();
@@ -329,10 +330,12 @@ const WorkflowList = memo(() => {
         />
 
         {/* Schedule Filter */}
-        <WorkflowFilters
-          hasScheduleFilter={hasScheduleFilter}
-          onHasScheduleFilterChange={setHasScheduleFilter}
-        />
+        {!isSelfHosted && (
+          <WorkflowFilters
+            hasScheduleFilter={hasScheduleFilter}
+            onHasScheduleFilterChange={setHasScheduleFilter}
+          />
+        )}
 
         {/* Sort Button */}
         <Button

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -18,6 +18,7 @@ export {
   canvasTemplateEnabled,
   sentryEnabled,
   envTag,
+  isSelfHosted,
   runtime,
   isDesktop,
 } from './utils/env';

--- a/packages/ui-kit/src/utils/env.ts
+++ b/packages/ui-kit/src/utils/env.ts
@@ -11,6 +11,7 @@ declare global {
       CANVAS_TEMPLATE_ENABLED?: boolean;
       SENTRY_ENABLED?: boolean;
       ENV_TAG?: string;
+      DEPLOY_TYPE?: string;
     };
 
     ipcRenderer?: {
@@ -83,6 +84,12 @@ export const sentryEnabled =
 
 export const envTag = getBrowserValue(() => window.ENV?.ENV_TAG, '') || process.env.VITE_ENV_TAG;
 console.log('envTag', envTag);
+
+const DEPLOY_TYPE_SELF_HOSTED = 'self-hosted';
+
+export const isSelfHosted =
+  getBrowserValue(() => window.ENV?.DEPLOY_TYPE, '') === DEPLOY_TYPE_SELF_HOSTED ||
+  process.env.VITE_DEPLOY_TYPE === DEPLOY_TYPE_SELF_HOSTED;
 
 export const runtime = process.env.VITE_RUNTIME as IRuntime;
 

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -51,6 +51,7 @@ declare global {
       CANVAS_TEMPLATE_ENABLED?: boolean;
       SENTRY_ENABLED?: boolean;
       ENV_TAG?: string;
+      DEPLOY_TYPE?: string;
     };
 
     ipcRenderer?: {


### PR DESCRIPTION
- Add DEPLOY_TYPE env (cloud / self-hosted) for api and web, with isSelfHosted in ui-kit
- Add docker-compose project name and usage comments; set DEPLOY_TYPE=self-hosted in services
- Add release-docker-images job to deploy-to-prod workflow to trigger release-image on deploy
- Hide app manager, marketplace, run history and canvas template in self-hosted mode
- Update .env.example for api and web with DEPLOY_TYPE docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added self-hosted deployment support with environment-specific configurations
  * Conditional feature visibility based on deployment type (hides marketplace, scheduling, and app management in self-hosted mode)

* **Chores**
  * Enhanced Docker image release automation
  * Extended environment variable and configuration documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->