### PR TITLE
[REF-1386] feat: Improve release image build with parallel native builds and GHA cache

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -8,20 +8,38 @@ on:
         required: true
         type: string
 
+env:
+  REGISTRY: docker.io
+  IMAGE_PREFIX: reflyai/refly
+
 jobs:
-  release-image:
-    name: Release Docker Images
-    runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.app }} (${{ matrix.suffix }})
+    runs-on: ${{ matrix.runner }}
     if: github.repository == 'refly-ai/refly'
     strategy:
+      fail-fast: false
       matrix:
-        app: ['api', 'web']
+        include:
+          - app: api
+            platform: linux/amd64
+            runner: ubuntu-latest
+            suffix: amd64
+          - app: api
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            suffix: arm64
+          - app: web
+            platform: linux/amd64
+            runner: ubuntu-latest
+            suffix: amd64
+          - app: web
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            suffix: arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -32,13 +50,104 @@ jobs:
           username: reflyai
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./apps/${{ matrix.app }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
-          tags: |
-            reflyai/refly-${{ matrix.app }}:latest
-            reflyai/refly-${{ matrix.app }}:${{ inputs.version }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-${{ matrix.app }},push-by-digest=true,name-canonical=true
+          cache-from: type=gha,scope=${{ matrix.app }}-${{ matrix.suffix }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.app }}-${{ matrix.suffix }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.app }}-${{ matrix.suffix }}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.app }}-${{ matrix.suffix }}
+          path: /tmp/digests/${{ matrix.app }}-${{ matrix.suffix }}
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge ${{ matrix.app }} manifests
+    runs-on: ubuntu-latest
+    if: github.repository == 'refly-ai/refly'
+    needs: build
+    strategy:
+      matrix:
+        app: ['api', 'web']
+    steps:
+      - name: Download amd64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digest-${{ matrix.app }}-amd64
+          path: /tmp/digests
+
+      - name: Download arm64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digest-${{ matrix.app }}-arm64
+          path: /tmp/digests
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: reflyai
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          AMD64_DIGEST=$(cat /tmp/digests/${{ matrix.app }}-amd64)
+          ARM64_DIGEST=$(cat /tmp/digests/${{ matrix.app }}-arm64)
+
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-${{ matrix.app }}"
+
+          docker buildx imagetools create \
+            -t "${IMAGE}:latest" \
+            -t "${IMAGE}:${{ inputs.version }}" \
+            "${IMAGE}@${AMD64_DIGEST}" \
+            "${IMAGE}@${ARM64_DIGEST}"
+
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect "${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-${{ matrix.app }}:${{ inputs.version }}"
+
+      - name: Generate summary
+        run: |
+          IMAGE="${{ env.IMAGE_PREFIX }}-${{ matrix.app }}"
+          VERSION="${{ inputs.version }}"
+
+          cat >> $GITHUB_STEP_SUMMARY << EOF
+          ## 🐳 Docker Image Published: ${{ matrix.app }}
+
+          **Version:** \`${VERSION}\`
+
+          **Image:** \`${IMAGE}\`
+
+          **Docker Hub:** [${IMAGE}](https://hub.docker.com/r/${IMAGE}/tags)
+
+          **Architectures:**
+          - ✅ linux/amd64
+          - ✅ linux/arm64
+
+          ### Pull Commands
+          \`\`\`bash
+          # Latest version
+          docker pull ${IMAGE}:latest
+
+          # Specific version
+          docker pull ${IMAGE}:${VERSION}
+          \`\`\`
+
+          ### Run Commands
+          \`\`\`bash
+          docker run -d ${IMAGE}:${VERSION}
+          \`\`\`
+          EOF

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -2,8 +2,8 @@
 FROM node:20.19.1-alpine3.20 AS builder
 WORKDIR /app
 
-# Install pnpm globally
-RUN npm install -g pnpm
+# Enable corepack and activate pnpm
+RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
 
 # Set environment variables to skip gyp-related installations
 ENV npm_config_gyp_ignore=true
@@ -19,17 +19,14 @@ COPY apps/api/prisma ./apps/api/prisma
 COPY packages/ ./packages/
 
 # Install dependencies with workspace support
-RUN pnpm install --ignore-scripts
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm install --ignore-scripts
 
 # Copy remaining source code
 COPY . .
 
 # Build packages in correct order
 RUN pnpm build:api
-
-# # Clean up development dependencies
-# RUN rm -rf node_modules
-# RUN pnpm install --prod --frozen-lockfile --ignore-scripts
 
 # wkhtmltopdf stage
 FROM surnet/alpine-wkhtmltopdf:3.20.3-0.12.6-small AS wkhtmltopdf

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -2,8 +2,8 @@
 FROM node:20.19.1-alpine3.20 AS builder
 WORKDIR /app
 
-# Install pnpm globally
-RUN npm install -g pnpm
+# Enable corepack and activate pnpm
+RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
 
 # Set environment variables to skip gyp-related installations
 ENV npm_config_gyp_ignore=true
@@ -18,7 +18,8 @@ COPY apps/web/package.json ./apps/web/
 COPY packages/ ./packages/
 
 # Install dependencies with workspace support
-RUN pnpm install --ignore-scripts
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm install --ignore-scripts
 
 # Copy remaining source code
 COPY . .

--- a/packages/ai-workspace-common/src/components/sider/layout.tsx
+++ b/packages/ai-workspace-common/src/components/sider/layout.tsx
@@ -435,16 +435,15 @@ const SiderLoggedIn = (props: { source: 'sider' | 'popover' }) => {
 
   // Secondary menu items (below divider)
   const secondaryMenuItems = useMemo(
-    () =>
-      [
-        {
-          icon: <History key="runHistory" style={{ fontSize: 20 }} />,
-          title: t('loggedHomePage.siderMenu.runHistory'),
-          onActionClick: () => navigate('/run-history'),
-          key: 'runHistory',
-        },
-      ].filter((item) => !isSelfHosted || item.key !== 'runHistory'),
-    [t, navigate, isSelfHosted],
+    () => [
+      {
+        icon: <History key="runHistory" style={{ fontSize: 20 }} />,
+        title: t('loggedHomePage.siderMenu.runHistory'),
+        onActionClick: () => navigate('/run-history'),
+        key: 'runHistory',
+      },
+    ],
+    [t, navigate],
   );
 
   const bottomMenuItems = useMemo(


### PR DESCRIPTION
## Summary

This PR speeds up the release Docker image workflow by building each architecture on native runners in parallel (no QEMU), reusing GHA cache, and merging multi-arch manifests after push-by-digest. It also updates API/Web Dockerfiles to use corepack for pnpm and adds a pnpm store cache mount for the API build.

## Changes

- **Release workflow**: Split into parallel build jobs (api/web × amd64/arm64) on `ubuntu-latest` and `ubuntu-24.04-arm`; use `cache-from`/`cache-to` with GHA; push by digest then a merge job creates and pushes multi-arch tags
- **Merge job**: Adds step summary with version, image name, Docker Hub link, and pull/run commands
- **API Dockerfile**: Use corepack for pnpm; add `--mount=type=cache` for pnpm store
- **Web Dockerfile**: Use corepack for pnpm
- **Sider layout**: Minor updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Run History menu item is now consistently available in the secondary menu across all deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->