### PR TITLE
[REF-1397] feat: Enable schedule and integration docs for self-hosted

### DIFF
--- a/packages/ai-workspace-common/src/components/canvas/top-toolbar/index.tsx
+++ b/packages/ai-workspace-common/src/components/canvas/top-toolbar/index.tsx
@@ -153,23 +153,21 @@ export const TopToolbar: FC<TopToolbarProps> = memo(({ canvasId, hideLogoButton,
           ) : (
             <>
               {/* <ShareSettings canvasId={canvasId} canvasTitle={canvasTitle} /> */}
+              <div className="top-toolbar-button-group">
+                <ScheduleButton
+                  canvasId={canvasId}
+                  className="top-toolbar-group-button top-toolbar-group-button-schedule"
+                />
+                <span className="top-toolbar-button-divider" />
+                <IntegrationDocsButton
+                  canvasId={canvasId}
+                  buttonClassName="top-toolbar-group-button top-toolbar-group-button-integration"
+                  buttonType="text"
+                />
+              </div>
+              <span className="top-toolbar-external-divider" />
               {!isSelfHosted && (
-                <>
-                  <div className="top-toolbar-button-group">
-                    <ScheduleButton
-                      canvasId={canvasId}
-                      className="top-toolbar-group-button top-toolbar-group-button-schedule"
-                    />
-                    <span className="top-toolbar-button-divider" />
-                    <IntegrationDocsButton
-                      canvasId={canvasId}
-                      buttonClassName="top-toolbar-group-button top-toolbar-group-button-integration"
-                      buttonType="text"
-                    />
-                  </div>
-                  <span className="top-toolbar-external-divider" />
-                  <PublishTemplateButton canvasId={canvasId} canvasTitle={canvasTitle} />
-                </>
+                <PublishTemplateButton canvasId={canvasId} canvasTitle={canvasTitle} />
               )}
               <div className="group relative">
                 <SettingItem showName={false} avatarAlign={'right'} />

--- a/packages/ai-workspace-common/src/components/workflow-list/index.tsx
+++ b/packages/ai-workspace-common/src/components/workflow-list/index.tsx
@@ -24,7 +24,6 @@ import defaultAvatar from '../../assets/refly_default_avatar_v2.webp';
 import { useDebouncedCallback } from 'use-debounce';
 import { useSiderStoreShallow, useSubscriptionStoreShallow } from '@refly/stores';
 import { SettingItem } from '@refly-packages/ai-workspace-common/components/canvas/front-page';
-import { isSelfHosted } from '@refly/ui-kit';
 
 const WorkflowList = memo(() => {
   const { t, i18n } = useTranslation();
@@ -330,12 +329,10 @@ const WorkflowList = memo(() => {
         />
 
         {/* Schedule Filter */}
-        {!isSelfHosted && (
-          <WorkflowFilters
-            hasScheduleFilter={hasScheduleFilter}
-            onHasScheduleFilterChange={setHasScheduleFilter}
-          />
-        )}
+        <WorkflowFilters
+          hasScheduleFilter={hasScheduleFilter}
+          onHasScheduleFilterChange={setHasScheduleFilter}
+        />
 
         {/* Sort Button */}
         <Button


### PR DESCRIPTION
## Summary

This PR enables schedule and integration docs for self-hosted. Schedule button, integration docs button, and workflow schedule filter are now shown in self-hosted mode.

## Changes

- Top toolbar: show ScheduleButton and IntegrationDocsButton for all users (including self-hosted); keep PublishTemplateButton behind commercial flag
- Workflow list: show WorkflowFilters (schedule filter) for self-hosted; remove unused isSelfHosted import


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Improvements**
  * Reorganized the toolbar layout with restructured button grouping and improved visual hierarchy.
  * Schedule filtering options are now consistently available in workflow management views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->