### PR TITLE
[REF-1454] feat: Add PTC tool execution support for config-based and legacy SDK tools

### DIFF
--- a/apps/api/src/modules/tool/dynamic-tooling/core/handler.ts
+++ b/apps/api/src/modules/tool/dynamic-tooling/core/handler.ts
@@ -19,6 +19,7 @@ import { createBasePostHandler } from './handler-post';
 import { createBasePreHandler } from './handler-pre';
 import { ResourceHandler } from '../../utils';
 import type { BillingService } from '../../billing/billing.service';
+import { MissingCanvasContextError } from '../../errors/resource-errors';
 
 /**
  * Base handler interface
@@ -150,7 +151,11 @@ abstract class BaseHandler implements IHandler {
             `Post-handler failed: ${(error as Error).message}`,
             (error as Error).stack,
           );
-          // Don't fail the request if post-handler fails, just log it
+          // Re-throw critical errors (e.g., missing canvasId for resource upload)
+          if (error instanceof MissingCanvasContextError) {
+            throw error;
+          }
+          // Don't fail the request if post-handler fails (for non-critical errors), just log it
           // The API call was successful, so we should return the response
         }
       }

--- a/apps/api/src/modules/tool/errors/resource-errors.ts
+++ b/apps/api/src/modules/tool/errors/resource-errors.ts
@@ -1,0 +1,16 @@
+/**
+ * Resource-related errors for tool execution
+ */
+
+/**
+ * Error thrown when canvasId is required but missing for resource operations
+ */
+export class MissingCanvasContextError extends Error {
+  constructor(message?: string) {
+    super(
+      message ||
+        'canvasId is required to save files. Please ensure the tool is executed within a canvas context.',
+    );
+    this.name = 'MissingCanvasContextError';
+  }
+}

--- a/apps/api/src/modules/tool/ptc/tool-execution.service.ts
+++ b/apps/api/src/modules/tool/ptc/tool-execution.service.ts
@@ -6,14 +6,31 @@
 
 import { Injectable, Logger } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
-import type { User } from '@refly/openapi-schema';
-import type { ExecuteToolRequest } from '@refly/openapi-schema';
+import type {
+  User,
+  ExecuteToolRequest,
+  HandlerRequest,
+  HandlerResponse,
+  ParsedMethodConfig,
+  ToolsetConfig,
+} from '@refly/openapi-schema';
+import type { SkillRunnableConfig } from '@refly/skill-template';
 import { ParamsError } from '@refly/errors';
+import { toolsetInventory } from '@refly/agent-tools';
+import type { AgentBaseTool, ToolCallResult } from '@refly/agent-tools';
+import { safeParseJSON } from '@refly/utils';
 import { ComposioService } from '../composio/composio.service';
 import { ToolIdentifyService } from './tool-identify.service';
 import type { ToolIdentification } from './tool-identify.service';
 import { ToolCallService, ToolCallStatus } from '../../tool-call/tool-call.service';
 import { PrismaService } from '../../common/prisma.service';
+import { EncryptionService } from '../../common/encryption.service';
+import { ToolInventoryService } from '../inventory/inventory.service';
+import { AdapterFactory } from '../dynamic-tooling/adapters/factory';
+import { HttpHandler } from '../dynamic-tooling/core/handler';
+import { BillingService } from '../billing/billing.service';
+import { ResourceHandler, parseJsonSchema, resolveCredentials, fillDefaultValues } from '../utils';
+import { runInContext } from '../tool-context';
 
 /**
  * PTC (Programmatic Tool Call) context for /v1/tool/execute API
@@ -26,6 +43,8 @@ export interface PtcToolExecuteContext {
   resultId?: string;
   /** Result version */
   version?: number;
+  /** Canvas ID for resource upload */
+  canvasId?: string;
 }
 
 export enum CallType {
@@ -42,6 +61,11 @@ export class ToolExecutionService {
     private readonly composioService: ComposioService,
     private readonly toolIdentifyService: ToolIdentifyService,
     private readonly toolCallService: ToolCallService,
+    private readonly inventoryService: ToolInventoryService,
+    private readonly adapterFactory: AdapterFactory,
+    private readonly resourceHandler: ResourceHandler,
+    private readonly billingService: BillingService,
+    private readonly encryptionService: EncryptionService,
   ) {}
 
   /**
@@ -73,7 +97,8 @@ export class ToolExecutionService {
     const callType = hasPtcContext ? CallType.PTC : CallType.STANDALONE;
 
     // Get resultId/version from HTTP headers (ptcContext)
-    const { resultId, version } = ptcContext ?? {};
+    const resultId = ptcContext?.resultId;
+    const version = ptcContext?.version;
 
     // For PTC mode, fetch stepName from parent execute_code call
     let stepName: string | undefined;
@@ -130,14 +155,24 @@ export class ToolExecutionService {
           break;
 
         case 'config_based':
-          throw new ParamsError(
-            `Toolset ${toolsetKey} not supported: config_based tool execution is not implemented.`,
+          result = await this.executeConfigBasedTool(
+            user,
+            toolsetKey,
+            toolName,
+            args ?? {},
+            ptcContext,
           );
+          break;
 
         case 'legacy_sdk':
-          throw new ParamsError(
-            `Toolset ${toolsetKey} not supported: legacy_sdk tool execution is not implemented.`,
+          result = await this.executeLegacySdkTool(
+            user,
+            toolsetKey,
+            toolName,
+            args ?? {},
+            ptcContext,
           );
+          break;
 
         case 'mcp':
           throw new ParamsError(
@@ -300,6 +335,310 @@ export class ToolExecutionService {
       status: 'error',
       error: result.error ?? 'Tool execution failed',
       data: result.data,
+    };
+  }
+
+  /**
+   * Execute a config-based tool (database-driven dynamic tools)
+   *
+   * @param user - The user executing the tool
+   * @param toolsetKey - The toolset key (e.g., 'firecrawl', 'fal_image')
+   * @param toolName - Tool method name
+   * @param args - Tool arguments
+   * @returns Execution result
+   */
+  private async executeConfigBasedTool(
+    user: User,
+    toolsetKey: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    ptcContext?: PtcToolExecuteContext,
+  ): Promise<Record<string, unknown>> {
+    // Step 1: Load tool configuration from inventory
+    const config = await this.inventoryService.getInventoryWithMethods(toolsetKey);
+    if (!config) {
+      throw new ParamsError(`Toolset configuration not found: ${toolsetKey}`);
+    }
+
+    // Step 2: Find the target method
+    const methodConfig = config.methods.find((m) => m.name === toolName);
+    if (!methodConfig) {
+      throw new ParamsError(
+        `Method '${toolName}' not found in toolset '${toolsetKey}'. Available methods: ${config.methods.map((m) => m.name).join(', ')}`,
+      );
+    }
+
+    // Step 3: Parse method config and resolve credentials
+    const parsedMethod = this.parseMethodConfig(methodConfig);
+    const credentials = resolveCredentials(config.credentials || {});
+
+    // Step 4: Create HTTP handler
+    const handler = await this.createHttpHandler(config, parsedMethod, credentials);
+
+    // Step 5: Prepare request with defaults and resource preprocessing
+    const request = await this.prepareToolRequest(config, parsedMethod, args, user);
+
+    // Step 6: Execute handler within request context
+    const runnableConfig: SkillRunnableConfig = {
+      configurable: {
+        user,
+        context: {},
+        resultId: ptcContext?.resultId,
+        version: ptcContext?.version,
+        canvasId: ptcContext?.canvasId,
+      },
+    };
+
+    const toolNameValue = parsedMethod?.name ?? '';
+    const toolsetKeyValue = config?.inventoryKey ?? '';
+    const response = await runInContext(
+      {
+        langchainConfig: runnableConfig,
+        requestId: `ptc-${toolsetKeyValue}-${toolNameValue}-${Date.now()}`,
+        metadata: { toolName: toolNameValue, toolsetKey: toolsetKeyValue },
+      },
+      async () => handler.handle(request),
+    );
+
+    // Step 7: Convert HandlerResponse to execution result format
+    return this.convertHandlerResponse(response);
+  }
+
+  /**
+   * Parse method config to extract schemas
+   */
+  private parseMethodConfig(method: ToolsetConfig['methods'][0]): ParsedMethodConfig {
+    const schema = parseJsonSchema(method.schema);
+    const responseSchema = parseJsonSchema(method.responseSchema);
+
+    return {
+      ...method,
+      schema,
+      responseSchema,
+    };
+  }
+
+  /**
+   * Create HTTP handler for config-based tool execution
+   */
+  private async createHttpHandler(
+    _config: ToolsetConfig,
+    parsedMethod: ParsedMethodConfig,
+    credentials: Record<string, unknown>,
+  ): Promise<HttpHandler> {
+    const adapter = await this.adapterFactory.createAdapter(parsedMethod, credentials);
+
+    return new HttpHandler(adapter, {
+      endpoint: parsedMethod.endpoint,
+      method: parsedMethod.method,
+      credentials,
+      responseSchema: parsedMethod.responseSchema,
+      billing: parsedMethod.billing,
+      billingService: this.billingService,
+      timeout: parsedMethod.timeout,
+      useFormData: parsedMethod.useFormData,
+      formatResponse: false, // Return JSON, not formatted text
+      enableResourceUpload: true, // Enable ResourceHandler for output processing
+      resourceHandler: this.resourceHandler,
+    });
+  }
+
+  /**
+   * Prepare tool request with default values and resource preprocessing
+   */
+  private async prepareToolRequest(
+    config: ToolsetConfig,
+    parsedMethod: ParsedMethodConfig,
+    args: Record<string, unknown>,
+    user: User,
+  ): Promise<HandlerRequest> {
+    // Fill default values from schema
+    let paramsWithDefaults = args;
+    if (parsedMethod.schema) {
+      paramsWithDefaults = fillDefaultValues(args, parsedMethod.schema);
+    }
+
+    // Build initial request
+    const initialRequest: HandlerRequest = {
+      provider: config.domain,
+      method: parsedMethod.name,
+      params: paramsWithDefaults,
+      user,
+      metadata: {
+        toolName: parsedMethod.name,
+        toolsetKey: config.inventoryKey,
+      },
+    };
+
+    // Preprocess input resources if needed
+    if (parsedMethod.schema?.properties) {
+      return await this.resourceHandler.resolveInputResources(initialRequest, parsedMethod.schema);
+    }
+
+    return initialRequest;
+  }
+
+  /**
+   * Convert HandlerResponse to unified execution result format
+   */
+  private convertHandlerResponse(response: HandlerResponse): Record<string, unknown> {
+    if (response.success) {
+      return {
+        status: 'success',
+        data: response.data,
+        ...(response.files ? { files: response.files } : {}),
+        ...(response.metadata ? { metadata: response.metadata } : {}),
+      };
+    }
+
+    return {
+      status: 'error',
+      error: response.error ?? 'Tool execution failed',
+      errorCode: response.errorCode,
+    };
+  }
+
+  /**
+   * Safely invoke a legacy SDK tool using the LangChain invoke interface.
+   */
+  private async invokeToolSafely(
+    toolInstance: AgentBaseTool<unknown>,
+    args: Record<string, unknown>,
+    runnableConfig: SkillRunnableConfig,
+  ): Promise<ToolCallResult> {
+    try {
+      const result = await toolInstance.invoke(args, runnableConfig);
+
+      if (typeof result === 'object' && result !== null) {
+        return result as ToolCallResult;
+      }
+
+      return {
+        status: 'success',
+        data: result,
+        summary: String(result),
+      };
+    } catch (error) {
+      this.logger.error(
+        `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return {
+        status: 'error',
+        error: error instanceof Error ? error.message : String(error),
+        summary: 'Tool execution failed',
+      };
+    }
+  }
+
+  /**
+   * Execute a Legacy SDK tool (e.g., Perplexity, Notion, Jina).
+   */
+  private async executeLegacySdkTool(
+    user: User,
+    toolsetKey: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    ptcContext?: PtcToolExecuteContext,
+  ): Promise<Record<string, unknown>> {
+    const userId = user?.uid;
+    if (!userId) {
+      throw new ParamsError('User is required for tool execution');
+    }
+
+    const inventoryItem = toolsetInventory?.[toolsetKey];
+    if (!inventoryItem?.class) {
+      throw new ParamsError(`Legacy SDK toolset not found or not implemented: ${toolsetKey}`);
+    }
+
+    const toolsetPO = await this.prisma.toolset.findFirst({
+      where: {
+        key: toolsetKey,
+        enabled: true,
+        deletedAt: null,
+        uninstalled: false,
+        OR: [{ uid: userId }, { isGlobal: true }],
+      },
+      orderBy: { isGlobal: 'asc' },
+    });
+
+    if (!toolsetPO) {
+      throw new ParamsError(`Toolset '${toolsetKey}' not found or not enabled for user`);
+    }
+
+    const config = toolsetPO?.config ? safeParseJSON(toolsetPO?.config) : {};
+    const authData = toolsetPO?.authData
+      ? safeParseJSON(this.encryptionService.decrypt(toolsetPO?.authData))
+      : {};
+
+    const toolParams = {
+      ...config,
+      ...authData,
+      user,
+      isGlobalToolset: toolsetPO?.isGlobal ?? false,
+    };
+
+    const toolsetInstance = new inventoryItem.class(toolParams);
+
+    let toolInstance: AgentBaseTool<unknown>;
+    try {
+      toolInstance = toolsetInstance.getToolInstance(toolName);
+    } catch (_error) {
+      const tools = inventoryItem?.definition?.tools;
+      const availableTools = Array.isArray(tools)
+        ? tools
+            .map((tool) => tool?.name ?? '')
+            .filter(Boolean)
+            .join(', ')
+        : 'none';
+      throw new ParamsError(
+        `Tool '${toolName}' not found in toolset '${toolsetKey}'. Available tools: ${availableTools}`,
+      );
+    }
+
+    const runnableConfig: SkillRunnableConfig = {
+      configurable: {
+        user,
+        context: {},
+        resultId: ptcContext?.resultId,
+        version: ptcContext?.version,
+        canvasId: ptcContext?.canvasId,
+      },
+    };
+
+    const toolCallResult = await this.invokeToolSafely(toolInstance, args, runnableConfig);
+
+    const creditCost = toolCallResult?.creditCost ?? 0;
+    if (creditCost > 0 && toolsetPO?.isGlobal && toolCallResult?.status !== 'error') {
+      try {
+        await this.billingService.processBilling({
+          uid: userId,
+          toolName,
+          toolsetKey,
+          discountedPrice: creditCost,
+          originalPrice: creditCost,
+          resultId: ptcContext?.resultId,
+          version: ptcContext?.version,
+        });
+      } catch (billingError) {
+        this.logger.error(
+          `Billing failed for ${toolsetKey}.${toolName}: ${billingError instanceof Error ? billingError.message : String(billingError)}`,
+        );
+      }
+    }
+
+    if (toolCallResult?.status === 'success') {
+      return {
+        status: 'success',
+        data: toolCallResult?.data,
+        ...(toolCallResult?.summary ? { summary: toolCallResult?.summary } : {}),
+        ...(toolCallResult?.files ? { files: toolCallResult?.files } : {}),
+      };
+    }
+
+    return {
+      status: 'error',
+      error: toolCallResult?.error ?? 'Tool execution failed',
+      ...(toolCallResult?.summary ? { summary: toolCallResult?.summary } : {}),
     };
   }
 }

--- a/apps/api/src/modules/tool/ptc/tool-identify.service.ts
+++ b/apps/api/src/modules/tool/ptc/tool-identify.service.ts
@@ -265,7 +265,52 @@ export class ToolIdentifyService {
       };
     }
 
-    // No record found anywhere
+    // Step 4: Fallback to static inventory if no database records found
+    // This handles tools registered in code but not yet in database
+    const inventoryItem = await this.inventoryService.getInventoryItem(toolsetKey);
+
+    if (inventoryItem) {
+      // If it has a class definition → legacy_sdk
+      if (inventoryItem.class) {
+        return {
+          type: 'legacy_sdk',
+          toolsetKey,
+        };
+      }
+
+      // If it has a definition without class → determine from authPatterns
+      if (inventoryItem.definition) {
+        const { authPatterns, type } = inventoryItem.definition;
+
+        // Check authPatterns for OAuth tools
+        if (authPatterns && authPatterns.length > 0) {
+          const authType = authPatterns[0]?.type;
+          if (authType === 'oauth') {
+            return {
+              type: 'composio_oauth',
+              toolsetKey,
+            };
+          }
+          // Could add support for other auth types here if needed
+        }
+
+        // Check definition.type for external tools
+        if (type === 'external_oauth') {
+          return {
+            type: 'composio_oauth',
+            toolsetKey,
+          };
+        }
+
+        // Default to config_based for other types
+        return {
+          type: 'config_based',
+          toolsetKey,
+        };
+      }
+    }
+
+    // No record found anywhere (neither database nor static inventory)
     throw new ToolsetNotFoundError(`Toolset not found: ${toolsetKey}`);
   }
 }

--- a/apps/api/src/modules/tool/resource.service.ts
+++ b/apps/api/src/modules/tool/resource.service.ts
@@ -33,6 +33,7 @@ import {
   getToolName,
   getToolsetKey,
 } from './tool-context';
+import { MissingCanvasContextError } from './errors/resource-errors';
 
 /**
  * Error thrown when resource value is neither a valid fileId nor a public URL
@@ -895,6 +896,11 @@ export class ResourceHandler {
       const user = getCurrentUser();
       const canvasId = getCanvasId();
 
+      // Validate required context
+      if (!canvasId) {
+        throw new MissingCanvasContextError();
+      }
+
       // Handle Buffer type
       if (Buffer.isBuffer(value)) {
         return await this.uploadBufferResource(user, canvasId, value, fileName);
@@ -1089,7 +1095,7 @@ export class ResourceHandler {
     const { canvasId, toolsetKey, toolName, content, resultId, resultVersion } = options;
 
     if (!canvasId) {
-      return null;
+      throw new MissingCanvasContextError();
     }
 
     try {

--- a/apps/api/src/modules/tool/tool.controller.ts
+++ b/apps/api/src/modules/tool/tool.controller.ts
@@ -144,15 +144,18 @@ export class ToolController {
     @Req() req: Request,
   ): Promise<ExecuteToolResponse> {
     // Extract PTC context from headers
-    const ptcCallId = req.headers['x-ptc-call-id'] as string | undefined;
-    const resultId = req.headers['x-refly-result-id'] as string | undefined;
-    const versionStr = req.headers['x-refly-result-version'] as string | undefined;
+    const headers = req?.headers ?? {};
+    const ptcCallId = headers?.['x-ptc-call-id'] as string | undefined;
+    const resultId = headers?.['x-refly-result-id'] as string | undefined;
+    const versionStr = headers?.['x-refly-result-version'] as string | undefined;
+    const canvasId = headers?.['x-refly-canvas-id'] as string | undefined;
     const version = versionStr ? Number.parseInt(versionStr, 10) : undefined;
 
     const result = await this.toolExecutionService.executeTool(user, request, {
       ptcCallId,
       resultId,
       version,
+      canvasId,
     });
     return buildSuccessResponse(result);
   }

--- a/apps/api/src/modules/tool/utils/schema-utils.ts
+++ b/apps/api/src/modules/tool/utils/schema-utils.ts
@@ -476,7 +476,7 @@ export function enhanceToolSchema(schema: JsonSchema): EnhancedSchemaResult {
  * This field guides the AI to generate descriptive filenames for tool outputs
  * @param schema - Schema to enhance with file_name_title field (mutates in place)
  */
-function addFileNameTitleField(schema: JsonSchema): void {
+export function addFileNameTitleField(schema: JsonSchema): void {
   // Ensure properties object exists
   if (!schema.properties) {
     schema.properties = {};


### PR DESCRIPTION
## Summary

This PR implements PTC (Programmatic Tool Call) tool execution support for both config-based and legacy SDK tools. Previously, only Composio tools were supported for PTC execution. Now users can execute all tool types through the unified /v1/tool/execute API.

## Changes

- Added config-based tool execution with HTTP handler integration and resource processing
- Implemented legacy SDK tool execution with automatic Zod to JSON Schema conversion
- Added canvasId validation with MissingCanvasContextError for proper error handling
- Updated PtcEnvService to pass debug flag and canvasId to sandbox environment
- Enhanced tool identification to fallback to static inventory for unregistered tools
- Added file_name_title field to all exported schemas for consistent resource naming
- Updated tool definition export to support both config-based and legacy SDK toolsets
- Fixed error propagation to ensure critical errors (missing canvasId) are not swallowed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Config-based and legacy SDK tools are now fully supported in the tool execution and export pipeline
  * Canvas context support enables file uploads and resource operations during tool execution
  * Expanded environment variable propagation for richer tool execution context

* **Bug Fixes**
  * Enhanced error handling for resource operations when canvas context is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->