### PR TITLE
fix: prevent Redis memory leaks from BullMQ and bare counters

### DIFF
--- a/apps/api/src/modules/app.module.ts
+++ b/apps/api/src/modules/app.module.ts
@@ -148,9 +148,21 @@ class CustomThrottlerGuard extends ThrottlerGuard {
             useFactory: (redisService: RedisService) => {
               return {
                 connection: redisService.getClient(),
+                // Bound BullMQ event streams so pub/sub history cannot grow without limit.
+                // Job payloads are cleaned via defaultJobOptions; streams are independent.
+                streams: {
+                  events: {
+                    maxLen: 1000,
+                  },
+                },
                 defaultJobOptions: {
+                  // Completed jobs (esp. skill payloads) can be multi-MB — delete immediately.
                   removeOnComplete: true,
-                  removeOnFail: true,
+                  // Keep a short, bounded failure window for debugging; never unbounded.
+                  removeOnFail: {
+                    age: 7 * 24 * 3600, // 7 days
+                    count: 200,
+                  },
                 },
               };
             },

--- a/apps/api/src/modules/app.module.ts
+++ b/apps/api/src/modules/app.module.ts
@@ -158,11 +158,10 @@ class CustomThrottlerGuard extends ThrottlerGuard {
                 defaultJobOptions: {
                   // Completed jobs (esp. skill payloads) can be multi-MB — delete immediately.
                   removeOnComplete: true,
-                  // Keep a short, bounded failure window for debugging; never unbounded.
-                  removeOnFail: {
-                    age: 7 * 24 * 3600, // 7 days
-                    count: 200,
-                  },
+                  // Global default: drop failures immediately. Queues that need a short
+                  // debug window (schedule, skill-package) override removeOnFail locally.
+                  // Keeping failures here would reintroduce bull:skill:* memory pressure.
+                  removeOnFail: true,
                 },
               };
             },

--- a/apps/api/src/modules/common/redis.service.ts
+++ b/apps/api/src/modules/common/redis.service.ts
@@ -205,9 +205,26 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     return item.value;
   }
 
-  async incr(key: string): Promise<number> {
+  /**
+   * Increment a counter. When ttlSeconds is provided, EXPIRE is applied in the
+   * same Redis round-trip so a crash between INCR and EXPIRE cannot leave a
+   * permanent key (the production ElastiCache leak class for bare counters).
+   */
+  async incr(key: string, ttlSeconds?: number): Promise<number> {
+    if (ttlSeconds !== undefined && (!Number.isInteger(ttlSeconds) || ttlSeconds <= 0)) {
+      throw new RangeError(`ttlSeconds must be a positive integer, received ${ttlSeconds}`);
+    }
+
     if (this.client) {
       try {
+        if (ttlSeconds) {
+          const script = `
+            local count = redis.call('INCR', KEYS[1])
+            redis.call('EXPIRE', KEYS[1], ARGV[1])
+            return count
+          `;
+          return (await this.client.eval(script, 1, key, ttlSeconds)) as number;
+        }
         return await this.client.incr(key);
       } catch (error) {
         this.logger.error(`Redis INCR failed: key=${key}, error=${error}`);
@@ -224,16 +241,44 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     }
 
     const newValue = currentValue + 1;
-    const expiresAt = item?.expiresAt ?? Date.now() + 24 * 60 * 60 * 1000; // Default 24h expiry if not set
+    const defaultTtlMs = 24 * 60 * 60 * 1000;
+    const expiresAt = ttlSeconds
+      ? Date.now() + ttlSeconds * 1000
+      : (item?.expiresAt ?? Date.now() + defaultTtlMs);
     this.inMemoryStore.set(key, { value: newValue.toString(), expiresAt });
 
     return newValue;
   }
 
-  async decr(key: string): Promise<number> {
+  /**
+   * Decrement a counter. Optional ttlSeconds refreshes EXPIRE atomically with DECR.
+   * When the value reaches <= 0 the key is deleted to avoid sticky zero counters.
+   */
+  async decr(key: string, ttlSeconds?: number): Promise<number> {
+    if (ttlSeconds !== undefined && (!Number.isInteger(ttlSeconds) || ttlSeconds <= 0)) {
+      throw new RangeError(`ttlSeconds must be a positive integer, received ${ttlSeconds}`);
+    }
+
     if (this.client) {
       try {
-        return await this.client.decr(key);
+        if (ttlSeconds) {
+          const script = `
+            local count = redis.call('DECR', KEYS[1])
+            if count <= 0 then
+              redis.call('DEL', KEYS[1])
+              return 0
+            end
+            redis.call('EXPIRE', KEYS[1], ARGV[1])
+            return count
+          `;
+          return (await this.client.eval(script, 1, key, ttlSeconds)) as number;
+        }
+        const count = await this.client.decr(key);
+        if (count <= 0) {
+          await this.client.del(key);
+          return 0;
+        }
+        return count;
       } catch (error) {
         this.logger.error(`Redis DECR failed: key=${key}, error=${error}`);
         throw error;
@@ -249,7 +294,14 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     }
 
     const newValue = Math.max(0, currentValue - 1);
-    const expiresAt = item?.expiresAt ?? Date.now() + 24 * 60 * 60 * 1000; // Default 24h expiry if not set
+    if (newValue <= 0) {
+      this.inMemoryStore.delete(key);
+      return 0;
+    }
+    const defaultTtlMs = 24 * 60 * 60 * 1000;
+    const expiresAt = ttlSeconds
+      ? Date.now() + ttlSeconds * 1000
+      : (item?.expiresAt ?? Date.now() + defaultTtlMs);
     this.inMemoryStore.set(key, { value: newValue.toString(), expiresAt });
 
     return newValue;

--- a/apps/api/src/modules/common/redis.service.ts
+++ b/apps/api/src/modules/common/redis.service.ts
@@ -242,9 +242,12 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
 
     const newValue = currentValue + 1;
     const defaultTtlMs = 24 * 60 * 60 * 1000;
+    // Only reuse expiry when the existing item is still valid; expired items get a fresh TTL.
     const expiresAt = ttlSeconds
       ? Date.now() + ttlSeconds * 1000
-      : (item?.expiresAt ?? Date.now() + defaultTtlMs);
+      : item && !this.isExpired(item)
+        ? item.expiresAt
+        : Date.now() + defaultTtlMs;
     this.inMemoryStore.set(key, { value: newValue.toString(), expiresAt });
 
     return newValue;
@@ -253,6 +256,7 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
   /**
    * Decrement a counter. Optional ttlSeconds refreshes EXPIRE atomically with DECR.
    * When the value reaches <= 0 the key is deleted to avoid sticky zero counters.
+   * DECR+DEL always runs in one Lua script so a concurrent INCR cannot be wiped.
    */
   async decr(key: string, ttlSeconds?: number): Promise<number> {
     if (ttlSeconds !== undefined && (!Number.isInteger(ttlSeconds) || ttlSeconds <= 0)) {
@@ -261,24 +265,24 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
 
     if (this.client) {
       try {
-        if (ttlSeconds) {
-          const script = `
-            local count = redis.call('DECR', KEYS[1])
-            if count <= 0 then
-              redis.call('DEL', KEYS[1])
-              return 0
-            end
+        // Always atomic: DECR then DEL-if-<=0 (and optional EXPIRE) in one round-trip.
+        const script = `
+          local count = redis.call('DECR', KEYS[1])
+          if count <= 0 then
+            redis.call('DEL', KEYS[1])
+            return 0
+          end
+          if ARGV[1] ~= '' then
             redis.call('EXPIRE', KEYS[1], ARGV[1])
-            return count
-          `;
-          return (await this.client.eval(script, 1, key, ttlSeconds)) as number;
-        }
-        const count = await this.client.decr(key);
-        if (count <= 0) {
-          await this.client.del(key);
-          return 0;
-        }
-        return count;
+          end
+          return count
+        `;
+        return (await this.client.eval(
+          script,
+          1,
+          key,
+          ttlSeconds ? String(ttlSeconds) : '',
+        )) as number;
       } catch (error) {
         this.logger.error(`Redis DECR failed: key=${key}, error=${error}`);
         throw error;
@@ -301,7 +305,9 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     const defaultTtlMs = 24 * 60 * 60 * 1000;
     const expiresAt = ttlSeconds
       ? Date.now() + ttlSeconds * 1000
-      : (item?.expiresAt ?? Date.now() + defaultTtlMs);
+      : item && !this.isExpired(item)
+        ? item.expiresAt
+        : Date.now() + defaultTtlMs;
     this.inMemoryStore.set(key, { value: newValue.toString(), expiresAt });
 
     return newValue;

--- a/apps/api/src/modules/provider/auto-model-trial.service.ts
+++ b/apps/api/src/modules/provider/auto-model-trial.service.ts
@@ -123,17 +123,10 @@ export class AutoModelTrialService {
    * @param ttlSeconds - TTL in seconds
    */
   private incrementCounterAsync(cacheKey: string, ttlSeconds: number): void {
-    // Fire and forget - don't await
-    this.redis
-      .incr(cacheKey)
-      .then(async (newValue) => {
-        // Refresh TTL after increment
-        await this.redis.expire(cacheKey, ttlSeconds);
-        return newValue;
-      })
-      .catch((error) => {
-        this.logger.warn(`Failed to increment trial counter: ${cacheKey}`, error);
-      });
+    // Fire and forget - don't await. INCR+EXPIRE is atomic via RedisService.incr(ttl).
+    this.redis.incr(cacheKey, ttlSeconds).catch((error) => {
+      this.logger.warn(`Failed to increment trial counter: ${cacheKey}`, error);
+    });
   }
 
   /**

--- a/apps/api/src/modules/schedule/schedule.listener.ts
+++ b/apps/api/src/modules/schedule/schedule.listener.ts
@@ -128,7 +128,9 @@ export class ScheduleEventListener {
   private async decrementRedisCounter(uid: string, isErrorHandler = false): Promise<boolean> {
     try {
       const redisKey = `${SCHEDULE_REDIS_KEYS.USER_CONCURRENT_PREFIX}${uid}`;
-      await this.redisService.decr(redisKey);
+      // Refresh TTL on decr so a half-finished counter cannot outlive the window.
+      const ttlSeconds = this.config.get<number>('schedule.userConcurrentTtl') ?? 2 * 60 * 60;
+      await this.redisService.decr(redisKey, ttlSeconds);
       const context = isErrorHandler ? 'in error handler' : '';
       this.logger.debug(`Decremented Redis counter for user ${uid} ${context}`);
       return true;

--- a/apps/api/src/modules/schedule/schedule.module.ts
+++ b/apps/api/src/modules/schedule/schedule.module.ts
@@ -30,7 +30,12 @@ import { ScheduleEventListener } from './schedule.listener';
       defaultJobOptions: {
         attempts: 1, // No automatic retry on failure, user must manually retry
         removeOnComplete: true,
-        removeOnFail: false, // Keep failed jobs for debugging/retry
+        // Keep a bounded window of failures for debugging/manual retry — never unbounded.
+        // (Was removeOnFail: false, which retained every failed job forever in Redis.)
+        removeOnFail: {
+          age: 7 * 24 * 3600,
+          count: 200,
+        },
       },
     }),
     WorkflowModule,

--- a/apps/api/src/modules/schedule/schedule.processor.ts
+++ b/apps/api/src/modules/schedule/schedule.processor.ts
@@ -125,16 +125,16 @@ export class ScheduleProcessor extends WorkerHost {
           );
         }
 
-        // Atomically increment counter
-        const currentCount = await this.redisService.incr(redisKey);
+        // Atomically increment counter + refresh TTL (single round-trip; no bare INCR leak)
+        const currentCount = await this.redisService.incr(
+          redisKey,
+          this.scheduleConfig.userConcurrentTtl,
+        );
         incrSucceeded = true;
-
-        // Set TTL to prevent counter leakage (only if key is new or expired)
-        await this.redisService.expire(redisKey, this.scheduleConfig.userConcurrentTtl);
 
         if (currentCount > this.scheduleConfig.userMaxConcurrent) {
           // Exceeded limit, rollback and delay
-          await this.redisService.decr(redisKey);
+          await this.redisService.decr(redisKey, this.scheduleConfig.userConcurrentTtl);
           incrSucceeded = false;
           this.logger.warn(
             `User ${uid} has ${currentCount} concurrent executions (Redis), delaying job ${job.id}`,
@@ -154,7 +154,7 @@ export class ScheduleProcessor extends WorkerHost {
         // If incr succeeded but subsequent operation failed, try to rollback
         if (incrSucceeded) {
           try {
-            await this.redisService.decr(redisKey);
+            await this.redisService.decr(redisKey, this.scheduleConfig.userConcurrentTtl);
             this.logger.debug(`Rolled back Redis counter for user ${uid} after partial failure`);
           } catch {
             // Rollback failed, but we'll continue with DB fallback
@@ -193,7 +193,7 @@ export class ScheduleProcessor extends WorkerHost {
             this.scheduleConfig.userConcurrentTtl,
             String(runningCount),
           );
-          await this.redisService.incr(redisKey);
+          await this.redisService.incr(redisKey, this.scheduleConfig.userConcurrentTtl);
           redisCounterActive = true;
           this.logger.debug(
             `Redis recovered, counter restored from DB (${runningCount}) and incremented for user ${uid}`,
@@ -254,7 +254,7 @@ export class ScheduleProcessor extends WorkerHost {
         if (redisCounterActive) {
           try {
             const redisKey = `${SCHEDULE_REDIS_KEYS.USER_CONCURRENT_PREFIX}${uid}`;
-            await this.redisService.decr(redisKey);
+            await this.redisService.decr(redisKey, this.scheduleConfig.userConcurrentTtl);
             this.logger.debug(`Rolled back Redis counter for user ${uid} (record already failed)`);
           } catch (redisError) {
             this.logger.warn(`Failed to rollback Redis counter for user ${uid}`, redisError);
@@ -281,7 +281,7 @@ export class ScheduleProcessor extends WorkerHost {
         if (redisCounterActive) {
           try {
             const redisKey = `${SCHEDULE_REDIS_KEYS.USER_CONCURRENT_PREFIX}${uid}`;
-            await this.redisService.decr(redisKey);
+            await this.redisService.decr(redisKey, this.scheduleConfig.userConcurrentTtl);
             this.logger.debug(`Rolled back Redis counter for user ${uid} (schedule not found)`);
           } catch (redisError) {
             this.logger.warn(`Failed to rollback Redis counter for user ${uid}`, redisError);
@@ -349,7 +349,7 @@ export class ScheduleProcessor extends WorkerHost {
           if (redisCounterActive) {
             try {
               const redisKey = `${SCHEDULE_REDIS_KEYS.USER_CONCURRENT_PREFIX}${uid}`;
-              await this.redisService.decr(redisKey);
+              await this.redisService.decr(redisKey, this.scheduleConfig.userConcurrentTtl);
             } catch (redisError) {
               this.logger.warn(`Failed to rollback Redis counter for user ${uid}`, redisError);
             }
@@ -404,7 +404,7 @@ export class ScheduleProcessor extends WorkerHost {
           if (redisCounterActive) {
             try {
               const redisKey = `${SCHEDULE_REDIS_KEYS.USER_CONCURRENT_PREFIX}${uid}`;
-              await this.redisService.decr(redisKey);
+              await this.redisService.decr(redisKey, this.scheduleConfig.userConcurrentTtl);
               this.logger.debug(`Rolled back Redis counter for user ${uid} (insufficient credits)`);
             } catch (redisError) {
               this.logger.warn(`Failed to rollback Redis counter for user ${uid}`, redisError);
@@ -526,7 +526,7 @@ export class ScheduleProcessor extends WorkerHost {
       if (redisCounterActive) {
         try {
           const redisKey = `${SCHEDULE_REDIS_KEYS.USER_CONCURRENT_PREFIX}${uid}`;
-          await this.redisService.decr(redisKey);
+          await this.redisService.decr(redisKey, this.scheduleConfig.userConcurrentTtl);
           this.logger.debug(`Decremented Redis counter for user ${uid} due to task failure`);
         } catch (redisError) {
           // Redis failure is not critical here, just log

--- a/apps/api/src/modules/skill-package/skill-package-executor.service.ts
+++ b/apps/api/src/modules/skill-package/skill-package-executor.service.ts
@@ -200,7 +200,11 @@ export class SkillPackageExecutorService {
       },
       {
         removeOnComplete: true,
-        removeOnFail: false,
+        // Failure details live in DB (skillExecution); keep only a short Redis window.
+        removeOnFail: {
+          age: 7 * 24 * 3600,
+          count: 200,
+        },
         attempts: 1, // Retries handled internally
       },
     );
@@ -287,7 +291,10 @@ export class SkillPackageExecutorService {
             },
             {
               removeOnComplete: true,
-              removeOnFail: false,
+              removeOnFail: {
+                age: 7 * 24 * 3600,
+                count: 200,
+              },
             },
           );
         });
@@ -463,7 +470,14 @@ export class SkillPackageExecutorService {
         await this.workflowQueue.add(
           'execute-workflow',
           { ...job, retryCount: workflowExec.retryCount + 1 },
-          { delay: backoff },
+          {
+            delay: backoff,
+            removeOnComplete: true,
+            removeOnFail: {
+              age: 7 * 24 * 3600,
+              count: 200,
+            },
+          },
         );
       } else {
         // Mark as failed

--- a/apps/api/src/scripts/cleanup-stale-bull-jobs.ts
+++ b/apps/api/src/scripts/cleanup-stale-bull-jobs.ts
@@ -1,0 +1,143 @@
+/**
+ * One-shot ops script: trim historical BullMQ job hashes that predate
+ * removeOnComplete/removeOnFail defaults (the Dec-2025 Redis OOM class).
+ *
+ * Usage (from apps/api, with REDIS_* or REDIS_URL in env):
+ *   DRY_RUN=1 npx ts-node -r tsconfig-paths/register src/scripts/cleanup-stale-bull-jobs.ts
+ *   npx ts-node -r tsconfig-paths/register src/scripts/cleanup-stale-bull-jobs.ts
+ *
+ * Safety:
+ * - Only deletes job hashes that are members of `:completed` or `:failed` zsets
+ *   (or orphan numeric job hashes older than MAX_AGE_MS with finishedOn set).
+ * - Never touches :wait / :active / :delayed / :paused / locks / meta.
+ * - DRY_RUN=1 (default) only prints counts.
+ */
+import Redis from 'ioredis';
+
+const DRY_RUN = process.env.DRY_RUN !== '0';
+const MAX_AGE_MS = Number(process.env.MAX_AGE_MS ?? 7 * 24 * 3600 * 1000);
+const BATCH = Number(process.env.BATCH ?? 200);
+const QUEUES = (
+  process.env.QUEUES ??
+  'skill,syncTokenUsage,syncRequestUsage,sandbox-execute-request,runWorkflow,autoNameCanvas,imageProcessing,scheduleExecution,scaleboxExecute,createShare,skillExecution,skillWorkflow'
+)
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+function createClient(): Redis {
+  if (process.env.REDIS_URL) {
+    return new Redis(process.env.REDIS_URL, {
+      maxRetriesPerRequest: null,
+      tls: process.env.REDIS_TLS === '1' ? {} : undefined,
+    });
+  }
+  return new Redis({
+    host: process.env.REDIS_HOST ?? '127.0.0.1',
+    port: Number(process.env.REDIS_PORT ?? 6379),
+    username: process.env.REDIS_USERNAME,
+    password: process.env.REDIS_PASSWORD,
+    tls: process.env.REDIS_TLS === '1' || process.env.REDIS_TLS === 'true' ? {} : undefined,
+    maxRetriesPerRequest: null,
+  });
+}
+
+async function drainZsetJobs(
+  redis: Redis,
+  queue: string,
+  state: 'completed' | 'failed',
+  cutoff: number,
+): Promise<{ scanned: number; deleted: number }> {
+  const zkey = `bull:${queue}:${state}`;
+  const type = await redis.type(zkey);
+  if (type !== 'zset') {
+    return { scanned: 0, deleted: 0 };
+  }
+
+  let scanned = 0;
+  let deleted = 0;
+  let start = 0;
+
+  // Scores in BullMQ completed/failed zsets are finishedOn timestamps (ms).
+  while (true) {
+    const batch = await redis.zrangebyscore(zkey, '-inf', cutoff, 'LIMIT', start, BATCH);
+    if (batch.length === 0) break;
+
+    scanned += batch.length;
+    const jobKeys = batch.map((id) => `bull:${queue}:${id}`);
+
+    if (DRY_RUN) {
+      deleted += jobKeys.length;
+      // Advance by batch size; dry-run does not mutate so use offset.
+      start += batch.length;
+      if (batch.length < BATCH) break;
+      continue;
+    }
+
+    const pipeline = redis.pipeline();
+    for (const id of batch) {
+      pipeline.del(`bull:${queue}:${id}`);
+      pipeline.zrem(zkey, id);
+    }
+    await pipeline.exec();
+    deleted += batch.length;
+    // After delete, next oldest is still at the front — do not advance start.
+    if (batch.length < BATCH) break;
+  }
+
+  return { scanned, deleted };
+}
+
+async function trimEventsStream(redis: Redis, queue: string, maxLen: number): Promise<number> {
+  const key = `bull:${queue}:events`;
+  const type = await redis.type(key);
+  if (type !== 'stream') return 0;
+  if (DRY_RUN) {
+    const len = await redis.xlen(key);
+    return Math.max(0, len - maxLen);
+  }
+  // Approximate trim to maxLen entries
+  await redis.xtrim(key, 'MAXLEN', '~', maxLen);
+  return maxLen;
+}
+
+async function main() {
+  const redis = createClient();
+  const cutoff = Date.now() - MAX_AGE_MS;
+  console.log(
+    JSON.stringify({
+      dryRun: DRY_RUN,
+      cutoffIso: new Date(cutoff).toISOString(),
+      maxAgeMs: MAX_AGE_MS,
+      queues: QUEUES,
+    }),
+  );
+
+  try {
+    await redis.ping();
+    for (const queue of QUEUES) {
+      const completed = await drainZsetJobs(redis, queue, 'completed', cutoff);
+      const failed = await drainZsetJobs(redis, queue, 'failed', cutoff);
+      const eventsTrimmed = await trimEventsStream(redis, queue, 1000);
+      console.log(
+        JSON.stringify({
+          queue,
+          completed,
+          failed,
+          eventsTrimmedApprox: eventsTrimmed,
+        }),
+      );
+    }
+  } finally {
+    await redis.quit();
+  }
+
+  if (DRY_RUN) {
+    console.log('Dry-run only. Re-run with DRY_RUN=0 to apply deletes.');
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/api/src/scripts/cleanup-stale-bull-jobs.ts
+++ b/apps/api/src/scripts/cleanup-stale-bull-jobs.ts
@@ -7,16 +7,28 @@
  *   npx ts-node -r tsconfig-paths/register src/scripts/cleanup-stale-bull-jobs.ts
  *
  * Safety:
- * - Only deletes job hashes that are members of `:completed` or `:failed` zsets
- *   (or orphan numeric job hashes older than MAX_AGE_MS with finishedOn set).
+ * - Uses BullMQ Queue.clean (atomic Lua) for completed/failed jobs only.
  * - Never touches :wait / :active / :delayed / :paused / locks / meta.
  * - DRY_RUN=1 (default) only prints counts.
  */
+import { Queue } from 'bullmq';
 import Redis from 'ioredis';
 
 const DRY_RUN = process.env.DRY_RUN !== '0';
-const MAX_AGE_MS = Number(process.env.MAX_AGE_MS ?? 7 * 24 * 3600 * 1000);
-const BATCH = Number(process.env.BATCH ?? 200);
+
+function parsePositiveInt(name: string, raw: string | undefined, defaultValue: number): number {
+  if (raw === undefined || raw === '') {
+    return defaultValue;
+  }
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+    throw new Error(`${name} must be a positive finite integer, got: ${JSON.stringify(raw)}`);
+  }
+  return n;
+}
+
+const MAX_AGE_MS = parsePositiveInt('MAX_AGE_MS', process.env.MAX_AGE_MS, 7 * 24 * 3600 * 1000);
+const BATCH = parsePositiveInt('BATCH', process.env.BATCH, 200);
 const QUEUES = (
   process.env.QUEUES ??
   'skill,syncTokenUsage,syncRequestUsage,sandbox-execute-request,runWorkflow,autoNameCanvas,imageProcessing,scheduleExecution,scaleboxExecute,createShare,skillExecution,skillWorkflow'
@@ -25,11 +37,17 @@ const QUEUES = (
   .map((s) => s.trim())
   .filter(Boolean);
 
-function createClient(): Redis {
+function isRedisTlsEnabled(): boolean {
+  const v = process.env.REDIS_TLS;
+  return v === '1' || v === 'true';
+}
+
+function createRedis(): Redis {
+  const tls = isRedisTlsEnabled() ? {} : undefined;
   if (process.env.REDIS_URL) {
     return new Redis(process.env.REDIS_URL, {
       maxRetriesPerRequest: null,
-      tls: process.env.REDIS_TLS === '1' ? {} : undefined,
+      tls,
     });
   }
   return new Redis({
@@ -37,91 +55,93 @@ function createClient(): Redis {
     port: Number(process.env.REDIS_PORT ?? 6379),
     username: process.env.REDIS_USERNAME,
     password: process.env.REDIS_PASSWORD,
-    tls: process.env.REDIS_TLS === '1' || process.env.REDIS_TLS === 'true' ? {} : undefined,
+    tls,
     maxRetriesPerRequest: null,
   });
 }
 
-async function drainZsetJobs(
-  redis: Redis,
-  queue: string,
+/**
+ * Remove completed/failed jobs older than MAX_AGE_MS via BullMQ's atomic clean.
+ */
+async function drainState(
+  queue: Queue,
   state: 'completed' | 'failed',
-  cutoff: number,
 ): Promise<{ scanned: number; deleted: number }> {
-  const zkey = `bull:${queue}:${state}`;
-  const type = await redis.type(zkey);
-  if (type !== 'zset') {
-    return { scanned: 0, deleted: 0 };
-  }
-
   let scanned = 0;
   let deleted = 0;
-  let start = 0;
 
-  // Scores in BullMQ completed/failed zsets are finishedOn timestamps (ms).
+  if (DRY_RUN) {
+    // Approximate: count finished jobs older than cutoff without mutating.
+    // getJobs may yield undefined for orphaned zset entries — skip those.
+    const cutoff = Date.now() - MAX_AGE_MS;
+    let start = 0;
+    while (true) {
+      const jobs = await queue.getJobs([state], start, start + BATCH - 1, true);
+      if (jobs.length === 0) break;
+      const stale = jobs.filter(
+        (j) => j != null && (j.finishedOn ?? 0) > 0 && (j.finishedOn ?? 0) <= cutoff,
+      );
+      scanned += stale.length;
+      deleted += stale.length;
+      if (jobs.length < BATCH) break;
+      start += jobs.length;
+    }
+    return { scanned, deleted };
+  }
+
   while (true) {
-    const batch = await redis.zrangebyscore(zkey, '-inf', cutoff, 'LIMIT', start, BATCH);
-    if (batch.length === 0) break;
-
-    scanned += batch.length;
-    const jobKeys = batch.map((id) => `bull:${queue}:${id}`);
-
-    if (DRY_RUN) {
-      deleted += jobKeys.length;
-      // Advance by batch size; dry-run does not mutate so use offset.
-      start += batch.length;
-      if (batch.length < BATCH) break;
-      continue;
-    }
-
-    const pipeline = redis.pipeline();
-    for (const id of batch) {
-      pipeline.del(`bull:${queue}:${id}`);
-      pipeline.zrem(zkey, id);
-    }
-    await pipeline.exec();
-    deleted += batch.length;
-    // After delete, next oldest is still at the front — do not advance start.
-    if (batch.length < BATCH) break;
+    // grace = MAX_AGE_MS: clean jobs finished more than MAX_AGE_MS ago.
+    const removed = await queue.clean(MAX_AGE_MS, BATCH, state);
+    scanned += removed.length;
+    deleted += removed.length;
+    if (removed.length < BATCH) break;
   }
 
   return { scanned, deleted };
 }
 
-async function trimEventsStream(redis: Redis, queue: string, maxLen: number): Promise<number> {
-  const key = `bull:${queue}:events`;
+async function trimEventsStream(redis: Redis, queueName: string, maxLen: number): Promise<number> {
+  const key = `bull:${queueName}:events`;
   const type = await redis.type(key);
   if (type !== 'stream') return 0;
   if (DRY_RUN) {
     const len = await redis.xlen(key);
     return Math.max(0, len - maxLen);
   }
-  // Approximate trim to maxLen entries
-  await redis.xtrim(key, 'MAXLEN', '~', maxLen);
-  return maxLen;
+  // XTRIM returns the number of entries actually removed.
+  return await redis.xtrim(key, 'MAXLEN', '~', maxLen);
 }
 
-async function main() {
-  const redis = createClient();
-  const cutoff = Date.now() - MAX_AGE_MS;
+async function main(): Promise<void> {
+  const redis = createRedis();
+
   console.log(
     JSON.stringify({
       dryRun: DRY_RUN,
-      cutoffIso: new Date(cutoff).toISOString(),
+      cutoffIso: new Date(Date.now() - MAX_AGE_MS).toISOString(),
       maxAgeMs: MAX_AGE_MS,
+      batch: BATCH,
       queues: QUEUES,
     }),
   );
 
+  const queues: Queue[] = [];
   try {
     await redis.ping();
-    for (const queue of QUEUES) {
-      const completed = await drainZsetJobs(redis, queue, 'completed', cutoff);
-      const failed = await drainZsetJobs(redis, queue, 'failed', cutoff);
-      const eventsTrimmed = await trimEventsStream(redis, queue, 1000);
+    for (const name of QUEUES) {
+      // Share the non-blocking client; skipMetasUpdate so we do not overwrite
+      // bull:<queue>:meta (e.g. streams.events.maxLen set by the app).
+      const queue = new Queue(name, {
+        connection: redis,
+        skipMetasUpdate: true,
+      });
+      queues.push(queue);
+      const completed = await drainState(queue, 'completed');
+      const failed = await drainState(queue, 'failed');
+      const eventsTrimmed = await trimEventsStream(redis, name, 1000);
       console.log(
         JSON.stringify({
-          queue,
+          queue: name,
           completed,
           failed,
           eventsTrimmedApprox: eventsTrimmed,
@@ -129,6 +149,8 @@ async function main() {
       );
     }
   } finally {
+    // close() only drops BullMQ listeners on a shared client; quit the client after.
+    await Promise.all(queues.map((q) => q.close()));
     await redis.quit();
   }
 


### PR DESCRIPTION
## Summary
- Bound BullMQ failed-job retention and event streams so Redis cannot grow without limit (fixes `removeOnFail: false` on schedule + skill-package queues).
- Make `RedisService.incr`/`decr` apply TTL atomically (Lua) and delete counters at ≤0; wire schedule concurrency + auto-model-trial through that path.
- Add dry-run ops script `cleanup-stale-bull-jobs.ts` for one-shot cleanup of historical completed/failed job hashes (the ~1.8GiB prod ElastiCache class from pre-#1916 / stalled skill jobs).

## Context
Prod ElastiCache (`refly-prod-redis`) is ~1.87GiB with ~98% keys lacking TTL. Memory is dominated by `bull:skill:*` job hashes (multi-MB `data` payloads), not application caches (those already use SETEX). Global `removeOnComplete/Fail: true` landed in #1916 (2025-12-22), but schedule/skill-package still overrode `removeOnFail: false`, and event streams were unbounded. Historical jobs do not self-expire — deploy this PR, then run the cleanup script against prod if desired.

## Test plan
- [ ] CI green
- [ ] Confirm schedule concurrency still delays when over limit (Redis counter + TTL)
- [ ] Confirm failed schedule/skill-package jobs are retained only within age/count bounds
- [ ] Dry-run cleanup script against a non-prod Redis: `DRY_RUN=1 npx ts-node -r tsconfig-paths/register src/scripts/cleanup-stale-bull-jobs.ts`
- [ ] After merge: optional prod cleanup with `DRY_RUN=0` in a maintenance window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis counter TTL handling using atomic increment/decrement with Lua to avoid stale concurrency data.
  * Updated concurrency increment/rollback flows to consistently refresh TTL across normal, retry, and recovery paths.
* **Chores**
  * Added bounds to BullMQ failed-job retention (7 days / 200) and capped BullMQ event stream history.
  * Added a maintenance script to trim stale completed/failed jobs and trim event streams with configurable limits (supports dry-run).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->