### PR TITLE
fix(ci): deploy prod from explicit ref instead of Orbit release

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -51,17 +51,22 @@ jobs:
         env:
           AWS_REGION: ${{ inputs.aws_region }}
         run: |
+          # Tag from the checked-out commit, not github.sha (caller workflow SHA).
+          # Otherwise deploying ref=release/* can silently reuse main's nightly image.
+          COMMIT_SHA="$(git rev-parse HEAD)"
           ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
           REGISTRY="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
           REPOSITORY="${REGISTRY}/refly-api"
-          IMAGE_TAG="${{ inputs.environment }}-${{ github.sha }}"
+          IMAGE_TAG="${{ inputs.environment }}-${COMMIT_SHA}"
           TAGS="${REPOSITORY}:${IMAGE_TAG}"
+          echo "Checked out commit: ${COMMIT_SHA}"
+          echo "Image tag: ${IMAGE_TAG}"
           echo "registry=$REGISTRY" >> "$GITHUB_OUTPUT"
           echo "repository=$REPOSITORY" >> "$GITHUB_OUTPUT"
           echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
           echo "deploy_image=${REPOSITORY}:${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
-          echo "nightly_tag=nightly-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "nightly_tag=nightly-${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Check for existing images
         id: check_image

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -9,16 +9,17 @@ on:
         type: string
         default: main
 
+# Default least privilege; deploy jobs elevate only what they need.
 permissions:
-  id-token: write
   contents: read
-  actions: write
 
 jobs:
   resolve-ref:
     name: Resolve Deploy Ref
     runs-on: ubuntu-latest
     if: github.repository == 'refly-ai/refly'
+    permissions:
+      contents: read
     outputs:
       ref: ${{ steps.resolve.outputs.ref }}
       sha: ${{ steps.resolve.outputs.sha }}
@@ -32,10 +33,11 @@ jobs:
 
       - name: Resolve commit SHA
         id: resolve
+        env:
+          REQUESTED_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
 
-          REQUESTED_REF="${{ inputs.ref }}"
           SHA="$(git rev-parse HEAD)"
           SHORT_SHA="$(git rev-parse --short=12 HEAD)"
           SUBJECT="$(git log -1 --format='%s')"
@@ -61,6 +63,9 @@ jobs:
   deploy-api-prod:
     name: Deploy API to Production
     needs: resolve-ref
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/deploy-api-prod.yml
     with:
       ref: ${{ needs.resolve-ref.outputs.sha }}
@@ -69,6 +74,8 @@ jobs:
   deploy-web-prod:
     name: Deploy Web to Production
     needs: [resolve-ref, deploy-api-prod]
+    permissions:
+      contents: read
     uses: ./.github/workflows/deploy-web-prod.yml
     with:
       ref: ${{ needs.resolve-ref.outputs.sha }}
@@ -79,19 +86,28 @@ jobs:
     runs-on: ubuntu-latest
     needs: [resolve-ref, deploy-api-prod, deploy-web-prod]
     if: always()
+    permissions:
+      contents: read
     steps:
       - name: Write summary
+        env:
+          DEPLOY_REF: ${{ needs.resolve-ref.outputs.ref }}
+          DEPLOY_SHA: ${{ needs.resolve-ref.outputs.sha }}
+          API_RESULT: ${{ needs.deploy-api-prod.result }}
+          WEB_RESULT: ${{ needs.deploy-web-prod.result }}
         run: |
+          set -euo pipefail
+
           {
             echo "## Deploy To Production finished"
             echo ""
-            echo "- **Ref:** \`${{ needs.resolve-ref.outputs.ref }}\`"
-            echo "- **SHA:** \`${{ needs.resolve-ref.outputs.sha }}\`"
-            echo "- **API:** \`${{ needs.deploy-api-prod.result }}\`"
-            echo "- **Web:** \`${{ needs.deploy-web-prod.result }}\`"
+            echo "- **Ref:** \`${DEPLOY_REF}\`"
+            echo "- **SHA:** \`${DEPLOY_SHA}\`"
+            echo "- **API:** \`${API_RESULT}\`"
+            echo "- **Web:** \`${WEB_RESULT}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "${{ needs.deploy-api-prod.result }}" != "success" ] || [ "${{ needs.deploy-web-prod.result }}" != "success" ]; then
+          if [ "${API_RESULT}" != "success" ] || [ "${WEB_RESULT}" != "success" ]; then
             echo "One or more deploy jobs failed."
             exit 1
           fi

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -2,165 +2,96 @@ name: Deploy To Production
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git branch, tag, or commit SHA to deploy (branch deploys its latest tip)"
+        required: true
+        type: string
+        default: main
 
 permissions:
   id-token: write
-  contents: write
+  contents: read
   actions: write
 
 jobs:
-  prepare-prod-deploy:
-    name: Prepare Production Deployment
+  resolve-ref:
+    name: Resolve Deploy Ref
     runs-on: ubuntu-latest
     if: github.repository == 'refly-ai/refly'
     outputs:
-      should_deploy: ${{ steps.check_release.outputs.should_deploy }}
-      project_id: ${{ steps.check_release.outputs.project_id }}
-      start_date: ${{ steps.check_release.outputs.start_date }}
-      release_branch: ${{ steps.check_release.outputs.release_branch }}
+      ref: ${{ steps.resolve.outputs.ref }}
+      sha: ${{ steps.resolve.outputs.sha }}
+      short_sha: ${{ steps.resolve.outputs.short_sha }}
     steps:
-      - name: Query active release project
-        id: check_release
-        env:
-          ORBIT_API_URL: ${{ vars.ORBIT_API_URL }}
-          ORBIT_API_KEY: ${{ secrets.ORBIT_API_KEY }}
-        run: |
-          echo "Querying for active release project..."
-
-          # Query for active release project
-          RESPONSE=$(curl -s -G "$ORBIT_API_URL/api/projects/active-release" \
-            -H "X-Orbit-API-Key: $ORBIT_API_KEY")
-
-          echo "Orbit API Response:"
-          echo "$RESPONSE" | jq .
-
-          # Check if project exists
-          PROJECT_ID=$(echo "$RESPONSE" | jq -r '.id // empty')
-
-          if [ -z "$PROJECT_ID" ]; then
-            echo "No active release project found. Skipping deployment."
-            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
-            echo "project_id=" >> "$GITHUB_OUTPUT"
-            echo "start_date=" >> "$GITHUB_OUTPUT"
-            echo "release_branch=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Extract project information
-          START_DATE=$(echo "$RESPONSE" | jq -r '.startDate // empty')
-          PROJECT_NAME=$(echo "$RESPONSE" | jq -r '.name // "Unknown"')
-          PROJECT_STATUS=$(echo "$RESPONSE" | jq -r '.status // "Unknown"')
-
-          echo "Found active release project:"
-          echo "  - ID: $PROJECT_ID"
-          echo "  - Name: $PROJECT_NAME"
-          echo "  - Status: $PROJECT_STATUS"
-          echo "  - Start Date: $START_DATE"
-
-          # Check if status is Staging
-          if [ "$PROJECT_STATUS" != "Staging" ]; then
-            echo "Project status is not 'Staging' (current: $PROJECT_STATUS). Skipping deployment."
-            echo "Only projects in Staging status can be deployed to production."
-            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ -z "$START_DATE" ]; then
-            echo "Error: Project found but startDate is missing"
-            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
-
-          RELEASE_BRANCH="release/${START_DATE}"
-
-          echo "Project is ready for production deployment:"
-          echo "  - Release Branch: $RELEASE_BRANCH"
-
-          echo "should_deploy=true" >> "$GITHUB_OUTPUT"
-          echo "project_id=$PROJECT_ID" >> "$GITHUB_OUTPUT"
-          echo "start_date=$START_DATE" >> "$GITHUB_OUTPUT"
-          echo "release_branch=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
-
-  ensure-release-branch:
-    name: Ensure Release Branch Exists
-    needs: prepare-prod-deploy
-    if: needs.prepare-prod-deploy.outputs.should_deploy == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
+      - name: Checkout requested ref
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Ensure release branch exists
-        env:
-          RELEASE_BRANCH: ${{ needs.prepare-prod-deploy.outputs.release_branch }}
+      - name: Resolve commit SHA
+        id: resolve
         run: |
-          echo "Checking if branch $RELEASE_BRANCH exists..."
+          set -euo pipefail
 
-          # Check if branch exists remotely
-          if git ls-remote --heads origin "$RELEASE_BRANCH" | grep -q "$RELEASE_BRANCH"; then
-            echo "Branch $RELEASE_BRANCH exists"
-          else
-            echo "Error: Release branch $RELEASE_BRANCH does not exist"
-            echo "Production deployment requires an existing release branch from staging"
-            exit 1
-          fi
+          REQUESTED_REF="${{ inputs.ref }}"
+          SHA="$(git rev-parse HEAD)"
+          SHORT_SHA="$(git rev-parse --short=12 HEAD)"
+          SUBJECT="$(git log -1 --format='%s')"
+
+          echo "Requested ref: ${REQUESTED_REF}"
+          echo "Resolved SHA:  ${SHA}"
+          echo "Commit:        ${SUBJECT}"
+
+          {
+            echo "ref=${REQUESTED_REF}"
+            echo "sha=${SHA}"
+            echo "short_sha=${SHORT_SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Production deploy target"
+            echo ""
+            echo "- **Requested ref:** \`${REQUESTED_REF}\`"
+            echo "- **Resolved SHA:** \`${SHA}\`"
+            echo "- **Commit:** ${SUBJECT}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   deploy-api-prod:
     name: Deploy API to Production
-    needs: [prepare-prod-deploy, ensure-release-branch]
-    if: needs.prepare-prod-deploy.outputs.should_deploy == 'true'
+    needs: resolve-ref
     uses: ./.github/workflows/deploy-api-prod.yml
     with:
-      ref: ${{ needs.prepare-prod-deploy.outputs.release_branch }}
+      ref: ${{ needs.resolve-ref.outputs.sha }}
     secrets: inherit
 
   deploy-web-prod:
     name: Deploy Web to Production
-    needs: [prepare-prod-deploy, ensure-release-branch, deploy-api-prod]
-    if: needs.prepare-prod-deploy.outputs.should_deploy == 'true'
+    needs: [resolve-ref, deploy-api-prod]
     uses: ./.github/workflows/deploy-web-prod.yml
     with:
-      ref: ${{ needs.prepare-prod-deploy.outputs.release_branch }}
+      ref: ${{ needs.resolve-ref.outputs.sha }}
     secrets: inherit
 
-  update-project-status:
-    name: Update Project Status to Done
+  summarize:
+    name: Deployment Summary
     runs-on: ubuntu-latest
-    needs: [prepare-prod-deploy, deploy-api-prod, deploy-web-prod]
-    if: success() && needs.prepare-prod-deploy.outputs.should_deploy == 'true'
+    needs: [resolve-ref, deploy-api-prod, deploy-web-prod]
+    if: always()
     steps:
-      - name: Update project status
-        env:
-          ORBIT_API_URL: ${{ vars.ORBIT_API_URL }}
-          ORBIT_API_KEY: ${{ secrets.ORBIT_API_KEY }}
-          PROJECT_ID: ${{ needs.prepare-prod-deploy.outputs.project_id }}
+      - name: Write summary
         run: |
-          echo "Updating project status to Done..."
+          {
+            echo "## Deploy To Production finished"
+            echo ""
+            echo "- **Ref:** \`${{ needs.resolve-ref.outputs.ref }}\`"
+            echo "- **SHA:** \`${{ needs.resolve-ref.outputs.sha }}\`"
+            echo "- **API:** \`${{ needs.deploy-api-prod.result }}\`"
+            echo "- **Web:** \`${{ needs.deploy-web-prod.result }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-          # Update project status to Done
-          RESPONSE=$(curl -s -X POST "$ORBIT_API_URL/api/projects/update" \
-            -H "Content-Type: application/json" \
-            -H "X-Orbit-API-Key: $ORBIT_API_KEY" \
-            -d '{
-              "input": {
-                "status": "Done"
-              }
-            }')
-
-          echo "Update response:"
-          echo "$RESPONSE" | jq .
-
-          # Check if the update was successful
-          SUCCESS=$(echo "$RESPONSE" | jq -r '.success // false')
-
-          if [ "$SUCCESS" = "true" ]; then
-            echo "✓ Successfully updated project status to Done"
-            echo "🎉 Production deployment complete!"
-          else
-            ERROR_MSG=$(echo "$RESPONSE" | jq -r '.error // "Unknown error"')
-            echo "✗ Failed to update project status: $ERROR_MSG"
+          if [ "${{ needs.deploy-api-prod.result }}" != "success" ] || [ "${{ needs.deploy-web-prod.result }}" != "success" ]; then
+            echo "One or more deploy jobs failed."
             exit 1
           fi

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -128,6 +128,8 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: ${{ inputs.cloudflare_project }}
-          branch: main
+          # Must match the Pages project's production branch to attach production aliases.
+          # Build content still comes from the checked-out ref above.
+          branch: ${{ inputs.environment == 'production' && 'main' || (inputs.ref || github.ref_name) }}
           workingDirectory: apps/web
           directory: dist

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -128,8 +128,9 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: ${{ inputs.cloudflare_project }}
-          # Must match the Pages project's production branch to attach production aliases.
-          # Build content still comes from the checked-out ref above.
-          branch: ${{ inputs.environment == 'production' && 'main' || (inputs.ref || github.ref_name) }}
+          # Always the Pages project's production branch so prod/staging custom
+          # domains update. Build content still comes from the checked-out ref.
+          # Do not pass inputs.ref here (may be tag/SHA/release/* → preview only).
+          branch: main
           workingDirectory: apps/web
           directory: dist


### PR DESCRIPTION
## Summary

- **Deploy To Production** no longer queries Orbit `active-release` / Linear Staging projects to pick `release/YYYY-MM-DD` (stale Staging projects can redeploy months-old code — root cause of the 2026-07-27 Pages rollback incident).
- `workflow_dispatch` now takes an explicit **`ref`** (branch / tag / SHA, default `main`), resolves the tip SHA, and deploys API + web from that commit.
- **API image tags** use the checked-out commit SHA (`git rev-parse HEAD`) instead of `github.sha` from the caller workflow, so deploying a non-main ref cannot silently reuse main's nightly image.
- Cloudflare Pages production deploys still use Pages production branch `main` for alias attachment; build content comes from the checked-out ref.

## Test plan

- [ ] Merge to `main`
- [ ] Run **Deploy To Production** with `ref=main`
- [ ] Confirm job summary shows resolved SHA = current `main` tip
- [ ] Confirm API image tag is `prod-<that-sha>` and pods roll to it
- [ ] Confirm Pages production aliases stay on `app.refly.ai` / `refly.ai` and build includes expected commit
- [ ] Optional: dry-run with a non-main branch and verify API tag matches that branch tip (not main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Deployment Improvements**
  - Production deployments can now be triggered from a selected Git reference, with the resolved commit used to keep API and web releases in sync.
  - Deployment summaries now include the resolved reference/commit and report individual API and web deployment results.
  - Web deployments continue to use the correct production branch for alias updates while building from the chosen source ref.
  - Deployed image tags now consistently derive from the checked-out commit.
- **Security**
  - Deployment workflows were adjusted to follow least-privilege permissions for improved safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->