### PR TITLE
fix: nexu modal should re-show on refresh but not on SPA nav

### DIFF
--- a/packages/ai-workspace-common/src/components/nexu-promotion/NexuModal.tsx
+++ b/packages/ai-workspace-common/src/components/nexu-promotion/NexuModal.tsx
@@ -8,7 +8,9 @@ import { LuMessageSquare, LuShield, LuGitFork } from 'react-icons/lu';
 
 const NEXU_URL = 'https://nexu.io';
 const STORAGE_KEY = 'nexu_modal_dismissed';
-const SESSION_KEY = 'nexu_modal_shown_this_session';
+
+// Module-level flag: resets on page refresh, persists across SPA navigation
+let hasShownThisPageLoad = false;
 
 interface NexuModalProps {
   open?: boolean;
@@ -26,16 +28,15 @@ export const NexuModal = memo(({ open: controlledOpen }: NexuModalProps) => {
       return;
     }
 
-    // Only show once per browser session (avoid re-showing on SPA navigation)
-    const shownThisSession = sessionStorage.getItem(SESSION_KEY);
-    if (shownThisSession === 'true') {
+    // Only show once per page load (avoid re-showing on SPA navigation)
+    if (hasShownThisPageLoad) {
       return;
     }
 
     // Show modal after a short delay
     const timer = setTimeout(() => {
       setVisible(true);
-      sessionStorage.setItem(SESSION_KEY, 'true');
+      hasShownThisPageLoad = true;
       logEvent('refly_nexu_workbench_modal_shown');
     }, 1000);
 


### PR DESCRIPTION
## Summary
- Replace `sessionStorage` with a module-level flag for tracking whether the nexu modal has been shown
- `sessionStorage` persists across page refresh, which incorrectly prevented the modal from re-appearing for users who haven't checked "don't show again"
- A module-level variable resets on page refresh (JS re-executes) but persists across SPA navigation (tab switching), which is the correct behavior

## Test plan
- [ ] Refresh the workspace page — modal should appear
- [ ] Close modal without checking "don't show again", then switch sidebar tabs — modal should NOT re-appear
- [ ] Refresh page again — modal should appear again
- [ ] Check "don't show again" and close — modal should never appear again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized modal display mechanism for improved performance with no change to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->