### PR TITLE
fix(api): mitigate refly-api Node RSS memory growth

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -189,9 +189,14 @@ OTLP_METRICS_INTERVAL_MS=60000
 LANGFUSE_PUBLIC_KEY=pk-lf-dev
 LANGFUSE_SECRET_KEY=sk-lf-dev
 
-# Sentry Configuration (Error Tracking)
+# Sentry Configuration (Error Tracking) — opt-in
+# Requires BOTH SENTRY_ENABLED=true and a non-empty SENTRY_DSN.
 # Get your DSN from https://sentry.io/
+# SENTRY_ENABLED=false
 # SENTRY_DSN=https://xxx@xxx.ingest.sentry.io/xxx
+# SENTRY_TRACES_SAMPLE_RATE=0.05
+# SENTRY_PROFILES_SAMPLE_RATE=0
+
 
 # Deploy Type Configuration
 # Options: cloud (default), self-hosted

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -23,14 +23,22 @@ import { CustomWsAdapter } from './utils/adapters/ws-adapter';
 import { setupStatsig } from '@refly/telemetry-node';
 import { migrateDbSchema, seedDatabase } from './utils/prisma';
 import { initTokenizer } from '@refly/utils/token';
+import {
+  getSentryProfilesSampleRate,
+  getSentryTracesSampleRate,
+  isSentryEnabled,
+} from './utils/sentry';
 
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  integrations: [nodeProfilingIntegration()],
-  environment: process.env.NODE_ENV,
-  tracesSampleRate: 1.0, //  Capture 100% of the transactions
-  profilesSampleRate: 1.0,
-});
+if (isSentryEnabled()) {
+  const profilesSampleRate = getSentryProfilesSampleRate();
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    integrations: profilesSampleRate > 0 ? [nodeProfilingIntegration()] : [],
+    environment: process.env.NODE_ENV,
+    tracesSampleRate: getSentryTracesSampleRate(),
+    profilesSampleRate,
+  });
+}
 
 async function bootstrap() {
   // Initialize tokenizer from CDN
@@ -58,14 +66,18 @@ async function bootstrap() {
   process.on('uncaughtException', (err) => {
     const stack = (err as Error)?.stack ?? String(err);
     logger.error(`main process uncaughtException: ${stack}`);
-    Sentry.captureException(err);
+    if (isSentryEnabled()) {
+      Sentry.captureException(err);
+    }
     // Do not exit; keep the process alive. Investigate recurring errors via Sentry logs.
   });
 
   process.on('unhandledRejection', (err) => {
     const message = (err as Error)?.stack ?? String(err);
     logger.error(`main process unhandledRejection: ${message}`);
-    Sentry.captureException(err as any);
+    if (isSentryEnabled()) {
+      Sentry.captureException(err as any);
+    }
     // Do not exit; keep the process alive. Investigate recurring errors via Sentry logs.
   });
 

--- a/apps/api/src/modules/collab/collab.service.ts
+++ b/apps/api/src/modules/collab/collab.service.ts
@@ -442,7 +442,11 @@ export class CollabService {
   }
 
   async modifyDocument(documentName: string, update: string) {
-    const { document } = await this.server.openDirectConnection(documentName);
-    incrementalMarkdownUpdate(document, update);
+    const connection = await this.server.openDirectConnection(documentName);
+    try {
+      incrementalMarkdownUpdate(connection.document, update);
+    } finally {
+      await connection.disconnect().catch(() => undefined);
+    }
   }
 }

--- a/apps/api/src/modules/common/prisma.service.ts
+++ b/apps/api/src/modules/common/prisma.service.ts
@@ -44,9 +44,20 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
           normalizedQuery.startsWith('update') ||
           normalizedQuery.startsWith('delete');
         if (isWriteQuery) {
-          this.logger.log(`query: ${e.query}, param: ${e.params}, duration: ${e.duration}ms`);
+          // Never log params in production — they often contain tokens/API keys/PII.
+          // Only log a short query prefix + duration for operational signal.
+          const query =
+            typeof e.query === 'string' ? this.truncateForLog(e.query, 200) : String(e.query ?? '');
+          this.logger.log(`query: ${query}, duration: ${e.duration}ms`);
         }
       }
     });
+  }
+
+  private truncateForLog(value: string, maxLen: number): string {
+    if (value.length <= maxLen) {
+      return value;
+    }
+    return `${value.slice(0, maxLen)}...[truncated ${value.length - maxLen} chars]`;
   }
 }

--- a/apps/api/src/modules/config/app.config.ts
+++ b/apps/api/src/modules/config/app.config.ts
@@ -18,6 +18,8 @@ export default () => ({
   },
   image: {
     maxArea: Number.parseInt(process.env.IMAGE_MAX_AREA) || 600 * 600,
+    // Keep historical default. Prefer setting IMAGE_PAYLOAD_MODE=url in env after provider canary.
+    // Note: current skill drive images use DRIVE_PAYLOAD_MODE, not this setting.
     payloadMode: process.env.IMAGE_PAYLOAD_MODE || 'base64', // 'url' or 'base64'
     presignExpiry: Number.parseInt(process.env.IMAGE_PRESIGN_EXPIRY) || 15 * 60, // 15 minutes
   },

--- a/apps/api/src/modules/skill/skill-invoker.service.ts
+++ b/apps/api/src/modules/skill/skill-invoker.service.ts
@@ -265,7 +265,10 @@ export class SkillInvokerService {
     data: InvokeSkillJobData & {
       eventListener?: (data: SkillEvent) => void;
     },
-  ): Promise<SkillRunnableConfig> {
+  ): Promise<{
+    config: SkillRunnableConfig;
+    cleanupResources?: () => Promise<void>;
+  }> {
     const {
       context,
       tplConfig,
@@ -410,72 +413,87 @@ export class SkillInvokerService {
       ).then((messages) => messages.flat());
     }
 
-    if (toolsets?.length > 0) {
-      const tools = await this.toolService.instantiateToolsets(user, toolsets, this.skillEngine, {
-        context,
-      });
+    let cleanupResources: (() => Promise<void>) | undefined;
 
-      // Inject categorized tools and toolsets into config
-      config.configurable.selectedTools = tools.all as any;
-      config.configurable.builtInTools = tools.builtIn as any;
-      config.configurable.nonBuiltInTools = tools.nonBuiltIn as any;
-      (config.configurable as any).builtInToolsets = tools.builtInToolsets;
-      (config.configurable as any).nonBuiltInToolsets = tools.nonBuiltInToolsets;
+    try {
+      if (toolsets?.length > 0) {
+        const tools = await this.toolService.instantiateToolsets(user, toolsets, this.skillEngine, {
+          context,
+        });
+        cleanupResources = tools.cleanup;
 
-      // Calculate PTC status based on user and toolsets (highest priority)
-      const ptcConfig = getPtcConfig(this.config);
-      const toolsetKeys = toolsets.map((t) => t?.toolset?.key ?? t?.id ?? '');
-      let ptcEnabled = isPtcEnabledForToolsets(user, toolsetKeys, ptcConfig);
+        // Inject categorized tools and toolsets into config
+        config.configurable.selectedTools = tools.all as any;
+        config.configurable.builtInTools = tools.builtIn as any;
+        config.configurable.nonBuiltInTools = tools.nonBuiltIn as any;
+        (config.configurable as any).builtInToolsets = tools.builtInToolsets;
+        (config.configurable as any).nonBuiltInToolsets = tools.nonBuiltInToolsets;
 
-      // Debug mode: title-based filtering, applied only when base check already permits PTC.
-      // opt-in  → enable only if title contains "useptc"
-      // opt-out → disable only if title contains "nonptc"
-      if (ptcEnabled && ptcConfig.debugMode !== null) {
-        const title = data.title?.toLowerCase() ?? '';
-        if (ptcConfig.debugMode === PtcDebugMode.OPT_IN) {
-          ptcEnabled = title.includes('useptc');
-        } else if (ptcConfig.debugMode === PtcDebugMode.OPT_OUT) {
-          ptcEnabled = !title.includes('nonptc');
+        // Calculate PTC status based on user and toolsets (highest priority)
+        const ptcConfig = getPtcConfig(this.config);
+        const toolsetKeys = toolsets.map((t) => t?.toolset?.key ?? t?.id ?? '');
+        let ptcEnabled = isPtcEnabledForToolsets(user, toolsetKeys, ptcConfig);
+
+        // Debug mode: title-based filtering, applied only when base check already permits PTC.
+        // opt-in  → enable only if title contains "useptc"
+        // opt-out → disable only if title contains "nonptc"
+        if (ptcEnabled && ptcConfig.debugMode !== null) {
+          const title = data.title?.toLowerCase() ?? '';
+          if (ptcConfig.debugMode === PtcDebugMode.OPT_IN) {
+            ptcEnabled = title.includes('useptc');
+          } else if (ptcConfig.debugMode === PtcDebugMode.OPT_OUT) {
+            ptcEnabled = !title.includes('nonptc');
+          }
+        }
+
+        config.configurable.ptcEnabled = ptcEnabled;
+        config.configurable.ptcSequential = ptcConfig.sequential;
+
+        if (ptcEnabled && tools.nonBuiltInToolsets.length > 0) {
+          const ptcContext = await this.ptcSdkService.buildPtcContext(tools.nonBuiltInToolsets);
+          config.configurable.ptcContext = ptcContext;
         }
       }
 
-      config.configurable.ptcEnabled = ptcEnabled;
-      config.configurable.ptcSequential = ptcConfig.sequential;
-
-      if (ptcEnabled && tools.nonBuiltInToolsets.length > 0) {
-        const ptcContext = await this.ptcSdkService.buildPtcContext(tools.nonBuiltInToolsets);
-        config.configurable.ptcContext = ptcContext;
+      // For copilot_agent mode, include all tools (authorized and unauthorized)
+      // This allows Copilot to generate workflows with tools that require authorization
+      if (data.mode === 'copilot_agent') {
+        config.configurable.installedToolsets = await this.toolService.listAllToolsForCopilot(user);
+      } else {
+        // For other modes, only include authorized/installed tools
+        config.configurable.installedToolsets = await this.toolService.listTools(user, {
+          enabled: true,
+        });
       }
+
+      config.configurable.webSearchEnabled = this.config.get<boolean>('tools.webSearchEnabled');
+
+      if (eventListener) {
+        const emitter = new EventEmitter<SkillEventMap>();
+
+        emitter.on('start', eventListener);
+        emitter.on('end', eventListener);
+        emitter.on('log', eventListener);
+        emitter.on('error', eventListener);
+        emitter.on('create_node', eventListener);
+        emitter.on('artifact', eventListener);
+        emitter.on('structured_data', eventListener);
+
+        config.configurable.emitter = emitter;
+      }
+
+      return { config, cleanupResources };
+    } catch (error) {
+      // If config build fails after MCP/tools were opened, release them immediately
+      if (cleanupResources) {
+        await cleanupResources().catch((cleanupError) => {
+          this.logger.error(
+            `Failed to cleanup resources after buildInvokeConfig error: ${(cleanupError as Error)?.message}`,
+          );
+        });
+      }
+      throw error;
     }
-
-    // For copilot_agent mode, include all tools (authorized and unauthorized)
-    // This allows Copilot to generate workflows with tools that require authorization
-    if (data.mode === 'copilot_agent') {
-      config.configurable.installedToolsets = await this.toolService.listAllToolsForCopilot(user);
-    } else {
-      // For other modes, only include authorized/installed tools
-      config.configurable.installedToolsets = await this.toolService.listTools(user, {
-        enabled: true,
-      });
-    }
-
-    config.configurable.webSearchEnabled = this.config.get<boolean>('tools.webSearchEnabled');
-
-    if (eventListener) {
-      const emitter = new EventEmitter<SkillEventMap>();
-
-      emitter.on('start', eventListener);
-      emitter.on('end', eventListener);
-      emitter.on('log', eventListener);
-      emitter.on('error', eventListener);
-      emitter.on('create_node', eventListener);
-      emitter.on('artifact', eventListener);
-      emitter.on('structured_data', eventListener);
-
-      config.configurable.emitter = emitter;
-    }
-
-    return config;
   }
 
   private categorizeError(err: Error): {
@@ -838,22 +856,13 @@ export class SkillInvokerService {
       }
     };
 
-    const resultAggregator = new ResultAggregator(this.stepService, resultId, version);
-    const messageAggregator = new MessageAggregator(resultId, version, this.prisma);
-
-    // Initialize structuredData with original query if available
-    const originalQuery = data.input?.originalQuery;
-    if (originalQuery) {
-      resultAggregator.addSkillEvent({
-        event: 'structured_data',
-        resultId,
-        step: { name: 'start' },
-        structuredData: {
-          query: originalQuery, // Store original query in structuredData
-          processedQuery: data.input?.query, // Store processed query for reference
-        },
-      });
-    }
+    // Resource handles — declared before the protected region so finally can always release them
+    let cleanupResources: (() => Promise<void>) | undefined;
+    let config: SkillRunnableConfig | undefined;
+    let resultAggregator: ResultAggregator | undefined;
+    let messageAggregator: MessageAggregator | undefined;
+    let ptcPollerManager: PtcPollerManager | undefined;
+    let runMeta: SkillRunnableMeta | null = null;
 
     // NOTE: Artifacts include both code artifacts and documents
     type ArtifactOutput = Artifact & {
@@ -862,57 +871,6 @@ export class SkillInvokerService {
       connection?: DirectConnection & { document: Y.Doc };
     };
     const artifactMap: Record<string, ArtifactOutput> = {};
-
-    const config = await this.buildInvokeConfig(user, {
-      ...data,
-      eventListener: async (data: SkillEvent) => {
-        if (abortController.signal.aborted) {
-          this.logger.warn(`skill invocation aborted, ignore event: ${JSON.stringify(data)}`);
-          return;
-        }
-
-        // Record output event for simple timeout tracking
-        lastOutputTime = Date.now();
-        hasAnyOutput = true;
-
-        if (res) {
-          writeSSEResponse(res, { ...data, resultId, version });
-        }
-
-        const { event, structuredData, artifact, log } = data;
-        switch (event) {
-          case 'log':
-            if (log) {
-              resultAggregator.addSkillEvent(data);
-            }
-            return;
-          case 'structured_data':
-            if (structuredData) {
-              resultAggregator.addSkillEvent(data);
-            }
-            return;
-          case 'artifact':
-            this.logger.info(`artifact event received: ${JSON.stringify(artifact)}`);
-            return;
-          case 'error':
-            result.errors.push(data.content);
-            return;
-        }
-      },
-    });
-
-    const skill = this.skillInventory.find((s) => s.name === data.skillName);
-
-    let runMeta: SkillRunnableMeta | null = null;
-    const basicUsageData = {
-      uid: user.uid,
-      resultId,
-      actionMeta,
-    };
-
-    if (res) {
-      writeSSEResponse(res, { event: 'start', resultId, version });
-    }
 
     // Consolidated cleanup function to handle ALL timeout intervals and resources
     let cleanupExecuted = false;
@@ -934,48 +892,116 @@ export class SkillInvokerService {
     // Register cleanup on abort signal
     abortController.signal.addEventListener('abort', performCleanup);
 
-    // Start the timeout check when we begin streaming (only if timeout is enabled)
-    if (streamIdleTimeout > 0) {
-      startTimeoutCheck();
-    }
-
-    // Create Langfuse callback handler if baseUrl is configured
-    // New @langfuse/langchain v4 API: simpler initialization, trace ID via runId parameter
-    const callbacks = [];
-    const langfuseBaseUrl = this.config.get<string>('langfuse.baseUrl');
-    if (langfuseBaseUrl) {
-      try {
-        const handler = this.createLangfuseHandler({
-          sessionId: data.target?.entityId,
-          userId: user.uid,
-          skillName: data.skillName,
-          mode: data.mode,
-        });
-        callbacks.push(handler);
-      } catch (err) {
-        this.logger.warn(`Failed to create Langfuse callback handler: ${err.message}`);
-      }
-    }
-
-    // Track latest tool call metadata for error handling
-    let _lastStepName: string | undefined;
-    let _lastToolCallMeta: ToolCallMeta | undefined;
-
-    // PTC polling manager for execute_code tools
-    // Declared outside try block so finally can clean up even if early error occurs
-    const ptcPollerManager = new PtcPollerManager(
-      {
-        res,
-        resultId,
-        version,
-        messageAggregator,
-        getRunMeta: () => runMeta,
-      },
-      this.toolCallService,
-      this.logger,
-    );
-
     try {
+      resultAggregator = new ResultAggregator(this.stepService, resultId, version);
+      messageAggregator = new MessageAggregator(resultId, version, this.prisma);
+
+      // Initialize structuredData with original query if available
+      const originalQuery = data.input?.originalQuery;
+      if (originalQuery) {
+        resultAggregator.addSkillEvent({
+          event: 'structured_data',
+          resultId,
+          step: { name: 'start' },
+          structuredData: {
+            query: originalQuery, // Store original query in structuredData
+            processedQuery: data.input?.query, // Store processed query for reference
+          },
+        });
+      }
+
+      const built = await this.buildInvokeConfig(user, {
+        ...data,
+        eventListener: async (data: SkillEvent) => {
+          if (abortController.signal.aborted) {
+            this.logger.warn(`skill invocation aborted, ignore event: ${JSON.stringify(data)}`);
+            return;
+          }
+
+          // Record output event for simple timeout tracking
+          lastOutputTime = Date.now();
+          hasAnyOutput = true;
+
+          if (res) {
+            writeSSEResponse(res, { ...data, resultId, version });
+          }
+
+          const { event, structuredData, artifact, log } = data;
+          switch (event) {
+            case 'log':
+              if (log) {
+                resultAggregator?.addSkillEvent(data);
+              }
+              return;
+            case 'structured_data':
+              if (structuredData) {
+                resultAggregator?.addSkillEvent(data);
+              }
+              return;
+            case 'artifact':
+              this.logger.info(`artifact event received: ${JSON.stringify(artifact)}`);
+              return;
+            case 'error':
+              result.errors.push(data.content);
+              return;
+          }
+        },
+      });
+      config = built.config;
+      cleanupResources = built.cleanupResources;
+
+      const skill = this.skillInventory.find((s) => s.name === data.skillName);
+
+      const basicUsageData = {
+        uid: user.uid,
+        resultId,
+        actionMeta,
+      };
+
+      if (res) {
+        writeSSEResponse(res, { event: 'start', resultId, version });
+      }
+
+      // Start the timeout check when we begin streaming (only if timeout is enabled)
+      if (streamIdleTimeout > 0) {
+        startTimeoutCheck();
+      }
+
+      // Create Langfuse callback handler if baseUrl is configured
+      // New @langfuse/langchain v4 API: simpler initialization, trace ID via runId parameter
+      const callbacks = [];
+      const langfuseBaseUrl = this.config.get<string>('langfuse.baseUrl');
+      if (langfuseBaseUrl) {
+        try {
+          const handler = this.createLangfuseHandler({
+            sessionId: data.target?.entityId,
+            userId: user.uid,
+            skillName: data.skillName,
+            mode: data.mode,
+          });
+          callbacks.push(handler);
+        } catch (err) {
+          this.logger.warn(`Failed to create Langfuse callback handler: ${err.message}`);
+        }
+      }
+
+      // Track latest tool call metadata for error handling
+      let _lastStepName: string | undefined;
+      let _lastToolCallMeta: ToolCallMeta | undefined;
+
+      // PTC polling manager for execute_code tools
+      ptcPollerManager = new PtcPollerManager(
+        {
+          res,
+          resultId,
+          version,
+          messageAggregator,
+          getRunMeta: () => runMeta,
+        },
+        this.toolCallService,
+        this.logger,
+      );
+
       // Check if already aborted before starting execution (handles queued aborts)
       const isAlreadyAborted = await this.actionService.isAbortRequested(resultId, version);
       if (isAlreadyAborted) {
@@ -1659,17 +1685,26 @@ export class SkillInvokerService {
       result.errorType = finalErrorType;
       result.errors.push(finalErrorMessage);
     } finally {
-      // Cleanup all timers and resources to prevent memory leaks
-      // Note: consolidated abort signal listener handles cleanup for early abort scenarios
+      // --- Resource release FIRST (must not be skipped by persistence failures) ---
 
-      // Perform cleanup for normal completion or exception scenarios
-      // (redundant with abort listener but ensures cleanup in all cases)
+      // Close MCP clients / tool resources before any DB/SSE work
+      if (cleanupResources) {
+        try {
+          await cleanupResources();
+        } catch (cleanupError) {
+          this.logger.error(
+            `Failed to cleanup skill resources for ${resultId}: ${(cleanupError as Error)?.message}`,
+          );
+        }
+      }
+
+      // Stop abort/timeout intervals
       if (!cleanupExecuted) {
         performCleanup();
       }
 
-      // Cleanup all PTC pollers
-      ptcPollerManager.cleanup();
+      // Cleanup PTC pollers
+      ptcPollerManager?.cleanup();
 
       // Unregister the abort controller
       this.actionService.unregisterAbortController(resultId);
@@ -1682,136 +1717,203 @@ export class SkillInvokerService {
         artifact.connection?.disconnect();
       }
 
-      // Flush all pending messages to the database
-      await messageAggregator.flush();
+      // Stop MessageAggregator auto-save timer even if flush/persist fails below
+      try {
+        messageAggregator?.dispose();
+      } catch (disposeError) {
+        this.logger.error(
+          `Failed to dispose messageAggregator for ${resultId}: ${(disposeError as Error)?.message}`,
+        );
+      }
 
-      const steps = await resultAggregator.getSteps({ resultId, version });
-      // Get only unpersisted messages (those that failed during auto-save)
-      const messages = messageAggregator.getUnpersistedMessagesAsPrismaInput();
-      const status = result.errors.length > 0 ? 'failed' : 'finish';
+      // Clean up added files map for this result to prevent memory leak
+      for (const key of this.addedFilesMap.keys()) {
+        if (key.startsWith(`${resultId}:`)) {
+          this.addedFilesMap.delete(key);
+        }
+      }
+    }
 
-      this.logger.info(
-        `Persisting ${steps.length} steps and ${messages.length} unpersisted messages for result ${resultId}`,
-      );
+    // --- Required persistence AFTER resource-cleanup finally (no throw/return from finally) ---
+    const status = result.errors.length > 0 ? 'failed' : 'finish';
+    // Use || instead of ?? to ensure errorType is never empty string
+    const errorType = status === 'failed' ? result.errorType || 'systemError' : null;
+    // Successful path must store []; setup-failure message only when status is failed and errors empty
+    const errorsJson =
+      status === 'failed' && result.errors.length === 0
+        ? JSON.stringify(['Skill invocation failed during setup'])
+        : JSON.stringify(result.errors);
 
-      await this.prisma.$transaction([
-        this.prisma.actionStep.createMany({ data: steps }),
-        // Persist remaining unpersisted messages to action_messages table
-        // Use skipDuplicates to handle cases where messages were already auto-saved
-        ...(messages.length > 0
-          ? [this.prisma.actionMessage.createMany({ data: messages, skipDuplicates: true })]
-          : []),
-        ...(result.workflowNodeExecutionId
-          ? [
-              this.prisma.workflowNodeExecution.updateMany({
-                where: { nodeExecutionId: result.workflowNodeExecutionId },
-                data: { status, errorMessage: JSON.stringify(result.errors), endTime: new Date() },
-              }),
-            ]
-          : []),
-        this.prisma.actionResult.updateMany({
-          where: { resultId, version },
-          data: {
-            status,
-            // Use || instead of ?? to ensure errorType is never empty string
-            // If status is failed, use result.errorType (which should always be set now), fallback to 'systemError'
-            errorType: status === 'failed' ? result.errorType || 'systemError' : null,
-            errors: JSON.stringify(result.errors),
-            ptcEnabled: config.configurable.ptcEnabled ?? false,
-          },
-        }),
-      ]);
+    try {
+      if (messageAggregator && resultAggregator && config) {
+        // Flush all pending messages to the database
+        await messageAggregator.flush();
 
-      // Sync workflow node status to canvas after execution completes
-      if (result.workflowNodeExecutionId) {
-        try {
-          const nodeExecution = await this.prisma.workflowNodeExecution.findUnique({
-            where: { nodeExecutionId: result.workflowNodeExecutionId },
-            select: { canvasId: true, nodeId: true },
-          });
+        const steps = await resultAggregator.getSteps({ resultId, version });
+        // Get only unpersisted messages (those that failed during auto-save)
+        const messages = messageAggregator.getUnpersistedMessagesAsPrismaInput();
 
-          if (nodeExecution?.canvasId && nodeExecution?.nodeId) {
-            const nodeDiff: NodeDiff = {
-              type: 'update',
-              id: nodeExecution.nodeId,
-              to: {
-                data: {
-                  metadata: {
+        this.logger.info(
+          `Persisting ${steps.length} steps and ${messages.length} unpersisted messages for result ${resultId}`,
+        );
+
+        await this.prisma.$transaction([
+          this.prisma.actionStep.createMany({ data: steps }),
+          // Persist remaining unpersisted messages to action_messages table
+          // Use skipDuplicates to handle cases where messages were already auto-saved
+          ...(messages.length > 0
+            ? [this.prisma.actionMessage.createMany({ data: messages, skipDuplicates: true })]
+            : []),
+          ...(result.workflowNodeExecutionId
+            ? [
+                this.prisma.workflowNodeExecution.updateMany({
+                  where: { nodeExecutionId: result.workflowNodeExecutionId },
+                  data: {
                     status,
+                    errorMessage: errorsJson,
+                    endTime: new Date(),
                   },
+                }),
+              ]
+            : []),
+          this.prisma.actionResult.updateMany({
+            where: { resultId, version },
+            data: {
+              status,
+              errorType,
+              errors: errorsJson,
+              ptcEnabled: config.configurable.ptcEnabled ?? false,
+            },
+          }),
+        ]);
+      } else {
+        // Setup failed before config/aggregators were ready — still mark action terminal
+        // so BullMQ success does not leave the row stuck in "executing".
+        this.logger.warn(
+          `Persisting minimal failed status for ${resultId} (setup incomplete: aggregator/config missing)`,
+        );
+        await this.prisma.$transaction([
+          this.prisma.actionResult.updateMany({
+            where: { resultId, version, status: { notIn: ['finish', 'failed'] } },
+            data: {
+              status: 'failed',
+              errorType: errorType || 'systemError',
+              errors: errorsJson,
+            },
+          }),
+          ...(result.workflowNodeExecutionId
+            ? [
+                this.prisma.workflowNodeExecution.updateMany({
+                  where: { nodeExecutionId: result.workflowNodeExecutionId },
+                  data: {
+                    status: 'failed',
+                    errorMessage: errorsJson,
+                    endTime: new Date(),
+                  },
+                }),
+              ]
+            : []),
+        ]);
+      }
+    } catch (persistError) {
+      this.logger.error(
+        `Failed required post-invoke persistence for ${resultId}: ${(persistError as Error)?.stack ?? persistError}`,
+      );
+      // Last-ditch terminal status so the action is not left executing
+      try {
+        await this.prisma.actionResult.updateMany({
+          where: { resultId, version, status: { notIn: ['finish', 'failed'] } },
+          data: {
+            status: 'failed',
+            errorType: 'systemError',
+            errors: JSON.stringify([
+              (persistError as Error)?.message || 'Failed to persist skill result',
+            ]),
+          },
+        });
+      } catch (fallbackError) {
+        this.logger.error(
+          `Failed fallback status update for ${resultId}: ${(fallbackError as Error)?.message}`,
+        );
+      }
+      try {
+        writeSSEResponse(res, { event: 'end', resultId, version });
+      } catch {
+        // ignore SSE failures during cleanup
+      }
+      // Propagate so queue workers can fail the job (streamInvokeSkill rethrows when !res)
+      throw persistError;
+    }
+
+    // Best-effort side effects — failures here must not undo required status persistence
+    try {
+      if (result.workflowNodeExecutionId) {
+        const nodeExecution = await this.prisma.workflowNodeExecution.findUnique({
+          where: { nodeExecutionId: result.workflowNodeExecutionId },
+          select: { canvasId: true, nodeId: true },
+        });
+
+        if (nodeExecution?.canvasId && nodeExecution?.nodeId) {
+          const nodeDiff: NodeDiff = {
+            type: 'update',
+            id: nodeExecution.nodeId,
+            to: {
+              data: {
+                metadata: {
+                  status,
                 },
               },
-            };
+            },
+          };
 
-            await this.canvasSyncService.syncState(user, {
-              canvasId: nodeExecution.canvasId,
-              transactions: [
-                {
-                  txId: genTransactionId(),
-                  createdAt: Date.now(),
-                  syncedAt: Date.now(),
-                  source: { type: 'system' },
-                  nodeDiffs: [nodeDiff],
-                  edgeDiffs: [],
-                },
-              ],
-            });
+          await this.canvasSyncService.syncState(user, {
+            canvasId: nodeExecution.canvasId,
+            transactions: [
+              {
+                txId: genTransactionId(),
+                createdAt: Date.now(),
+                syncedAt: Date.now(),
+                source: { type: 'system' },
+                nodeDiffs: [nodeDiff],
+                edgeDiffs: [],
+              },
+            ],
+          });
 
-            this.logger.debug(
-              `Synced workflow node ${nodeExecution.nodeId} status to canvas ${nodeExecution.canvasId}`,
-            );
-          }
-        } catch (syncError) {
-          // Log but don't fail the skill invocation if canvas sync fails
-          this.logger.error(
-            `Failed to sync workflow node status to canvas: ${(syncError as Error).message}`,
+          this.logger.debug(
+            `Synced workflow node ${nodeExecution.nodeId} status to canvas ${nodeExecution.canvasId}`,
           );
         }
       }
-
-      writeSSEResponse(res, { event: 'end', resultId, version });
 
       // Check if we need to auto-name the target canvas
       if (data.target?.entityType === 'canvas' && !result.errors.length) {
         const canvas = await this.prisma.canvas.findFirst({
           where: { canvasId: data.target.entityId, uid: user.uid },
         });
-        if (canvas && !canvas.title) {
-          if (this.autoNameCanvasQueue) {
-            await this.autoNameCanvasQueue.add('autoNameCanvas', {
-              uid: user.uid,
-              canvasId: canvas.canvasId,
-            });
-          }
-          // In desktop mode, we could handle auto-naming differently if needed
-        }
-      }
-
-      if (tier) {
-        if (this.requestUsageQueue) {
-          await this.requestUsageQueue.add('syncRequestUsage', {
+        if (canvas && !canvas.title && this.autoNameCanvasQueue) {
+          await this.autoNameCanvasQueue.add('autoNameCanvas', {
             uid: user.uid,
-            tier,
-            timestamp: new Date(),
+            canvasId: canvas.canvasId,
           });
         }
-        // In desktop mode, we could handle usage tracking differently if needed
       }
 
-      await resultAggregator.clearCache();
-
-      // Clean up added files map for this result to prevent memory leak
-      // Remove all entries for this resultId
-      for (const key of this.addedFilesMap.keys()) {
-        if (key.startsWith(`${resultId}:`)) {
-          this.addedFilesMap.delete(key);
-        }
+      if (tier && this.requestUsageQueue) {
+        await this.requestUsageQueue.add('syncRequestUsage', {
+          uid: user.uid,
+          tier,
+          timestamp: new Date(),
+        });
       }
-      // Process credit billing for all steps after skill completion
+
+      await resultAggregator?.clearCache();
+
       // Bill credits for successful completions and user aborts (partial usage should be charged)
-      const shouldBillCredits = !result.errors.length || result.errorType === 'userAbort';
+      const shouldBillCredits =
+        !!resultAggregator && (!result.errors.length || result.errorType === 'userAbort');
 
-      if (shouldBillCredits) {
+      if (shouldBillCredits && resultAggregator) {
         await this.processCreditUsageReport(
           user,
           resultId,
@@ -1820,9 +1922,18 @@ export class SkillInvokerService {
           data.providerItem,
         );
       }
+    } catch (sideEffectError) {
+      this.logger.error(
+        `Best-effort post-invoke side effects failed for ${resultId}: ${(sideEffectError as Error)?.stack ?? sideEffectError}`,
+      );
+    }
 
-      // Dispose message aggregator to clean up resources (stop auto-save timer)
-      messageAggregator.dispose();
+    try {
+      writeSSEResponse(res, { event: 'end', resultId, version });
+    } catch (sseError) {
+      this.logger.warn(
+        `Failed to write SSE end for ${resultId}: ${(sseError as Error)?.message ?? sseError}`,
+      );
     }
   }
 
@@ -2198,10 +2309,12 @@ export class SkillInvokerService {
 
     const { resultId, version } = data.result;
 
-    const defaultModel = await this.providerService.findDefaultProviderItem(user, 'chat');
-    this.skillEngine.setOptions({ defaultModel: defaultModel?.name });
-
     try {
+      // Keep provider/default-model setup inside try so failures still terminalize action/workflow
+      // and always hit finally (res.end) / queue rethrow.
+      const defaultModel = await this.providerService.findDefaultProviderItem(user, 'chat');
+      this.skillEngine.setOptions({ defaultModel: defaultModel?.name });
+
       await this._invokeSkill(user, data, res);
     } catch (err) {
       if (res) {
@@ -2215,14 +2328,37 @@ export class SkillInvokerService {
       }
       this.logger.error(`invoke skill error: ${err.stack}`);
 
-      await this.prisma.actionResult.updateMany({
-        where: { resultId, version, status: { notIn: ['finish', 'failed'] } },
-        data: {
-          status: 'failed',
-          errorType: 'systemError',
-          errors: JSON.stringify([err.message]),
-        },
-      });
+      try {
+        await this.prisma.actionResult.updateMany({
+          where: { resultId, version, status: { notIn: ['finish', 'failed'] } },
+          data: {
+            status: 'failed',
+            errorType: 'systemError',
+            errors: JSON.stringify([err.message]),
+          },
+        });
+        // Also terminalize workflow node if present (outer fallback for pre-try setup failures)
+        if (data.result?.workflowNodeExecutionId) {
+          await this.prisma.workflowNodeExecution.updateMany({
+            where: { nodeExecutionId: data.result.workflowNodeExecutionId },
+            data: {
+              status: 'failed',
+              errorMessage: JSON.stringify([err.message]),
+              endTime: new Date(),
+            },
+          });
+        }
+      } catch (statusError) {
+        this.logger.error(
+          `Failed to mark action failed after invoke error: ${(statusError as Error)?.message}`,
+        );
+      }
+
+      // Queue path (!res): rethrow so BullMQ marks the job failed and can retry.
+      // HTTP SSE path: status already written; do not rethrow (client already got error event).
+      if (!res) {
+        throw err;
+      }
     } finally {
       if (res) {
         res.end('');

--- a/apps/api/src/modules/skill/skill-invoker.service.ts
+++ b/apps/api/src/modules/skill/skill-invoker.service.ts
@@ -1706,15 +1706,27 @@ export class SkillInvokerService {
       // Cleanup PTC pollers
       ptcPollerManager?.cleanup();
 
-      // Unregister the abort controller
-      this.actionService.unregisterAbortController(resultId);
+      // Unregister the abort controller (must not throw past finally into skipped persistence)
+      try {
+        this.actionService.unregisterAbortController(resultId);
+      } catch (unregisterError) {
+        this.logger.error(
+          `Failed to unregister abort controller for ${resultId}: ${(unregisterError as Error)?.message}`,
+        );
+      }
 
       // Note: @langfuse/langchain v4 CallbackHandler creates OTEL spans via startAndRegisterOtelSpan()
       // These spans are processed by LangfuseSpanProcessor which handles batching and export
       // No manual flush needed - the span processor has its own export interval
 
       for (const artifact of Object.values(artifactMap)) {
-        artifact.connection?.disconnect();
+        try {
+          artifact.connection?.disconnect();
+        } catch (disconnectError) {
+          this.logger.error(
+            `Failed to disconnect artifact connection for ${resultId}: ${(disconnectError as Error)?.message}`,
+          );
+        }
       }
 
       // Stop MessageAggregator auto-save timer even if flush/persist fails below
@@ -1836,16 +1848,14 @@ export class SkillInvokerService {
           `Failed fallback status update for ${resultId}: ${(fallbackError as Error)?.message}`,
         );
       }
-      try {
-        writeSSEResponse(res, { event: 'end', resultId, version });
-      } catch {
-        // ignore SSE failures during cleanup
-      }
+      // Do not emit SSE `end` here — streamInvokeSkill catch emits `error` on HTTP path.
+      // Emitting `end` first would mark the client action finished before the error event.
       // Propagate so queue workers can fail the job (streamInvokeSkill rethrows when !res)
       throw persistError;
     }
 
-    // Best-effort side effects — failures here must not undo required status persistence
+    // Best-effort side effects — failures here must not undo required status persistence.
+    // Canvas sync is isolated so a collab failure cannot skip usage/billing/cache cleanup.
     try {
       if (result.workflowNodeExecutionId) {
         const nodeExecution = await this.prisma.workflowNodeExecution.findUnique({
@@ -1885,7 +1895,13 @@ export class SkillInvokerService {
           );
         }
       }
+    } catch (canvasSyncError) {
+      this.logger.error(
+        `Best-effort canvas status sync failed for ${resultId}: ${(canvasSyncError as Error)?.stack ?? canvasSyncError}`,
+      );
+    }
 
+    try {
       // Check if we need to auto-name the target canvas
       if (data.target?.entityType === 'canvas' && !result.errors.length) {
         const canvas = await this.prisma.canvas.findFirst({

--- a/apps/api/src/modules/skill/skill-invoker.service.ts
+++ b/apps/api/src/modules/skill/skill-invoker.service.ts
@@ -1901,6 +1901,16 @@ export class SkillInvokerService {
       );
     }
 
+    // Terminal SSE event immediately after required persistence (+ canvas sync).
+    // Do not wait for auto-name / usage / billing — clients stop polling on `end`.
+    try {
+      writeSSEResponse(res, { event: 'end', resultId, version });
+    } catch (sseError) {
+      this.logger.warn(
+        `Failed to write SSE end for ${resultId}: ${(sseError as Error)?.message ?? sseError}`,
+      );
+    }
+
     try {
       // Check if we need to auto-name the target canvas
       if (data.target?.entityType === 'canvas' && !result.errors.length) {
@@ -1941,14 +1951,6 @@ export class SkillInvokerService {
     } catch (sideEffectError) {
       this.logger.error(
         `Best-effort post-invoke side effects failed for ${resultId}: ${(sideEffectError as Error)?.stack ?? sideEffectError}`,
-      );
-    }
-
-    try {
-      writeSSEResponse(res, { event: 'end', resultId, version });
-    } catch (sseError) {
-      this.logger.warn(
-        `Failed to write SSE end for ${resultId}: ${(sseError as Error)?.message ?? sseError}`,
       );
     }
   }

--- a/apps/api/src/modules/tool/ptc/ptc-env.service.ts
+++ b/apps/api/src/modules/tool/ptc/ptc-env.service.ts
@@ -22,6 +22,8 @@ interface CachedApiKey {
 
 /** Cache TTL: 12 hours (leaves buffer before the 1-day key expiration) */
 const API_KEY_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
+/** Hard cap on cached entries (evict oldest when exceeded) */
+const API_KEY_CACHE_MAX_SIZE = 500;
 
 @Injectable()
 export class PtcEnvService {
@@ -69,16 +71,43 @@ export class PtcEnvService {
    * Get a cached API key for the user, or create a new one if expired/missing.
    */
   private async getOrCreateApiKey(uid: string): Promise<string> {
+    this.evictApiKeyCache();
+
     const cached = this.apiKeyCache.get(uid);
     if (cached && Date.now() - cached.createdAt < API_KEY_CACHE_TTL_MS) {
+      // Refresh insertion order for LRU-ish eviction (Map preserves order)
+      this.apiKeyCache.delete(uid);
+      this.apiKeyCache.set(uid, cached);
       return cached.apiKey;
+    }
+    if (cached) {
+      this.apiKeyCache.delete(uid);
     }
 
     const sessionName = `PTC_SESSION_${uid}`;
     const created = await this.apiKeyService.createApiKey(uid, sessionName, 1);
 
     this.apiKeyCache.set(uid, { apiKey: created.apiKey, createdAt: Date.now() });
+    this.evictApiKeyCache();
 
     return created.apiKey;
+  }
+
+  /** Drop expired entries, then oldest entries if still over the hard cap. */
+  private evictApiKeyCache(): void {
+    const now = Date.now();
+    for (const [cachedUid, entry] of this.apiKeyCache) {
+      if (now - entry.createdAt >= API_KEY_CACHE_TTL_MS) {
+        this.apiKeyCache.delete(cachedUid);
+      }
+    }
+
+    while (this.apiKeyCache.size > API_KEY_CACHE_MAX_SIZE) {
+      const oldestKey = this.apiKeyCache.keys().next().value as string | undefined;
+      if (oldestKey === undefined) {
+        break;
+      }
+      this.apiKeyCache.delete(oldestKey);
+    }
   }
 }

--- a/apps/api/src/modules/tool/tool.service.ts
+++ b/apps/api/src/modules/tool/tool.service.ts
@@ -1116,13 +1116,14 @@ export class ToolService {
         this.composioService.instantiateToolsets(user, toolsets, 'oauth'),
       ]);
     } catch (error) {
-      // If MCP connected but regular/oauth failed, Promise.all rejects without returning cleanup
-      try {
-        const opened = await mcpResultPromise;
-        await opened.cleanup();
-      } catch {
-        // Prefer the original Promise.all error
-      }
+      // If MCP connected but regular/oauth failed, Promise.all rejects without returning cleanup.
+      // Do not await MCP startup here — a slow/unreachable MCP would block the already-known
+      // sibling error. Attach eventual cleanup in the background.
+      void mcpResultPromise
+        .then((opened) => opened.cleanup())
+        .catch(() => {
+          // Prefer the original Promise.all error; cleanup failures are best-effort
+        });
       throw error;
     }
 

--- a/apps/api/src/modules/tool/tool.service.ts
+++ b/apps/api/src/modules/tool/tool.service.ts
@@ -69,6 +69,8 @@ export interface InstantiatedTools {
   builtInToolsets: GenericToolset[];
   // Non-builtin toolsets (regular + MCP + OAuth)
   nonBuiltInToolsets: GenericToolset[];
+  /** Release long-lived resources (e.g. MCP clients). Safe to call multiple times. */
+  cleanup?: () => Promise<void>;
 }
 
 @Injectable()
@@ -1100,17 +1102,35 @@ export class ToolService {
     const regularToolsets = toolsets.filter((t) => t.type === ToolsetType.REGULAR && !t.builtin);
     const mcpServers = toolsets.filter((t) => t.type === ToolsetType.MCP);
 
-    const [regularTools, mcpTools, oauthToolsets] = await Promise.all([
-      this.instantiateRegularToolsets(user, regularToolsets, engine, options),
-      this.instantiateMcpServers(user, mcpServers),
-      this.composioService.instantiateToolsets(user, toolsets, 'oauth'),
-    ]);
+    // Keep MCP promise separate so a sibling failure can still close an opened client
+    const mcpResultPromise = this.instantiateMcpServers(user, mcpServers);
+
+    let regularTools: StructuredToolInterface[] = [];
+    let mcpResult: { tools: StructuredToolInterface[]; cleanup: () => Promise<void> };
+    let oauthToolsets: StructuredToolInterface[] = [];
+
+    try {
+      [regularTools, mcpResult, oauthToolsets] = await Promise.all([
+        this.instantiateRegularToolsets(user, regularToolsets, engine, options),
+        mcpResultPromise,
+        this.composioService.instantiateToolsets(user, toolsets, 'oauth'),
+      ]);
+    } catch (error) {
+      // If MCP connected but regular/oauth failed, Promise.all rejects without returning cleanup
+      try {
+        const opened = await mcpResultPromise;
+        await opened.cleanup();
+      } catch {
+        // Prefer the original Promise.all error
+      }
+      throw error;
+    }
 
     // Categorize tools: builtIn (builtin + copilot) and nonBuiltIn (regular + MCP + OAuth)
     const builtIn = [...builtinTools, ...copilotTools];
     const nonBuiltIn = [
       ...(Array.isArray(regularTools) ? regularTools : []),
-      ...(Array.isArray(mcpTools) ? mcpTools : []),
+      ...(Array.isArray(mcpResult.tools) ? mcpResult.tools : []),
       ...(Array.isArray(oauthToolsets) ? oauthToolsets : []),
     ];
     const all = [...builtIn, ...nonBuiltIn];
@@ -1132,6 +1152,7 @@ export class ToolService {
       nonBuiltIn,
       builtInToolsets,
       nonBuiltInToolsets,
+      cleanup: mcpResult.cleanup,
     };
   }
 
@@ -1437,13 +1458,16 @@ export class ToolService {
 
   /**
    * Instantiate selected MCP servers into structured tools, by creating a MCP client and getting the tools.
+   * Caller must invoke `cleanup` after the skill finishes so the MCP client/sockets are released.
    */
   private async instantiateMcpServers(
     user: User,
     mcpServers: GenericToolset[],
-  ): Promise<StructuredToolInterface[]> {
+  ): Promise<{ tools: StructuredToolInterface[]; cleanup: () => Promise<void> }> {
+    const noopCleanup = async () => undefined;
+
     if (!mcpServers?.length) {
-      return [];
+      return { tools: [], cleanup: noopCleanup };
     }
 
     const mcpServerNames = mcpServers.map((s) => s.name);
@@ -1451,8 +1475,21 @@ export class ToolService {
       .listMcpServers(user, { enabled: true })
       .then((data) => data.filter((item) => mcpServerNames.includes(item.name)));
 
-    // TODO: should return cleanup function to close the client
     let tempMcpClient: MultiServerMCPClient | undefined;
+    let closed = false;
+    const closeClient = async (reason: string) => {
+      if (!tempMcpClient || closed) {
+        return;
+      }
+      try {
+        await tempMcpClient.close();
+        closed = true;
+      } catch (closeError) {
+        // Allow a later cleanup attempt if close failed (e.g. transient transport error)
+        this.logger.error(`Error closing MCP client (${reason}):`, closeError);
+        throw closeError;
+      }
+    };
 
     try {
       // Pass mcpServersResponse (which is ListMcpServersResponse) to convertMcpServersToClientConfig
@@ -1469,37 +1506,27 @@ export class ToolService {
         this.logger.warn(
           `No MCP tools found for user ${user.uid} after initializing client. Proceeding without MCP tools.`,
         );
-        if (tempMcpClient) {
-          await tempMcpClient
-            .close()
-            .catch((closeError) =>
-              this.logger.error(
-                'Error closing MCP client when no tools found after connection:',
-                closeError,
-              ),
-            );
-        }
-      } else {
-        this.logger.log(
-          `Loaded ${toolsFromMcp.length} MCP tools: ${toolsFromMcp
-            .map((tool) => tool.name)
-            .join(', ')}`,
-        );
+        await closeClient('no tools found after connection');
+        return { tools: [], cleanup: noopCleanup };
       }
 
-      return toolsFromMcp;
+      this.logger.log(
+        `Loaded ${toolsFromMcp.length} MCP tools: ${toolsFromMcp
+          .map((tool) => tool.name)
+          .join(', ')}`,
+      );
+
+      // Keep client open while tools are in use; skill-invoker finally calls cleanup.
+      return {
+        tools: toolsFromMcp,
+        cleanup: () => closeClient('skill invoke finished'),
+      };
     } catch (mcpError) {
       this.logger.error(
         `Error during MCP client operation (initializeConnections or getTools): ${mcpError?.stack}`,
       );
-      if (tempMcpClient) {
-        await tempMcpClient
-          .close()
-          .catch((closeError) =>
-            this.logger.error('Error closing MCP client after operation failure:', closeError),
-          );
-      }
-      return [];
+      await closeClient('operation failure');
+      return { tools: [], cleanup: noopCleanup };
     }
   }
 

--- a/apps/api/src/modules/tool/tool.service.ts
+++ b/apps/api/src/modules/tool/tool.service.ts
@@ -1525,7 +1525,11 @@ export class ToolService {
       this.logger.error(
         `Error during MCP client operation (initializeConnections or getTools): ${mcpError?.stack}`,
       );
-      await closeClient('operation failure');
+      // Terminal failure path: close best-effort; do not let close errors abort skill invoke
+      // (previous behavior degraded to empty MCP tools).
+      await closeClient('operation failure').catch(() => {
+        // Already logged in closeClient
+      });
       return { tools: [], cleanup: noopCleanup };
     }
   }

--- a/apps/api/src/tracer.ts
+++ b/apps/api/src/tracer.ts
@@ -69,7 +69,14 @@ export function initTracer(): void {
   // OTLP trace exporter for Tempo/Grafana - receives all spans
   if (otlp.tracesUrl) {
     const traceExporter = new OTLPTraceExporter({ url: otlp.tracesUrl });
-    spanProcessors.push(new BatchSpanProcessor(traceExporter));
+    // Bound in-process span queues to limit RSS growth under backpressure
+    spanProcessors.push(
+      new BatchSpanProcessor(traceExporter, {
+        maxQueueSize: 2048,
+        maxExportBatchSize: 512,
+        scheduledDelayMillis: 5000,
+      }),
+    );
   }
 
   // Langfuse processor - receives filtered LLM spans only
@@ -93,7 +100,15 @@ export function initTracer(): void {
   sdk = new NodeSDK({
     spanProcessors: spanProcessors.length > 0 ? spanProcessors : undefined,
     metricReader,
-    instrumentations: [getNodeAutoInstrumentations()],
+    instrumentations: [
+      getNodeAutoInstrumentations({
+        // High-cardinality / high-volume instrumentations that inflate RSS without much product value
+        '@opentelemetry/instrumentation-fs': { enabled: false },
+        '@opentelemetry/instrumentation-dns': { enabled: false },
+        '@opentelemetry/instrumentation-net': { enabled: false },
+        '@opentelemetry/instrumentation-generic-pool': { enabled: false },
+      }),
+    ],
     resource: resourceFromAttributes({
       [ATTR_SERVICE_NAME]: 'reflyd',
     }),

--- a/apps/api/src/utils/filters/global-exception.filter.ts
+++ b/apps/api/src/utils/filters/global-exception.filter.ts
@@ -15,6 +15,7 @@ import { getRPCMetadata, RPCType } from '@opentelemetry/core';
 import * as Sentry from '@sentry/node';
 import { OAuthError, UnknownError } from '@refly/errors';
 import { genBaseRespDataFromError } from '../exception';
+import { isSentryEnabled } from '../sentry';
 import { User } from '@prisma/client';
 
 @Catch()
@@ -108,12 +109,14 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     }
 
     if (baseRespData.errCode === new UnknownError().code) {
-      Sentry.captureException(exception, {
-        user: {
-          id: user?.uid,
-          email: user?.email,
-        },
-      });
+      if (isSentryEnabled()) {
+        Sentry.captureException(exception, {
+          user: {
+            id: user?.uid,
+            email: user?.email,
+          },
+        });
+      }
 
       const safeBody = this.getSafeBodyForLogging(request.body);
       this.logger.error(

--- a/apps/api/src/utils/sentry.ts
+++ b/apps/api/src/utils/sentry.ts
@@ -1,0 +1,19 @@
+/**
+ * Sentry is opt-in to avoid production RSS growth from 100% traces/profiles.
+ * Enable with SENTRY_ENABLED=true and a non-empty SENTRY_DSN.
+ */
+export function isSentryEnabled(): boolean {
+  return process.env.SENTRY_ENABLED === 'true' && Boolean(process.env.SENTRY_DSN?.trim());
+}
+
+export function getSentryTracesSampleRate(): number {
+  const raw = Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? '0.05');
+  if (!Number.isFinite(raw)) return 0.05;
+  return Math.min(1, Math.max(0, raw));
+}
+
+export function getSentryProfilesSampleRate(): number {
+  const raw = Number(process.env.SENTRY_PROFILES_SAMPLE_RATE ?? '0');
+  if (!Number.isFinite(raw)) return 0;
+  return Math.min(1, Math.max(0, raw));
+}

--- a/deploy/docker/env.example
+++ b/deploy/docker/env.example
@@ -174,9 +174,14 @@ OTLP_METRICS_INTERVAL_MS=60000
 LANGFUSE_PUBLIC_KEY=pk-lf-dev
 LANGFUSE_SECRET_KEY=sk-lf-dev
 
-# Sentry Configuration (Error Tracking)
+# Sentry Configuration (Error Tracking) — opt-in
+# Requires BOTH SENTRY_ENABLED=true and a non-empty SENTRY_DSN.
 # Get your DSN from https://sentry.io/
+# SENTRY_ENABLED=false
 # SENTRY_DSN=https://xxx@xxx.ingest.sentry.io/xxx
+# SENTRY_TRACES_SAMPLE_RATE=0.05
+# SENTRY_PROFILES_SAMPLE_RATE=0
+
 
 # Statsig Configuration (Feature Flags & Analytics)
 # Get your key from https://console.statsig.com/


### PR DESCRIPTION
## Summary

Mitigates production `refly-api` Node RSS growth (pods climbing toward `--max-old-space-size=3072`).

- **Sentry opt-in**: only initializes when `SENTRY_ENABLED=true` and `SENTRY_DSN` is set (default off). Optional `SENTRY_TRACES_SAMPLE_RATE` / `SENTRY_PROFILES_SAMPLE_RATE`.
- **MCP client cleanup**: successful MCP tool loads return a `cleanup()`; skill invoke always releases it. Sibling `Promise.all` failures also close opened MCP clients.
- **Skill lifecycle**: resource release (MCP, intervals, PTC, abort controller, message aggregator) runs in `finally` first; required DB status persistence runs after; queue path (`!res`) rethrows so BullMQ can fail/retry.
- **OTEL**: disable high-volume `fs`/`dns`/`net`/`generic-pool` auto-instrumentations; bound span batch queue.
- **Prisma**: production write logs no longer include query params (tokens/PII).
- **Other**: collab `modifyDocument` disconnects direct connections; PTC API key cache hard-capped at 500; env examples updated.

## Production notes

- Existing prod has `SENTRY_DSN` only → after deploy Sentry is **off** until `SENTRY_ENABLED=true` is set.
- Restart pods after deploy; already-leaked RSS is not reclaimed by code alone.
- `IMAGE_PAYLOAD_MODE` default remains `base64` (current skill images use `DRIVE_PAYLOAD_MODE`).

## Test plan

- [ ] Deploy to staging/canary and compare `container_memory_working_set_bytes` growth rate vs baseline (young pod should not climb ~100+ MiB/h toward 3Gi as fast)
- [ ] Confirm Sentry is silent without `SENTRY_ENABLED=true`
- [ ] With `SENTRY_ENABLED=true`, confirm errors still report at reduced sample rates
- [ ] Skill invoke with MCP toolset: connections close after finish/fail (no FD/socket growth)
- [ ] Skill invoke failure / setup failure: `actionResult` reaches `failed` (not stuck `executing`)
- [ ] Queue skill job persistence failure: BullMQ job fails (not silent success)
- [ ] Normal skill success path: status `finish`, `errors` is `[]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved skill execution reliability with stricter resource cleanup and safer persistence/termination handling.
  - Added safer collaborative document connection lifecycle management.
  - Tightened MCP tool cleanup to reduce leaked connections.
- **Security & Privacy**
  - Production database query logging no longer records query parameters.
- **Configuration**
  - Sentry is now opt-in, with conditional error reporting and configurable tracing/profiling sampling.
  - Updated example environment files with clearer Sentry setup guidance.
- **Performance**
  - Added bounded per-UID API key cache eviction (TTL + max-size).
  - Reduced high-volume telemetry from selected auto-instrumentation sources.
  - Tuned OTLP trace batching/export backpressure settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->