### PR TITLE
[REF-1388] fix(env): add build argument for Cloudflare site key in Dockerfile an…

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -175,6 +175,8 @@ jobs:
           tags: ${{ steps.docker_tags.outputs.tags }}
           cache-from: type=registry,ref=${{ steps.docker_tags.outputs.repository }}:buildcache
           cache-to: type=registry,ref=${{ steps.docker_tags.outputs.repository }}:buildcache,mode=max
+          build-args: |
+            PUBLIC_CLOUDFLARE_SITE_KEY=${{ vars.TEST_PUBLIC_CLOUDFLARE_SITE_KEY }}
 
       - name: Update kubeconfig for EKS cluster
         if: github.ref_name == 'main'

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -24,6 +24,10 @@ RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
 # Copy remaining source code
 COPY . .
 
+# Build arguments for environment variables
+ARG PUBLIC_CLOUDFLARE_SITE_KEY
+ENV PUBLIC_CLOUDFLARE_SITE_KEY=$PUBLIC_CLOUDFLARE_SITE_KEY
+
 # Build packages in correct order
 RUN pnpm build:web
 

--- a/apps/web/rsbuild.config.ts
+++ b/apps/web/rsbuild.config.ts
@@ -10,7 +10,7 @@ import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import { PrecacheManifestPlugin } from './config/plugins/precache-manifest-plugin';
 import { ChunkDependencyReportPlugin } from './config/plugins/chunk-dependency-report-plugin';
 
-const { publicVars } = loadEnv({ prefixes: ['VITE_'] });
+const { publicVars } = loadEnv({ prefixes: ['VITE_', 'PUBLIC_'] });
 
 import path from 'node:path';
 import crypto from 'node:crypto';


### PR DESCRIPTION
…d workflow

- Introduced a build argument for PUBLIC_CLOUDFLARE_SITE_KEY in the Dockerfile to ensure the environment variable is set during the build process.
- Updated the GitHub Actions workflow to pass the Cloudflare site key as a build argument, enhancing deployment configuration.
- Adjusted environment variable loading in rsbuild.config.ts to include the new prefix for better consistency.
- Ensured compliance with code style and performance optimization rules throughout the changes.