### PR TITLE
fix: enable Bedrock tool_choice for Claude 5 models

### DIFF
--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -6,7 +6,7 @@
   "types": "src/index.ts",
   "scripts": {
     "clean": "rimraf dist && rimraf tsconfig.tsbuildinfo",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "",

--- a/packages/providers/src/llm/bedrock-tool-choice.test.ts
+++ b/packages/providers/src/llm/bedrock-tool-choice.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { resolveBedrockToolChoiceValues } from './index';
+
+/**
+ * Mirrors @langchain/aws@1.1.0 supportedToolChoiceValuesForModel.
+ * Kept inline so the regression stays visible if langchain is upgraded.
+ */
+function langchainInferredToolChoiceValues(
+  model: string,
+): Array<'auto' | 'any' | 'tool'> | undefined {
+  if (
+    model.includes('claude-3') ||
+    model.includes('claude-4') ||
+    model.includes('claude-opus-4') ||
+    model.includes('claude-sonnet-4')
+  ) {
+    return ['auto', 'any', 'tool'];
+  }
+  if (model.includes('mistral-large')) {
+    return ['auto', 'any'];
+  }
+  return undefined;
+}
+
+function assertToolChoiceAllowed(
+  model: string,
+  toolChoiceType: 'auto' | 'any' | 'tool',
+  supportsToolChoiceValues?: Array<'auto' | 'any' | 'tool'>,
+): void {
+  const values = supportsToolChoiceValues ?? [];
+  if (!values.includes(toolChoiceType)) {
+    throw new Error(
+      values.length
+        ? `Model ${model} does not currently support 'tool_choice' of type ${toolChoiceType}.`
+        : `Model ${model} does not currently support 'tool_choice'.`,
+    );
+  }
+}
+
+const CLAUDE_MODELS = [
+  'global.anthropic.claude-opus-5',
+  'global.anthropic.claude-sonnet-5',
+  'global.anthropic.claude-opus-4-8',
+  'global.anthropic.claude-opus-4-7',
+];
+
+describe('resolveBedrockToolChoiceValues', () => {
+  it.each(CLAUDE_MODELS)('enables tool_choice for %s', (modelId) => {
+    expect(resolveBedrockToolChoiceValues(modelId)).toEqual(['auto', 'any', 'tool']);
+  });
+
+  it('respects explicit supportToolChoice=false', () => {
+    expect(resolveBedrockToolChoiceValues('global.anthropic.claude-opus-5', false)).toBeUndefined();
+  });
+
+  it('returns undefined for unknown models', () => {
+    expect(resolveBedrockToolChoiceValues('amazon.titan-text-express-v1')).toBeUndefined();
+  });
+});
+
+describe('Claude 5 tool_choice regression vs langchain inference', () => {
+  it('langchain inference rejects Claude 5 (prod failure mode)', () => {
+    for (const model of ['global.anthropic.claude-opus-5', 'global.anthropic.claude-sonnet-5']) {
+      expect(langchainInferredToolChoiceValues(model)).toBeUndefined();
+      expect(() => assertToolChoiceAllowed(model, 'auto')).toThrow(
+        /does not currently support 'tool_choice'/,
+      );
+    }
+  });
+
+  it('langchain inference still accepts Claude 4.x', () => {
+    expect(langchainInferredToolChoiceValues('global.anthropic.claude-opus-4-8')).toEqual([
+      'auto',
+      'any',
+      'tool',
+    ]);
+  });
+
+  it.each(['global.anthropic.claude-opus-5', 'global.anthropic.claude-sonnet-5'])(
+    'override allows tool_choice for %s',
+    (modelId) => {
+      const override = resolveBedrockToolChoiceValues(modelId);
+      expect(() => assertToolChoiceAllowed(modelId, 'auto', override)).not.toThrow();
+    },
+  );
+});

--- a/packages/providers/src/llm/index.ts
+++ b/packages/providers/src/llm/index.ts
@@ -50,7 +50,7 @@ const selectBedrockRegion = (extraParams: BedrockExtraParams): string => {
  * before the request is sent. Override when the model is Claude and the
  * provider item has not explicitly disabled tool_choice.
  */
-const resolveBedrockToolChoiceValues = (
+export const resolveBedrockToolChoiceValues = (
   modelId: string,
   supportToolChoice?: boolean,
 ): Array<'auto' | 'any' | 'tool'> | undefined => {

--- a/packages/providers/src/llm/index.ts
+++ b/packages/providers/src/llm/index.ts
@@ -44,6 +44,42 @@ const selectBedrockRegion = (extraParams: BedrockExtraParams): string => {
   );
 };
 
+/**
+ * @langchain/aws only infers tool_choice support for Claude 3/4 name patterns.
+ * Claude 5+ IDs (e.g. claude-opus-5, claude-sonnet-5) fall through and throw
+ * before the request is sent. Override when the model is Claude and the
+ * provider item has not explicitly disabled tool_choice.
+ */
+const resolveBedrockToolChoiceValues = (
+  modelId: string,
+  supportToolChoice?: boolean,
+): Array<'auto' | 'any' | 'tool'> | undefined => {
+  if (supportToolChoice === false) {
+    return undefined;
+  }
+
+  const id = modelId.toLowerCase();
+  const isClaude =
+    id.includes('claude-3') ||
+    id.includes('claude-4') ||
+    id.includes('claude-5') ||
+    id.includes('claude-opus') ||
+    id.includes('claude-sonnet') ||
+    id.includes('claude-haiku') ||
+    id.includes('claude-fable') ||
+    id.includes('claude-mythos');
+
+  if (isClaude) {
+    return ['auto', 'any', 'tool'];
+  }
+
+  if (id.includes('mistral-large')) {
+    return ['auto', 'any'];
+  }
+
+  return undefined;
+};
+
 export const getChatModel = (
   provider: BaseProvider,
   config: LLMModelConfig,
@@ -108,12 +144,18 @@ export const getChatModel = (
 
       try {
         const apiKeyConfig = JSON.parse(provider.apiKey) as BedrockApiKeyConfig;
+        const supportsToolChoiceValues = resolveBedrockToolChoiceValues(
+          config.modelId,
+          config?.capabilities?.supportToolChoice,
+        );
+
         model = new ChatBedrockConverse({
           model: config.modelId,
           region: selectedRegion,
           credentials: apiKeyConfig,
           maxTokens: config?.maxOutput,
           ...bedrockCommonParams,
+          ...(supportsToolChoiceValues ? { supportsToolChoiceValues } : {}),
           ...(config?.capabilities?.reasoning
             ? {
                 additionalModelRequestFields: {

--- a/packages/providers/vitest.config.ts
+++ b/packages/providers/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    exclude: ['node_modules', 'dist', '.turbo'],
+  },
+});


### PR DESCRIPTION
## Summary
- Prod skill invoke fails for Claude Opus 5 / Sonnet 5 with: `Model ... does not currently support 'tool_choice'`
- Root cause: `@langchain/aws` only infers tool_choice support for Claude 3/4 name patterns; Claude 5 IDs fall through and throw client-side before Bedrock is called
- Fix: when creating `ChatBedrockConverse`, explicitly set `supportsToolChoiceValues` for Claude family models (respects `capabilities.supportToolChoice === false`)

## Test plan
- [ ] Deploy / run skill invoke with tools on `global.anthropic.claude-opus-5`
- [ ] Same for `global.anthropic.claude-sonnet-5`
- [ ] Confirm Opus 4.7 / 4.8 still work
- [ ] Models with `supportToolChoice: false` still skip tool_choice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Amazon Bedrock model compatibility by automatically deriving supported tool-choice options from the selected model.
- **Bug Fixes**
  - Prevented unsupported tool-choice options from being sent to Bedrock models that don’t support them, reducing request errors and improving tool integration reliability.
- **Tests**
  - Added coverage to validate tool-choice resolution across supported and unsupported model scenarios.
- **Chores**
  - Updated the providers test script and added a Vitest configuration for consistent test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->