### PR TITLE
[REF-011] docs: Add self-deploy FAQ for IP access and fix cookie secure config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,9 @@
   },
   "files.eol": "\n",
   "editor.formatOnSave": true,
+  "[markdown]": {
+    "editor.formatOnSave": false
+  },
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "tailwindCSS.includeLanguages": {
     "typescript": "tsx",

--- a/apps/api/src/modules/config/app.config.ts
+++ b/apps/api/src/modules/config/app.config.ts
@@ -104,7 +104,7 @@ export default () => ({
     redirectUrl: process.env.LOGIN_REDIRECT_URL,
     cookie: {
       domain: process.env.REFLY_COOKIE_DOMAIN,
-      secure: process.env.REFLY_COOKIE_SECURE,
+      secure: process.env.REFLY_COOKIE_SECURE === 'true' || false,
       sameSite: process.env.REFLY_COOKIE_SAME_SITE,
     },
     jwt: {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -42,6 +42,10 @@ const sidebar = {
           text: 'Self Deploy',
           link: '/community-version/self-deploy/',
         },
+        {
+          text: 'FAQ: Accessing via IP address',
+          link: '/community-version/self-deploy/faq-ip-access',
+        },
       ],
     },
     {
@@ -102,6 +106,10 @@ const sidebar = {
         {
           text: '私有部署',
           link: '/zh/community-version/self-deploy/',
+        },
+        {
+          text: 'FAQ：通过 IP 地址访问',
+          link: '/zh/community-version/self-deploy/faq-ip-access',
         },
       ],
     },

--- a/docs/community-version/self-deploy/faq-ip-access.md
+++ b/docs/community-version/self-deploy/faq-ip-access.md
@@ -1,0 +1,52 @@
+# FAQ: Accessing via IP address
+
+If you are deploying Refly on a cloud server and accessing it via `http://<Public IP>:5700`, you might encounter issues with redirection after login. This is caused by mismatched Cookie domain configurations.
+
+Please follow these steps to adjust your configuration:
+
+## Step 1: Confirm Server Information
+
+Get your cloud server's public IP address, for example: `a.b.c.d`.
+
+## Step 2: Modify Environment Variables
+
+Edit the `deploy/docker/.env` file:
+
+```bash
+# Set ORIGIN to the full URL used in the browser, including protocol and port
+ORIGIN=http://a.b.c.d:5700
+
+# Set REFLY_COOKIE_DOMAIN to the IP address, without the protocol prefix
+REFLY_COOKIE_DOMAIN=a.b.c.d
+
+# Set REFLY_COOKIE_SECURE to empty
+REFLY_COOKIE_SECURE=
+```
+
+## Step 3: Restart Services
+
+After modifying the configuration file, restart the services for the changes to take effect:
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+## Step 4: Verification and Testing
+
+Run the following command to check if the container's environment variables are correct:
+
+```bash
+docker exec refly_api env | egrep 'REFLY_COOKIE|ORIGIN'
+```
+
+Example of correct environment variables:
+
+```bash
+ORIGIN=http://a.b.c.d:5700
+REFLY_COOKIE_DOMAIN=a.b.c.d
+REFLY_COOKIE_SECURE=
+REFLY_COOKIE_SAME_SITE=Lax
+```
+
+Once the environment variables are correct, clear your browser cache and cookies, then try logging in again.

--- a/docs/community-version/self-deploy/index.md
+++ b/docs/community-version/self-deploy/index.md
@@ -51,6 +51,10 @@ If you need to generate image/audio/video, please get your own key from https://
 TOOLSET_FAL_API_KEY=your_fal_api_key
 ```
 
+#### 2.3. Accessing via IP address {#ip-access-section}
+
+If you are deploying on a cloud server and accessing it via an IP address, please refer to the [Accessing via IP address](./faq-ip-access.md) for environment variable settings.
+
 ### 3. Start the application via docker compose {#start-the-application-via-docker-compose}
 
 ```bash

--- a/docs/zh/community-version/self-deploy/faq-ip-access.md
+++ b/docs/zh/community-version/self-deploy/faq-ip-access.md
@@ -1,0 +1,52 @@
+# FAQ：通过 IP 地址访问
+
+如果您在云服务器上部署 Refly，并尝试通过 `http://<公网IP>:5700` 访问，可能会遇到登录后无法正常跳转的问题。这是由于 Cookie 域名配置不匹配导致的。
+
+请按照以下步骤调整配置：
+
+## 第一步：确认服务器信息
+
+获取您的云服务器公网 IP 地址，例如：`a.b.c.d`。
+
+## 第二步：修改环境变量配置
+
+修改 `deploy/docker/.env` 文件：
+
+```bash
+# 将 ORIGIN 设置为浏览器访问的完整地址，包含协议和端口号
+ORIGIN=http://a.b.c.d:5700
+
+# 将 REFLY_COOKIE_DOMAIN 设置为 IP 地址，不要包含协议前缀
+REFLY_COOKIE_DOMAIN=a.b.c.d
+
+# 将 REFLY_COOKIE_SECURE 设置为空
+REFLY_COOKIE_SECURE=
+```
+
+## 第三步：重启服务
+
+修改完配置文件后，需要重启服务以使配置生效：
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+## 第四步：验证与测试
+
+运行以下命令检查容器环境变量是否正确：
+
+```bash
+docker exec refly_api env | egrep 'REFLY_COOKIE|ORIGIN'
+```
+
+正确环境变量示例：
+
+```bash
+ORIGIN=http://a.b.c.d:5700
+REFLY_COOKIE_DOMAIN=a.b.c.d
+REFLY_COOKIE_SECURE=
+REFLY_COOKIE_SAME_SITE=Lax
+```
+
+环境变量正确后，清理浏览器缓存和 Cookie，并尝试重新登录。

--- a/docs/zh/community-version/self-deploy/index.md
+++ b/docs/zh/community-version/self-deploy/index.md
@@ -51,6 +51,10 @@ RESEND_API_KEY=your_resend_api_key
 TOOLSET_FAL_API_KEY=your_fal_api_key
 ```
 
+#### 2.3. FAQ：通过 IP 地址访问 {#faq-ip-access-section}
+
+如果您在云服务器上部署并通过 IP 地址访问，请参考[FAQ：通过 IP 地址访问](./faq-ip-access.md)来设置环境变量。
+
 ### 3. 通过 docker compose 启动应用 {#start-the-application-via-docker-compose}
 
 ```bash


### PR DESCRIPTION
## Summary

This PR adds docs and a config fix for self-deploy users who access Refly via IP address. Login redirect was failing due to cookie domain mismatch; the new FAQ explains how to set ORIGIN, REFLY_COOKIE_DOMAIN and REFLY_COOKIE_SECURE. Also fixes REFLY_COOKIE_SECURE so it is only true when the env value is the string `'true'`.

## Changes

- Add FAQ page (en + zh): accessing via IP, env steps, verification commands
- Link the FAQ from self-deploy sidebar and index in both locales
- Fix `REFLY_COOKIE_SECURE` in app config to parse as boolean
- Disable format on save for Markdown in .vscode settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added bilingual FAQ and deployment guide for accessing the app via IP address, with step-by-step environment variable guidance and troubleshooting for login/cookie issues; sidebar updated to link the new FAQ.

* **Bug Fixes**
  * Corrected cookie security handling so the setting is interpreted as a boolean.

* **Chores**
  * Updated editor configuration to disable auto-format-on-save for Markdown files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->