### PR TITLE
[REF-1440] feat: Improve display of PTC tool call results

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1818,6 +1818,10 @@ model ToolCallResult {
   status    String    @default("executing") @map("status")
   /// Error message
   error     String?   @map("error")
+  /// Call type: agent (standard), ptc (sandbox), standalone (direct API)
+  type      String    @default("agent") @map("type")
+  /// PTC parent call ID (links to execute_code's callId, only for type='ptc')
+  ptcCallId String?   @map("ptc_call_id")
   /// Create timestamp
   createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz()
   /// Update timestamp
@@ -1828,6 +1832,8 @@ model ToolCallResult {
   @@index([resultId, version])
   @@index([toolsetId, deletedAt])
   @@index([toolName, deletedAt])
+  @@index([ptcCallId, type, deletedAt])
+  @@index([resultId, version, type])
   @@map("tool_call_results")
 }
 

--- a/apps/api/src/modules/action/action.dto.ts
+++ b/apps/api/src/modules/action/action.dto.ts
@@ -46,10 +46,12 @@ function actionStepPO2DTO(step: ActionStepDetail, options?: SanitizeOptions): Ac
 }
 
 export function actionMessagePO2DTO(message: ActionMessageModel): ActionMessage {
+  const isPtc = message.toolCallId?.startsWith('ptc:');
   return {
     ...pick(message, ['messageId', 'content', 'reasoningContent', 'usageMeta', 'toolCallId']),
     type: message.type as ActionMessageType,
     toolCallMeta: safeParseJSON(message.toolCallMeta || '{}') as ToolCallMeta,
+    ...(isPtc && { isPtc: true }),
     createdAt: message.createdAt.toJSON(),
     updatedAt: message.updatedAt.toJSON(),
   };

--- a/apps/api/src/modules/config/app.config.ts
+++ b/apps/api/src/modules/config/app.config.ts
@@ -256,6 +256,7 @@ export default () => ({
   },
   ptc: {
     mode: process.env.PTC_MODE || 'off',
+    debug: process.env.PTC_DEBUG || '',
     userAllowlist: process.env.PTC_USER_ALLOWLIST || '',
     toolsetAllowlist: process.env.PTC_TOOLSET_ALLOWLIST || '',
     toolsetBlocklist: process.env.PTC_TOOLSET_BLOCKLIST || '',

--- a/apps/api/src/modules/sandbox/sandbox.schema.ts
+++ b/apps/api/src/modules/sandbox/sandbox.schema.ts
@@ -32,6 +32,7 @@ export const S3LibConfigSchema = z.object({
   hash: z.string(),
   cache: z.boolean().optional(),
   reset: z.boolean().optional(),
+  endpoint: z.string(),
 });
 
 export type S3LibConfig = z.infer<typeof S3LibConfigSchema>;

--- a/apps/api/src/modules/sandbox/sandbox.service.ts
+++ b/apps/api/src/modules/sandbox/sandbox.service.ts
@@ -76,7 +76,7 @@ export class SandboxService {
 
       const storagePath = this.driveService.buildS3DrivePath(user.uid, canvasId);
       const s3Config = this.buildS3Config();
-      const s3LibConfig = this.buildS3LibConfig();
+      const s3LibConfig = this.buildS3LibConfig(s3Config);
       const requestEnv = (request.context as { env?: Record<string, string> } | undefined)?.env;
       const env = {
         ...requestEnv,
@@ -128,10 +128,13 @@ export class SandboxService {
     }
   }
 
-  private buildS3LibConfig(): S3LibConfig | undefined {
+  private buildS3LibConfig(s3Config: S3Config): S3LibConfig | undefined {
     if (!this.s3LibEnabled || !this.s3LibPathPrefix || !this.s3LibHash) return undefined;
 
     const normalizedPrefix = this.s3LibPathPrefix.replace(/\/+$/, '');
+
+    const protocol = s3Config.useSSL ? 'https' : 'http';
+    const endpoint = `${protocol}://${s3Config.endPoint}:${s3Config.port}`;
 
     return {
       accessKey: this.s3Config.accessKey,
@@ -142,6 +145,7 @@ export class SandboxService {
       hash: this.s3LibHash,
       cache: this.s3LibCache,
       reset: this.s3LibReset,
+      endpoint,
     };
   }
 

--- a/apps/api/src/modules/skill/ptc-poller.manager.ts
+++ b/apps/api/src/modules/skill/ptc-poller.manager.ts
@@ -1,0 +1,191 @@
+import { Response } from 'express';
+import { PinoLogger } from 'nestjs-pino';
+import { ToolCallMeta } from '@refly/openapi-schema';
+import { SkillRunnableMeta } from '@refly/skill-template';
+import { safeParseJSON } from '@refly/utils';
+import { writeSSEResponse } from '../../utils/response';
+import { MessageAggregator } from '../../utils/message-aggregator';
+import { ToolCallService } from '../tool-call/tool-call.service';
+
+/**
+ * Context required for PTC polling operations.
+ * Contains all dependencies needed to send SSE events and persist messages.
+ */
+export interface PtcPollerContext {
+  /** HTTP Response object for SSE streaming (undefined if no streaming) */
+  res: Response | undefined;
+  /** Action result ID */
+  resultId: string;
+  /** Action result version */
+  version: number;
+  /** Message aggregator for persistence */
+  messageAggregator: MessageAggregator;
+  /** Getter for current run metadata (dynamic, updated during event loop) */
+  getRunMeta: () => SkillRunnableMeta | null;
+}
+
+interface PollerState {
+  interval: NodeJS.Timeout;
+  sentCallIds: Set<string>;
+}
+
+/**
+ * Manages PTC (Programmatic Tool Call) polling for execute_code tool executions.
+ *
+ * During execute_code execution, this manager polls the database to discover
+ * internal tool calls made from the sandbox, then forwards them as SSE events
+ * to provide real-time progress to the user.
+ *
+ * Lifecycle:
+ * 1. Create instance at the start of skill invocation
+ * 2. Call start() when execute_code tool starts
+ * 3. Call stop() when execute_code tool ends (or errors)
+ * 4. Call cleanup() in finally block to ensure all pollers are stopped
+ */
+export class PtcPollerManager {
+  private pollers: Map<string, PollerState> = new Map();
+  private readonly pollIntervalMs = 1500;
+
+  constructor(
+    private readonly context: PtcPollerContext,
+    private readonly toolCallService: ToolCallService,
+    private readonly logger: PinoLogger,
+  ) {}
+
+  /**
+   * Start polling for PTC tool calls for a specific execute_code invocation.
+   * @param toolCallId - The callId of the execute_code tool
+   */
+  start(toolCallId: string): void {
+    if (this.pollers.has(toolCallId)) {
+      return; // Already polling
+    }
+
+    const sentCallIds = new Set<string>();
+    const interval = setInterval(async () => {
+      try {
+        const ptcCalls = await this.toolCallService.fetchPtcToolCalls(toolCallId);
+        for (const ptcCall of ptcCalls) {
+          // Only send completed/failed calls that haven't been sent yet
+          if (
+            !sentCallIds.has(ptcCall.callId) &&
+            (ptcCall.status === 'completed' || ptcCall.status === 'failed')
+          ) {
+            sentCallIds.add(ptcCall.callId);
+            this.sendEvent(ptcCall);
+          }
+        }
+      } catch (error) {
+        this.logger.error(`PTC polling error for ${toolCallId}: ${error?.message}`);
+      }
+    }, this.pollIntervalMs);
+
+    this.pollers.set(toolCallId, { interval, sentCallIds });
+    this.logger.debug(`Started PTC polling for execute_code ${toolCallId}`);
+  }
+
+  /**
+   * Stop polling for a specific execute_code invocation and send any remaining events.
+   * @param toolCallId - The callId of the execute_code tool
+   */
+  async stop(toolCallId: string): Promise<void> {
+    const poller = this.pollers.get(toolCallId);
+    if (!poller) {
+      return;
+    }
+
+    clearInterval(poller.interval);
+    this.pollers.delete(toolCallId);
+
+    // Final check: send any remaining PTC calls
+    try {
+      const ptcCalls = await this.toolCallService.fetchPtcToolCalls(toolCallId);
+      let newCount = 0;
+      for (const ptcCall of ptcCalls) {
+        if (
+          !poller.sentCallIds.has(ptcCall.callId) &&
+          (ptcCall.status === 'completed' || ptcCall.status === 'failed')
+        ) {
+          poller.sentCallIds.add(ptcCall.callId);
+          this.sendEvent(ptcCall);
+          newCount++;
+        }
+      }
+      if (newCount > 0) {
+        this.logger.debug(`Sent ${newCount} remaining PTC events for execute_code ${toolCallId}`);
+      }
+    } catch (error) {
+      this.logger.error(`Final PTC fetch error for ${toolCallId}: ${error?.message}`);
+    }
+
+    this.logger.debug(`Stopped PTC polling for execute_code ${toolCallId}`);
+  }
+
+  /**
+   * Cleanup all active pollers. Call this in the finally block to ensure
+   * no intervals are left running after skill invocation completes.
+   */
+  cleanup(): void {
+    for (const [toolCallId, poller] of this.pollers) {
+      clearInterval(poller.interval);
+      this.logger.debug(`Cleaned up PTC poller for ${toolCallId} in cleanup()`);
+    }
+    this.pollers.clear();
+  }
+
+  /**
+   * Send a PTC tool call event via SSE.
+   */
+  private sendEvent(
+    ptcCall: Awaited<ReturnType<typeof this.toolCallService.fetchPtcToolCalls>>[number],
+  ): void {
+    const { res, resultId, version, messageAggregator, getRunMeta } = this.context;
+
+    if (!res) {
+      return;
+    }
+
+    const parsedInput = safeParseJSON(ptcCall.input || '{}') ?? {};
+    const parsedOutput = safeParseJSON(ptcCall.output || '{}') ?? {};
+
+    const ptcToolCallMeta: ToolCallMeta = {
+      toolName: ptcCall.toolName,
+      toolsetId: ptcCall.toolsetId,
+      toolsetKey: ptcCall.toolsetId,
+      toolCallId: ptcCall.callId,
+      status: ptcCall.status === 'failed' ? 'failed' : 'completed',
+      startTs: ptcCall.createdAt.getTime(),
+      endTs: ptcCall.updatedAt.getTime(),
+    };
+
+    const ptcMessageId = messageAggregator.addToolMessage({
+      toolCallId: ptcCall.callId,
+      toolCallMeta: ptcToolCallMeta,
+    });
+
+    const runMeta = getRunMeta();
+    const ssePayload = {
+      event: ptcCall.status === 'failed' ? 'tool_call_error' : 'tool_call_end',
+      isPtc: true,
+      resultId,
+      version,
+      step: runMeta?.step,
+      messageId: ptcMessageId,
+      toolCallMeta: ptcToolCallMeta,
+      toolCallResult: {
+        callId: ptcCall.callId,
+        toolsetId: ptcCall.toolsetId,
+        toolName: ptcCall.toolName,
+        stepName: ptcCall.stepName,
+        input: parsedInput,
+        output: parsedOutput,
+        status: ptcCall.status === 'failed' ? 'failed' : 'completed',
+        ...(ptcCall.error ? { error: ptcCall.error } : {}),
+        createdAt: ptcCall.createdAt.getTime(),
+        updatedAt: ptcCall.updatedAt.getTime(),
+      },
+    };
+
+    writeSSEResponse(res, ssePayload as Parameters<typeof writeSSEResponse>[1]);
+  }
+}

--- a/apps/api/src/modules/skill/skill-engine.service.ts
+++ b/apps/api/src/modules/skill/skill-engine.service.ts
@@ -291,8 +291,7 @@ export class SkillEngineService implements OnModuleInit {
       execute: async (user: User, req: SandboxExecuteRequest): Promise<SandboxExecuteResponse> => {
         // Inject PTC environment variables if enabled
         if (req.context?.ptcEnabled) {
-          const resultId = req.context.parentResultId;
-          const ptcEnvVars = await this.ptcEnvService.getPtcEnvVars(user.uid, resultId);
+          const ptcEnvVars = await this.ptcEnvService.getPtcEnvVars(user, req);
 
           // Ensure context and env exist
           req.context = req.context || {};

--- a/apps/api/src/modules/tool-call/tool-call.service.ts
+++ b/apps/api/src/modules/tool-call/tool-call.service.ts
@@ -191,6 +191,21 @@ export class ToolCallService {
   }
 
   /**
+   * Fetch PTC tool calls by ptcCallId (the execute_code's callId)
+   * Used to retrieve all tool calls made from within a sandbox execution
+   */
+  async fetchPtcToolCalls(ptcCallId: string) {
+    return this.prisma.toolCallResult.findMany({
+      where: {
+        ptcCallId,
+        type: 'ptc',
+        deletedAt: null,
+      },
+      orderBy: { pk: 'asc' },
+    });
+  }
+
+  /**
    * Build consolidated tool call history entries grouped by step name for a given result.
    * Only final tool call results are returned to avoid duplicating streaming fragments.
    */

--- a/apps/api/src/modules/tool/ptc/ptc-config.spec.ts
+++ b/apps/api/src/modules/tool/ptc/ptc-config.spec.ts
@@ -18,6 +18,7 @@ describe('PtcConfig', () => {
       get: jest.fn((key: string) => {
         const configs: Record<string, string> = {
           'ptc.mode': 'off',
+          'ptc.debug': '',
           'ptc.userAllowlist': '',
           'ptc.toolsetAllowlist': '',
           'ptc.toolsetBlocklist': '',
@@ -31,6 +32,7 @@ describe('PtcConfig', () => {
     it('should parse default config correctly', () => {
       const config = getPtcConfig(mockConfigService as ConfigService);
       expect(config.mode).toBe(PtcMode.OFF);
+      expect(config.debug).toBe(false);
       expect(config.userAllowlist.size).toBe(0);
       expect(config.toolsetAllowlist).toBeNull();
       expect(config.toolsetBlocklist.size).toBe(0);
@@ -40,6 +42,7 @@ describe('PtcConfig', () => {
       mockConfigService.get = jest.fn((key: string) => {
         const configs: Record<string, string> = {
           'ptc.mode': 'partial',
+          'ptc.debug': '',
           'ptc.userAllowlist': 'u-1, u-2 ',
           'ptc.toolsetAllowlist': 'google, notion',
           'ptc.toolsetBlocklist': 'bad-tool',
@@ -60,12 +63,30 @@ describe('PtcConfig', () => {
       const config = getPtcConfig(mockConfigService as ConfigService);
       expect(config.mode).toBe(PtcMode.OFF);
     });
+
+    it('should parse debugMode as true when set to "true"', () => {
+      mockConfigService.get = jest.fn((key: string) => {
+        const configs: Record<string, string> = {
+          'ptc.mode': 'on',
+          'ptc.debug': 'true',
+          'ptc.userAllowlist': '',
+          'ptc.toolsetAllowlist': '',
+          'ptc.toolsetBlocklist': '',
+          'ptc.workflowAllowlist': '',
+        };
+        return configs[key];
+      });
+
+      const config = getPtcConfig(mockConfigService as ConfigService);
+      expect(config.debug).toBe(true);
+    });
   });
 
   describe('isPtcEnabledForUser', () => {
     it('should return false when mode is OFF', () => {
       const config: PtcConfig = {
         mode: PtcMode.OFF,
+        debug: false,
         userAllowlist: new Set<string>(),
         toolsetAllowlist: null,
         toolsetBlocklist: new Set<string>(),
@@ -76,6 +97,7 @@ describe('PtcConfig', () => {
     it('should return true when mode is ON', () => {
       const config: PtcConfig = {
         mode: PtcMode.ON,
+        debug: false,
         userAllowlist: new Set<string>(),
         toolsetAllowlist: null,
         toolsetBlocklist: new Set<string>(),
@@ -86,6 +108,7 @@ describe('PtcConfig', () => {
     it('should check allowlist when mode is PARTIAL', () => {
       const config: PtcConfig = {
         mode: PtcMode.PARTIAL,
+        debug: false,
         userAllowlist: new Set<string>(['u-123']),
         toolsetAllowlist: null,
         toolsetBlocklist: new Set<string>(),
@@ -98,6 +121,7 @@ describe('PtcConfig', () => {
   describe('isToolsetAllowed', () => {
     const baseConfig: PtcConfig = {
       mode: PtcMode.ON,
+      debug: false,
       userAllowlist: new Set<string>(),
       toolsetAllowlist: null,
       toolsetBlocklist: new Set<string>(),
@@ -135,6 +159,7 @@ describe('PtcConfig', () => {
   describe('isPtcEnabledForToolsets', () => {
     const config: PtcConfig = {
       mode: PtcMode.ON,
+      debug: false,
       userAllowlist: new Set<string>(),
       toolsetAllowlist: new Set<string>(['t1', 't2']),
       toolsetBlocklist: new Set<string>(['blocked']),

--- a/apps/api/src/modules/tool/ptc/ptc-config.ts
+++ b/apps/api/src/modules/tool/ptc/ptc-config.ts
@@ -27,6 +27,7 @@ export enum PtcMode {
  */
 export interface PtcConfig {
   mode: PtcMode;
+  debug: boolean;
   userAllowlist: Set<string>;
   toolsetAllowlist: Set<string> | null;
   toolsetBlocklist: Set<string>;
@@ -40,6 +41,7 @@ export interface PtcConfig {
  */
 export function getPtcConfig(configService: ConfigService): PtcConfig {
   const mode = parsePtcMode(configService.get<string>('ptc.mode'));
+  const debug = configService.get<string>('ptc.debug') === 'true';
   const userAllowlist = parseCommaSeparatedList(configService.get<string>('ptc.userAllowlist'));
   const toolsetAllowlist = parseOptionalCommaSeparatedList(
     configService.get<string>('ptc.toolsetAllowlist'),
@@ -50,6 +52,7 @@ export function getPtcConfig(configService: ConfigService): PtcConfig {
 
   return {
     mode,
+    debug,
     userAllowlist,
     toolsetAllowlist,
     toolsetBlocklist,

--- a/apps/api/src/modules/tool/ptc/ptc-env.service.ts
+++ b/apps/api/src/modules/tool/ptc/ptc-env.service.ts
@@ -1,47 +1,85 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { PinoLogger } from 'nestjs-pino';
+import { SandboxExecuteRequest, User } from '@refly/openapi-schema';
 import { Config } from '../../config/config.decorator';
 import { ApiKeyService } from '../../auth/api-key.service';
-import { getEnv, IENV } from '@refly/utils';
 
 export interface PtcEnvVars {
   REFLY_TOOL_SERVICE_API_URL: string;
   REFLY_TOOL_SERVICE_API_KEY: string;
+  REFLY_RESULT_ID?: string;
+  REFLY_RESULT_VERSION?: string;
+  REFLY_PTC_CALL_ID?: string;
 }
+
+interface CachedApiKey {
+  apiKey: string;
+  createdAt: number;
+}
+
+/** Cache TTL: 12 hours (leaves buffer before the 1-day key expiration) */
+const API_KEY_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
 
 @Injectable()
 export class PtcEnvService {
   @Config.string('endpoint', 'http://localhost:5800')
   private readonly endpoint: string;
 
+  /** In-memory cache: uid -> cached API key */
+  private readonly apiKeyCache = new Map<string, CachedApiKey>();
+
   constructor(
+    private readonly config: ConfigService,
     private readonly logger: PinoLogger,
     private readonly apiKeyService: ApiKeyService,
   ) {
     this.logger.setContext(PtcEnvService.name);
+    void this.config; // Suppress unused warning - used by @Config decorators
   }
 
   /**
    * Get PTC environment variables for sandbox execution
    * In development mode, use environment variables directly
    * In production, create temporary API key for sandbox authentication
+   *
+   * @param user - User
+   * @param req - Sandbox execute request containing context
    */
-  async getPtcEnvVars(uid: string, resultId?: string): Promise<PtcEnvVars> {
-    if (getEnv() === IENV.DEVELOPMENT) {
-      return {
-        REFLY_TOOL_SERVICE_API_URL: process.env.REFLY_TOOL_SERVICE_API_URL,
-        REFLY_TOOL_SERVICE_API_KEY: process.env.REFLY_TOOL_SERVICE_API_KEY,
-      };
-    }
+  async getPtcEnvVars(user: User, req: SandboxExecuteRequest): Promise<PtcEnvVars> {
+    const { parentResultId: resultId, version, toolCallId } = req.context ?? {};
 
-    // Create temporary API key for sandbox authentication (1 day expiration)
-    // Use resultId if available, otherwise use a generic name
-    const sessionName = resultId ? `PTC_SESSION_${resultId}` : 'PTC_SESSION_GENERIC';
-    const createdApiKey = await this.apiKeyService.createApiKey(uid, sessionName, 1);
+    // Context tracking environment variables
+    const contextEnvVars: Partial<PtcEnvVars> = {
+      ...(resultId && { REFLY_RESULT_ID: resultId }),
+      ...(version !== undefined && { REFLY_RESULT_VERSION: String(version) }),
+      ...(toolCallId && { REFLY_PTC_CALL_ID: toolCallId }),
+    };
+
+    const toolServiceApiUrl = this.endpoint.replace('localhost', 'host.docker.internal');
+    const toolServiceApiKey = await this.getOrCreateApiKey(user.uid);
 
     return {
-      REFLY_TOOL_SERVICE_API_URL: this.endpoint,
-      REFLY_TOOL_SERVICE_API_KEY: createdApiKey.apiKey,
+      ...contextEnvVars,
+      REFLY_TOOL_SERVICE_API_URL: toolServiceApiUrl,
+      REFLY_TOOL_SERVICE_API_KEY: toolServiceApiKey,
     };
+  }
+
+  /**
+   * Get a cached API key for the user, or create a new one if expired/missing.
+   */
+  private async getOrCreateApiKey(uid: string): Promise<string> {
+    const cached = this.apiKeyCache.get(uid);
+    if (cached && Date.now() - cached.createdAt < API_KEY_CACHE_TTL_MS) {
+      return cached.apiKey;
+    }
+
+    const sessionName = `PTC_SESSION_${uid}`;
+    const created = await this.apiKeyService.createApiKey(uid, sessionName, 1);
+
+    this.apiKeyCache.set(uid, { apiKey: created.apiKey, createdAt: Date.now() });
+
+    return created.apiKey;
   }
 }

--- a/apps/api/src/modules/tool/ptc/tool-execution.service.ts
+++ b/apps/api/src/modules/tool/ptc/tool-execution.service.ts
@@ -5,20 +5,43 @@
  */
 
 import { Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
 import type { User } from '@refly/openapi-schema';
 import type { ExecuteToolRequest } from '@refly/openapi-schema';
 import { ParamsError } from '@refly/errors';
 import { ComposioService } from '../composio/composio.service';
 import { ToolIdentifyService } from './tool-identify.service';
 import type { ToolIdentification } from './tool-identify.service';
+import { ToolCallService, ToolCallStatus } from '../../tool-call/tool-call.service';
+import { PrismaService } from '../../common/prisma.service';
+
+/**
+ * PTC (Programmatic Tool Call) context for /v1/tool/execute API
+ * Passed from sandbox environment via HTTP headers
+ */
+export interface PtcToolExecuteContext {
+  /** Parent call ID from execute_code tool */
+  ptcCallId?: string;
+  /** Result ID for the action */
+  resultId?: string;
+  /** Result version */
+  version?: number;
+}
+
+export enum CallType {
+  PTC = 'ptc',
+  STANDALONE = 'standalone',
+}
 
 @Injectable()
 export class ToolExecutionService {
   private readonly logger = new Logger(ToolExecutionService.name);
 
   constructor(
+    private readonly prisma: PrismaService,
     private readonly composioService: ComposioService,
     private readonly toolIdentifyService: ToolIdentifyService,
+    private readonly toolCallService: ToolCallService,
   ) {}
 
   /**
@@ -27,9 +50,14 @@ export class ToolExecutionService {
    *
    * @param user - The user executing the tool
    * @param request - The execution request (toolsetKey, toolName, arguments)
+   * @param ptcContext - Optional PTC context for sandbox tool calls
    * @returns Tool execution result
    */
-  async executeTool(user: User, request: ExecuteToolRequest): Promise<Record<string, unknown>> {
+  async executeTool(
+    user: User,
+    request: ExecuteToolRequest,
+    ptcContext?: PtcToolExecuteContext,
+  ): Promise<Record<string, unknown>> {
     const { toolsetKey, toolName, arguments: args } = request;
 
     if (!toolsetKey) {
@@ -40,43 +68,199 @@ export class ToolExecutionService {
       throw new ParamsError('toolName is required');
     }
 
-    // 1. Identify tool type and get connection info
-    const toolInfo = await this.toolIdentifyService.identifyTool(user, toolsetKey);
+    // Determine call type and context
+    const hasPtcContext = !!ptcContext?.ptcCallId;
+    const callType = hasPtcContext ? CallType.PTC : CallType.STANDALONE;
+
+    // Get resultId/version from HTTP headers (ptcContext)
+    const { resultId, version } = ptcContext ?? {};
+
+    // For PTC mode, fetch stepName from parent execute_code call
+    let stepName: string | undefined;
+    if (hasPtcContext && ptcContext?.ptcCallId) {
+      try {
+        const parentCall = await this.prisma.toolCallResult.findUnique({
+          where: { callId: ptcContext.ptcCallId },
+          select: { stepName: true },
+        });
+        stepName = parentCall?.stepName ?? undefined;
+      } catch (error) {
+        this.logger.warn(
+          `Failed to fetch stepName for ptcCallId ${ptcContext.ptcCallId}: ${error}`,
+        );
+      }
+    }
+
+    // Generate a unique call ID for this execution
+    const callId = this.generateCallId(callType);
+    const startTime = Date.now();
 
     this.logger.log(
-      `Executing tool: ${toolName} from toolset: ${toolsetKey}, type: ${toolInfo.type}`,
+      `Executing tool: ${toolName} from toolset: ${toolsetKey}, type: ${callType}, callId: ${callId}`,
     );
 
-    // 2. Route to appropriate executor based on type
-    switch (toolInfo.type) {
-      case 'composio_oauth':
-      case 'composio_apikey':
-        return await this.executeComposioTool(toolInfo, toolName, args ?? {});
+    // 1. Persist initial "executing" record BEFORE any execution logic
+    await this.persistToolCallStart({
+      callId,
+      uid: user.uid,
+      toolsetId: toolsetKey,
+      toolName,
+      input: { input: args ?? {} },
+      type: callType,
+      ptcCallId: ptcContext?.ptcCallId,
+      resultId: resultId ?? 'non-result-id',
+      version: version ?? 0,
+      createdAt: startTime,
+      stepName, // Pass stepName for PTC calls
+    });
 
-      case 'config_based':
-        throw new ParamsError(
-          `Toolset ${toolsetKey} not supported: config_based tool execution is not implemented.`,
-        );
+    // 2. Execute tool and capture result
+    let result: Record<string, unknown>;
+    let errorMessage: string | undefined;
 
-      case 'legacy_sdk':
-        throw new ParamsError(
-          `Toolset ${toolsetKey} not supported: legacy_sdk tool execution is not implemented.`,
-        );
+    try {
+      // Identify tool type and get connection info
+      const toolInfo = await this.toolIdentifyService.identifyTool(user, toolsetKey);
 
-      case 'mcp':
-        // TODO return a user-friendly error message
-        throw new ParamsError(
-          `Toolset ${toolsetKey} not supported: MCP tool execution is not supported.`,
-        );
+      // Route to appropriate executor based on type
+      switch (toolInfo.type) {
+        case 'composio_oauth':
+        case 'composio_apikey':
+          result = await this.executeComposioTool(toolInfo, toolName, args ?? {});
+          break;
 
-      case 'builtin':
-        throw new ParamsError(
-          `Toolset ${toolsetKey} not supported: builtin tool execution is not supported.`,
-        );
+        case 'config_based':
+          throw new ParamsError(
+            `Toolset ${toolsetKey} not supported: config_based tool execution is not implemented.`,
+          );
 
-      default:
-        throw new ParamsError(`Unsupported tool type: ${toolInfo.type}`);
+        case 'legacy_sdk':
+          throw new ParamsError(
+            `Toolset ${toolsetKey} not supported: legacy_sdk tool execution is not implemented.`,
+          );
+
+        case 'mcp':
+          throw new ParamsError(
+            `Toolset ${toolsetKey} not supported: MCP tool execution is not supported.`,
+          );
+
+        case 'builtin':
+          throw new ParamsError(
+            `Toolset ${toolsetKey} not supported: builtin tool execution is not supported.`,
+          );
+
+        default:
+          throw new ParamsError(`Unsupported tool type: ${toolInfo.type}`);
+      }
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : String(error);
+      result = { status: 'error', error: errorMessage };
     }
+
+    // 4. Update record with final status
+    const endTime = Date.now();
+    if (result?.status === 'error') {
+      const resultError = result?.error;
+      const derivedErrorMessage =
+        typeof resultError === 'string'
+          ? resultError
+          : resultError != null
+            ? String(resultError)
+            : String(result);
+      errorMessage = errorMessage ?? derivedErrorMessage;
+    }
+    const status = errorMessage ? ToolCallStatus.FAILED : ToolCallStatus.COMPLETED;
+
+    await this.persistToolCallEnd({
+      callId,
+      output: result,
+      status,
+      error: errorMessage,
+      updatedAt: endTime,
+    });
+
+    return result;
+  }
+
+  /**
+   * Generate a unique call ID for tool execution
+   * Format: `{callType}:{uuid}` (toolset/tool info lives in the DB record)
+   */
+  private generateCallId(callType: CallType): string {
+    return `${callType}:${randomUUID()}`;
+  }
+
+  /**
+   * Persist initial tool call record with "executing" status
+   */
+  private async persistToolCallStart(params: {
+    callId: string;
+    uid: string;
+    toolsetId: string;
+    toolName: string;
+    input: Record<string, unknown>;
+    type: 'ptc' | 'standalone';
+    ptcCallId?: string;
+    resultId: string;
+    version: number;
+    createdAt: number;
+    stepName?: string;
+  }): Promise<void> {
+    const {
+      callId,
+      uid,
+      toolsetId,
+      toolName,
+      input,
+      type,
+      ptcCallId,
+      resultId,
+      version,
+      createdAt,
+      stepName,
+    } = params;
+
+    await this.prisma.toolCallResult.create({
+      data: {
+        callId,
+        uid,
+        toolsetId,
+        toolName,
+        input: JSON.stringify(input),
+        output: '',
+        status: ToolCallStatus.EXECUTING,
+        type,
+        ptcCallId: ptcCallId ?? null,
+        resultId,
+        version,
+        createdAt: new Date(createdAt),
+        updatedAt: new Date(createdAt),
+        stepName: stepName ?? null,
+      },
+    });
+  }
+
+  /**
+   * Update tool call record with final status
+   */
+  private async persistToolCallEnd(params: {
+    callId: string;
+    output: Record<string, unknown>;
+    status: ToolCallStatus;
+    error?: string;
+    updatedAt: number;
+  }): Promise<void> {
+    const { callId, output, status, error, updatedAt } = params;
+
+    await this.prisma.toolCallResult.update({
+      where: { callId },
+      data: {
+        output: JSON.stringify(output),
+        status,
+        error: error ?? null,
+        updatedAt: new Date(updatedAt),
+      },
+    });
   }
 
   /**

--- a/apps/api/src/modules/tool/tool.controller.ts
+++ b/apps/api/src/modules/tool/tool.controller.ts
@@ -1,4 +1,5 @@
-import { Body, Controller, Get, ParseBoolPipe, Post, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, ParseBoolPipe, Post, Query, Req, UseGuards } from '@nestjs/common';
+import { Request } from 'express';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
 import { LoginedUser } from '../../utils/decorators/user.decorator';
 import { User as UserModel } from '@prisma/client';
@@ -140,8 +141,19 @@ export class ToolController {
   async executeTool(
     @LoginedUser() user: UserModel,
     @Body() request: ExecuteToolRequest,
+    @Req() req: Request,
   ): Promise<ExecuteToolResponse> {
-    const result = await this.toolExecutionService.executeTool(user, request);
+    // Extract PTC context from headers
+    const ptcCallId = req.headers['x-ptc-call-id'] as string | undefined;
+    const resultId = req.headers['x-refly-result-id'] as string | undefined;
+    const versionStr = req.headers['x-refly-result-version'] as string | undefined;
+    const version = versionStr ? Number.parseInt(versionStr, 10) : undefined;
+
+    const result = await this.toolExecutionService.executeTool(user, request, {
+      ptcCallId,
+      resultId,
+      version,
+    });
     return buildSuccessResponse(result);
   }
 }

--- a/apps/api/src/modules/tool/tool.module.ts
+++ b/apps/api/src/modules/tool/tool.module.ts
@@ -13,6 +13,7 @@ import { KnowledgeModule } from '../knowledge/knowledge.module';
 import { McpServerModule } from '../mcp-server/mcp-server.module';
 import { MiscModule } from '../misc/misc.module';
 import { ProviderModule } from '../provider/provider.module';
+import { ToolCallModule } from '../tool-call/tool-call.module';
 import { BillingModule } from './billing/billing.module';
 import { ComposioModule } from './composio/composio.module';
 import { AdapterFactory } from './dynamic-tooling/adapters/factory';
@@ -50,6 +51,7 @@ import { ToolService } from './tool.service';
     CreditModule,
     BillingModule,
     ScaleboxModule,
+    ToolCallModule,
     ...(isDesktop() ? [] : [BullModule.registerQueue({ name: QUEUE_SYNC_TOOL_CREDIT_USAGE })]),
   ],
   controllers: [ToolController],

--- a/packages/agent-tools/src/builtin/sandbox.ts
+++ b/packages/agent-tools/src/builtin/sandbox.ts
@@ -95,7 +95,7 @@ plt.savefig('chart.png')
 
   async _call(
     input: z.infer<typeof this.schema>,
-    _: any,
+    runManager: { runId?: string } | undefined,
     config: RunnableConfig,
   ): Promise<ToolCallResult> {
     try {
@@ -119,6 +119,7 @@ plt.savefig('chart.png')
           canvasId: config.configurable?.canvasId,
           version: config.configurable?.version,
           ptcEnabled: config.configurable?.ptcEnabled,
+          toolCallId: runManager?.runId,
         },
       };
 

--- a/packages/ai-workspace-common/src/components/markdown/plugins/tool-call/render.tsx
+++ b/packages/ai-workspace-common/src/components/markdown/plugins/tool-call/render.tsx
@@ -45,6 +45,7 @@ interface ToolCallProps {
   'data-tool-video-name'?: string;
   'data-tool-video-format'?: string;
   'data-tool-error'?: string;
+  'data-tool-is-ptc'?: string;
   id?: string;
   mode?: MarkdownMode;
 }
@@ -167,13 +168,24 @@ const ToolCall: React.FC<ToolCallProps> = (props) => {
     ToolCallStatus.EXECUTING;
 
   // Format the content for parameters
+  // Note: input field has inconsistent formats across different call types:
+  // - old style: nested JSON string {"input": "{\"key\":\"value\"}"}
+  // - new style: flat object {"input": {"key": "value"}}
   const parametersContent = useMemo(() => {
     // First try props data
     if (props['data-tool-arguments']) {
       try {
         const argsStr = props['data-tool-arguments'];
         const args = JSON.parse(argsStr);
-        return JSON.parse(args?.input ?? '{}');
+        const input = args?.input;
+
+        // Handle both formats: string (old style) or object (new style)
+        if (typeof input === 'string') {
+          return JSON.parse(input);
+        } else if (typeof input === 'object' && input !== null) {
+          return input;
+        }
+        return {};
       } catch {
         // Fall through to API data
       }
@@ -181,7 +193,16 @@ const ToolCall: React.FC<ToolCallProps> = (props) => {
 
     // Fall back to API data
     if (fetchedData?.data?.result?.input) {
-      return fetchedData.data.result.input;
+      const input = fetchedData.data.result.input;
+      // Also handle both formats for API data
+      if (typeof input === 'string') {
+        try {
+          return JSON.parse(input);
+        } catch {
+          return {};
+        }
+      }
+      return input;
     }
 
     return {};
@@ -398,6 +419,9 @@ const ToolCall: React.FC<ToolCallProps> = (props) => {
     return filePreviewDriveFile.length > 0;
   }, [filePreviewDriveFile]);
 
+  // Check if this is a PTC tool call
+  const isPtc = props['data-tool-is-ptc'] === 'true';
+
   const { data } = useListToolsetInventory({}, null, {
     enabled: true,
   });
@@ -423,7 +447,12 @@ const ToolCall: React.FC<ToolCallProps> = (props) => {
 
   return (
     <>
-      <div className="rounded-lg overflow-hidden bg-refly-bg-control-z0 text-refly-text-0">
+      <div
+        className={cn(
+          'rounded-lg overflow-hidden bg-refly-bg-control-z0 text-refly-text-0',
+          isPtc && 'ml-4',
+        )}
+      >
         {/* Header bar */}
         <div
           className="flex items-center justify-between p-3 gap-3 cursor-pointer select-none min-h-[48px] transition-all duration-200"

--- a/packages/ai-workspace-common/src/components/result-message/index.tsx
+++ b/packages/ai-workspace-common/src/components/result-message/index.tsx
@@ -83,6 +83,7 @@ const ToolMessageCard = memo(({ message }: ToolMessageCardProps) => {
       'data-tool-arguments': JSON.stringify(toolCallResult?.input),
       'data-tool-result': JSON.stringify(toolCallResult?.output),
       'data-tool-error': toolCallMeta?.error,
+      'data-tool-is-ptc': message.isPtc ? 'true' : undefined,
     }),
     [toolCallMeta, message, toolCallResult],
   );

--- a/packages/ai-workspace-common/src/hooks/canvas/use-invoke-action.ts
+++ b/packages/ai-workspace-common/src/hooks/canvas/use-invoke-action.ts
@@ -610,6 +610,7 @@ export const useInvokeAction = (params?: { source?: string }) => {
       step,
       content = '',
       artifact,
+      isPtc,
     } = skillEvent;
     const status = getActionStatus(resultId);
 
@@ -625,7 +626,41 @@ export const useInvokeAction = (params?: { source?: string }) => {
       status,
     };
 
-    // Update messages with completed status
+    // Handle PTC (Programmatic Tool Calling) internal tool calls
+    // PTC events have isPtc: true and toolCallResult, but no messageId and toolCallMeta
+    if (isPtc && toolCallResult) {
+      const currentMessages = getLatestMessages(resultId);
+      // Use messageId from SSE if available, otherwise generate one
+      const ptcMessageId = messageId ?? `ptc-${toolCallResult.callId}`;
+      // Use toolCallMeta from SSE if available, otherwise construct one from toolCallResult
+      const effectiveToolCallMeta = toolCallMeta ?? {
+        toolName: toolCallResult.toolName,
+        toolsetId: toolCallResult.toolsetId,
+        toolsetKey: toolCallResult.toolsetId, // Use toolsetId as fallback for toolsetKey
+        toolCallId: toolCallResult.callId,
+        status: toolCallResult.status === 'failed' ? ('failed' as const) : ('completed' as const),
+        startTs: toolCallResult.createdAt,
+        endTs: toolCallResult.updatedAt,
+      };
+      const ptcMessage: ActionMessage = {
+        messageId: ptcMessageId,
+        type: 'tool',
+        isPtc: true,
+        toolCallId: toolCallResult.callId,
+        toolCallMeta: effectiveToolCallMeta,
+        toolCallResult,
+        createdAt: new Date(toolCallResult.createdAt ?? Date.now()).toISOString(),
+        updatedAt: new Date(toolCallResult.updatedAt ?? Date.now()).toISOString(),
+      };
+
+      const mergedMessages = getUpdatedMessages(currentMessages, ptcMessage);
+      setLatestMessages(resultId, mergedMessages);
+      payload.messages = mergedMessages;
+      onUpdateResult(resultId, payload, skillEvent);
+      return;
+    }
+
+    // Update messages with completed status (standard tool call)
     if (messageId && toolCallMeta) {
       const currentMessages = getLatestMessages(resultId);
       const updatedMessage = findOrCreateMessage(currentMessages, messageId, 'tool');
@@ -673,7 +708,15 @@ export const useInvokeAction = (params?: { source?: string }) => {
 
   // Handle tool_call_error event - update tool message status to failed
   const onToolCallError = (skillEvent: SkillEvent) => {
-    const { resultId, messageId, toolCallMeta, toolCallResult, step, content = '' } = skillEvent;
+    const {
+      resultId,
+      messageId,
+      toolCallMeta,
+      toolCallResult,
+      step,
+      content = '',
+      isPtc,
+    } = skillEvent;
     const status = getActionStatus(resultId);
 
     if (!status) return;
@@ -688,7 +731,42 @@ export const useInvokeAction = (params?: { source?: string }) => {
       status,
     };
 
-    // Update messages with failed status
+    // Handle PTC (Programmatic Tool Calling) internal tool call errors
+    // PTC events have isPtc: true and toolCallResult, but no messageId and toolCallMeta
+    if (isPtc && toolCallResult) {
+      const currentMessages = getLatestMessages(resultId);
+      // Use messageId from SSE if available, otherwise generate one
+      const ptcMessageId = messageId ?? `ptc-${toolCallResult.callId}`;
+      // Use toolCallMeta from SSE if available, otherwise construct one from toolCallResult
+      const effectiveToolCallMeta = toolCallMeta ?? {
+        toolName: toolCallResult.toolName,
+        toolsetId: toolCallResult.toolsetId,
+        toolsetKey: toolCallResult.toolsetId,
+        toolCallId: toolCallResult.callId,
+        status: 'failed' as const,
+        startTs: toolCallResult.createdAt,
+        endTs: toolCallResult.updatedAt,
+        error: toolCallResult.error,
+      };
+      const ptcMessage: ActionMessage = {
+        messageId: ptcMessageId,
+        type: 'tool',
+        isPtc: true,
+        toolCallId: toolCallResult.callId,
+        toolCallMeta: effectiveToolCallMeta,
+        toolCallResult,
+        createdAt: new Date(toolCallResult.createdAt ?? Date.now()).toISOString(),
+        updatedAt: new Date(toolCallResult.updatedAt ?? Date.now()).toISOString(),
+      };
+
+      const mergedMessages = getUpdatedMessages(currentMessages, ptcMessage);
+      setLatestMessages(resultId, mergedMessages);
+      payload.messages = mergedMessages;
+      onUpdateResult(resultId, payload, skillEvent);
+      return;
+    }
+
+    // Update messages with failed status (standard tool call)
     if (messageId && toolCallMeta) {
       const currentMessages = getLatestMessages(resultId);
       const updatedMessage = findOrCreateMessage(currentMessages, messageId, 'tool');

--- a/packages/openapi-schema/schema.yml
+++ b/packages/openapi-schema/schema.yml
@@ -6400,6 +6400,9 @@ components:
         toolCallResult:
           $ref: "#/components/schemas/ToolCallResult"
           description: Tool call result
+        isPtc:
+          type: boolean
+          description: Whether this is a PTC (Programmatic Tool Calling) internal tool call
         createdAt:
           type: string
           format: date-time
@@ -8124,6 +8127,9 @@ components:
         toolCallResult:
           description: Tool call result data.
           $ref: "#/components/schemas/ToolCallResult"
+        isPtc:
+          type: boolean
+          description: Whether this is a PTC (Programmatic Tool Calling) internal tool call. Only present when `event` is `tool_call_end` or `tool_call_error` for PTC internal calls.
     ToolCallStatus:
       type: string
       description: Tool call status
@@ -9173,6 +9179,9 @@ components:
         ptcEnabled:
           type: boolean
           description: Whether PTC (Programmatic Tool Calling) is enabled
+        toolCallId:
+          type: string
+          description: Tool call ID (execute_code's toolCallId) for PTC context tracking
         env:
           type: object
           additionalProperties:

--- a/packages/openapi-schema/src/schemas.gen.ts
+++ b/packages/openapi-schema/src/schemas.gen.ts
@@ -2351,6 +2351,10 @@ export const ActionMessageSchema = {
       $ref: '#/components/schemas/ToolCallResult',
       description: 'Tool call result',
     },
+    isPtc: {
+      type: 'boolean',
+      description: 'Whether this is a PTC (Programmatic Tool Calling) internal tool call',
+    },
     createdAt: {
       type: 'string',
       format: 'date-time',
@@ -4755,6 +4759,11 @@ export const SkillEventSchema = {
       description: 'Tool call result data.',
       $ref: '#/components/schemas/ToolCallResult',
     },
+    isPtc: {
+      type: 'boolean',
+      description:
+        'Whether this is a PTC (Programmatic Tool Calling) internal tool call. Only present when `event` is `tool_call_end` or `tool_call_error` for PTC internal calls.',
+    },
   },
 } as const;
 
@@ -6203,6 +6212,10 @@ export const SandboxExecuteContextSchema = {
     ptcEnabled: {
       type: 'boolean',
       description: 'Whether PTC (Programmatic Tool Calling) is enabled',
+    },
+    toolCallId: {
+      type: 'string',
+      description: "Tool call ID (execute_code's toolCallId) for PTC context tracking",
     },
     env: {
       type: 'object',

--- a/packages/openapi-schema/src/types.gen.ts
+++ b/packages/openapi-schema/src/types.gen.ts
@@ -2135,6 +2135,10 @@ export type ActionMessage = {
    */
   toolCallResult?: ToolCallResult;
   /**
+   * Whether this is a PTC (Programmatic Tool Calling) internal tool call
+   */
+  isPtc?: boolean;
+  /**
    * Action message creation time
    */
   createdAt?: string;
@@ -3957,6 +3961,10 @@ export type SkillEvent = {
    * Tool call result data.
    */
   toolCallResult?: ToolCallResult;
+  /**
+   * Whether this is a PTC (Programmatic Tool Calling) internal tool call. Only present when `event` is `tool_call_end` or `tool_call_error` for PTC internal calls.
+   */
+  isPtc?: boolean;
 };
 
 /**
@@ -5130,6 +5138,10 @@ export type SandboxExecuteContext = {
    * Whether PTC (Programmatic Tool Calling) is enabled
    */
   ptcEnabled?: boolean;
+  /**
+   * Tool call ID (execute_code's toolCallId) for PTC context tracking
+   */
+  toolCallId?: string;
   /**
    * Environment variables for execution
    */


### PR DESCRIPTION
## Summary

This PR improves the display of PTC (Programmatic Tool Calling) tool call results by polling internal tool calls made from sandbox execution and forwarding them as real-time SSE events. Users can now see the progress and results of internal tool calls directly in the UI.

## Changes

- Add PTC poller manager to poll database and forward internal tool calls as SSE events
- Add database schema changes for ToolCallResult with type and ptcCallId fields to track PTC calls
- Add PTC environment service with API key caching for sandbox authentication
- Add PTC tool execution service with context tracking via HTTP headers
- Add frontend support for PTC tool call rendering with visual indentation
- Add debug mode for PTC with agent node title filtering
- Update sandbox service to include S3 endpoint configuration
- Update skill invoker to manage PTC polling lifecycle during execute_code execution
- Update action DTO to identify PTC messages from toolCallId prefix
- Update OpenAPI schema with isPtc flag and toolCallId context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Programmatic Tool Call (PTC) support for execute-code tools with server-sent event streaming and result polling.
  * Per-call tracking via toolCallId and unique call identifiers; PTC events surfaced in messages.

* **Enhancements**
  * Optional debug mode to control PTC enablement.
  * API and workspace schemas extended to include PTC metadata (isPtc, toolCallId) and improved result streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->