### PR TITLE
fix(api): reduce refly-api RSS from image path and stream snapshots

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -32,6 +32,10 @@ RUN pnpm build:api
 FROM node:24.13.1-slim AS production
 WORKDIR /app
 
+# Cap glibc arenas to reduce RSS fragmentation under Sharp/libvips (defense-in-depth for non-helm deploys).
+# See: https://sharp.pixelplumbing.com/install/#linux-memory-allocator
+ENV MALLOC_ARENA_MAX=2
+
 # Install system dependencies in a single layer
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/apps/api/src/modules/drive/drive.service.ts
+++ b/apps/api/src/modules/drive/drive.service.ts
@@ -65,6 +65,13 @@ import { SubscriptionService } from '../subscription/subscription.service';
 import { readingTime } from 'reading-time-estimator';
 import { MiscService } from '../misc/misc.service';
 
+// Shared across concurrent skill invocations to cap peak RSS from Sharp/libvips + base64 copies.
+const rawImageConcurrency = Number.parseInt(process.env.IMAGE_PROCESS_CONCURRENCY ?? '', 10);
+const imageProcessConcurrency = Number.isFinite(rawImageConcurrency)
+  ? Math.min(4, Math.max(1, rawImageConcurrency))
+  : 2;
+const imageProcessLimit = pLimit(imageProcessConcurrency);
+
 export interface ExtendedUpsertDriveFileRequest extends UpsertDriveFileRequest {
   buffer?: Buffer;
 }
@@ -103,6 +110,8 @@ export class DriveService implements OnModuleInit {
   async onModuleInit() {
     // Use moduleRef.get with { strict: false } to resolve circular dependency at runtime
     this.subscriptionService = this.moduleRef.get(SubscriptionService, { strict: false });
+    // Limits libvips internal threads per process to reduce native allocator pressure under concurrent image ops.
+    sharp.concurrency(1);
   }
 
   /**
@@ -1192,54 +1201,56 @@ export class DriveService implements OnModuleInit {
     try {
       if (fileMode === 'base64') {
         const urls = await Promise.all(
-          files.map(async (file) => {
-            const driveStorageKey = this.generateStorageKey(user, file);
+          files.map((file) =>
+            imageProcessLimit(async () => {
+              const driveStorageKey = this.generateStorageKey(user, file);
 
-            try {
-              const data = await this.internalOss.getObject(driveStorageKey);
-              const chunks: Buffer[] = [];
+              try {
+                const data = await this.internalOss.getObject(driveStorageKey);
+                const chunks: Buffer[] = [];
 
-              for await (const chunk of data) {
-                chunks.push(chunk);
+                for await (const chunk of data) {
+                  chunks.push(chunk);
+                }
+
+                let buffer = Buffer.concat(chunks);
+
+                // Compress image before converting to base64
+                const maxArea = Number.parseInt(process.env.IMAGE_MAX_AREA) || 600 * 600;
+                const metadata = await sharp(buffer).metadata();
+                const originalWidth = metadata?.width ?? 0;
+                const originalHeight = metadata?.height ?? 0;
+                const isGif = metadata?.format === 'gif';
+
+                // Calculate scaling factor based on max area
+                const originalArea = originalWidth * originalHeight;
+                const scaleFactor = originalArea > maxArea ? Math.sqrt(maxArea / originalArea) : 1;
+
+                // Resize and convert format if needed
+                if (scaleFactor < 1 || !isGif) {
+                  const processedBuffer = await sharp(buffer)
+                    .resize({
+                      width: Math.round(originalWidth * scaleFactor),
+                      height: Math.round(originalHeight * scaleFactor),
+                      fit: 'fill',
+                    })
+                    [isGif ? 'toFormat' : 'toFormat'](isGif ? 'gif' : 'webp')
+                    .toBuffer();
+                  buffer = processedBuffer;
+                }
+
+                const base64 = buffer.toString('base64');
+                const contentType = isGif ? 'image/gif' : 'image/webp';
+
+                return `data:${contentType};base64,${base64}`;
+              } catch (error) {
+                this.logger.error(
+                  `Failed to generate compressed base64 for drive file ${file.fileId}: ${error.stack}`,
+                );
+                return '';
               }
-
-              let buffer = Buffer.concat(chunks);
-
-              // Compress image before converting to base64
-              const maxArea = Number.parseInt(process.env.IMAGE_MAX_AREA) || 600 * 600;
-              const metadata = await sharp(buffer).metadata();
-              const originalWidth = metadata?.width ?? 0;
-              const originalHeight = metadata?.height ?? 0;
-              const isGif = metadata?.format === 'gif';
-
-              // Calculate scaling factor based on max area
-              const originalArea = originalWidth * originalHeight;
-              const scaleFactor = originalArea > maxArea ? Math.sqrt(maxArea / originalArea) : 1;
-
-              // Resize and convert format if needed
-              if (scaleFactor < 1 || !isGif) {
-                const processedBuffer = await sharp(buffer)
-                  .resize({
-                    width: Math.round(originalWidth * scaleFactor),
-                    height: Math.round(originalHeight * scaleFactor),
-                    fit: 'fill',
-                  })
-                  [isGif ? 'toFormat' : 'toFormat'](isGif ? 'gif' : 'webp')
-                  .toBuffer();
-                buffer = Buffer.from(processedBuffer);
-              }
-
-              const base64 = buffer.toString('base64');
-              const contentType = isGif ? 'image/gif' : 'image/webp';
-
-              return `data:${contentType};base64,${base64}`;
-            } catch (error) {
-              this.logger.error(
-                `Failed to generate compressed base64 for drive file ${file.fileId}: ${error.stack}`,
-              );
-              return '';
-            }
-          }),
+            }),
+          ),
         );
         return urls.filter(Boolean);
       }

--- a/apps/api/src/modules/drive/drive.service.ts
+++ b/apps/api/src/modules/drive/drive.service.ts
@@ -66,10 +66,16 @@ import { readingTime } from 'reading-time-estimator';
 import { MiscService } from '../misc/misc.service';
 
 // Shared across concurrent skill invocations to cap peak RSS from Sharp/libvips + base64 copies.
+const MIN_IMAGE_PROCESS_CONCURRENCY = 1;
+const MAX_IMAGE_PROCESS_CONCURRENCY = 4;
+const DEFAULT_IMAGE_PROCESS_CONCURRENCY = 2;
 const rawImageConcurrency = Number.parseInt(process.env.IMAGE_PROCESS_CONCURRENCY ?? '', 10);
 const imageProcessConcurrency = Number.isFinite(rawImageConcurrency)
-  ? Math.min(4, Math.max(1, rawImageConcurrency))
-  : 2;
+  ? Math.min(
+      MAX_IMAGE_PROCESS_CONCURRENCY,
+      Math.max(MIN_IMAGE_PROCESS_CONCURRENCY, rawImageConcurrency),
+    )
+  : DEFAULT_IMAGE_PROCESS_CONCURRENCY;
 const imageProcessLimit = pLimit(imageProcessConcurrency);
 
 export interface ExtendedUpsertDriveFileRequest extends UpsertDriveFileRequest {

--- a/apps/api/src/modules/drive/drive.service.ts
+++ b/apps/api/src/modules/drive/drive.service.ts
@@ -66,17 +66,22 @@ import { readingTime } from 'reading-time-estimator';
 import { MiscService } from '../misc/misc.service';
 
 // Shared across concurrent skill invocations to cap peak RSS from Sharp/libvips + base64 copies.
+// Lazy: process.env is only reliable after ConfigModule.forRoot loads .env (not at import time).
 const MIN_IMAGE_PROCESS_CONCURRENCY = 1;
 const MAX_IMAGE_PROCESS_CONCURRENCY = 4;
 const DEFAULT_IMAGE_PROCESS_CONCURRENCY = 2;
-const rawImageConcurrency = Number.parseInt(process.env.IMAGE_PROCESS_CONCURRENCY ?? '', 10);
-const imageProcessConcurrency = Number.isFinite(rawImageConcurrency)
-  ? Math.min(
-      MAX_IMAGE_PROCESS_CONCURRENCY,
-      Math.max(MIN_IMAGE_PROCESS_CONCURRENCY, rawImageConcurrency),
-    )
-  : DEFAULT_IMAGE_PROCESS_CONCURRENCY;
-const imageProcessLimit = pLimit(imageProcessConcurrency);
+let imageProcessLimit: ReturnType<typeof pLimit> | undefined;
+
+function getImageProcessLimit(): ReturnType<typeof pLimit> {
+  if (!imageProcessLimit) {
+    const raw = Number.parseInt(process.env.IMAGE_PROCESS_CONCURRENCY ?? '', 10);
+    const concurrency = Number.isFinite(raw)
+      ? Math.min(MAX_IMAGE_PROCESS_CONCURRENCY, Math.max(MIN_IMAGE_PROCESS_CONCURRENCY, raw))
+      : DEFAULT_IMAGE_PROCESS_CONCURRENCY;
+    imageProcessLimit = pLimit(concurrency);
+  }
+  return imageProcessLimit;
+}
 
 export interface ExtendedUpsertDriveFileRequest extends UpsertDriveFileRequest {
   buffer?: Buffer;
@@ -118,6 +123,8 @@ export class DriveService implements OnModuleInit {
     this.subscriptionService = this.moduleRef.get(SubscriptionService, { strict: false });
     // Limits libvips internal threads per process to reduce native allocator pressure under concurrent image ops.
     sharp.concurrency(1);
+    // Init after ConfigModule has loaded .env so IMAGE_PROCESS_CONCURRENCY is honored.
+    getImageProcessLimit();
   }
 
   /**
@@ -1208,7 +1215,7 @@ export class DriveService implements OnModuleInit {
       if (fileMode === 'base64') {
         const urls = await Promise.all(
           files.map((file) =>
-            imageProcessLimit(async () => {
+            getImageProcessLimit()(async () => {
               const driveStorageKey = this.generateStorageKey(user, file);
 
               try {

--- a/apps/api/src/utils/result.spec.ts
+++ b/apps/api/src/utils/result.spec.ts
@@ -1,0 +1,146 @@
+jest.mock('@refly/utils', () => ({
+  aggregateTokenUsage: (items: unknown[]) => items ?? [],
+}));
+
+import { ResultAggregator } from './result';
+import type { StepService } from '../modules/step/step.service';
+
+describe('ResultAggregator', () => {
+  const resultId = 'result-1';
+  const version = 1;
+  const cacheKey = `steps:${resultId}:${version}`;
+
+  let setCacheCalls: Array<{ key: string; steps: Record<string, unknown> }>;
+  let clearCacheCalls: Array<{ resultId: string; version: number }>;
+  let stepService: jest.Mocked<Pick<StepService, 'buildCacheKey' | 'setCache' | 'clearCache'>>;
+  let aggregator: ResultAggregator;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setCacheCalls = [];
+    clearCacheCalls = [];
+
+    stepService = {
+      buildCacheKey: jest.fn().mockReturnValue(cacheKey),
+      setCache: jest
+        .fn()
+        .mockImplementation(async (key: string, steps: Record<string, unknown>) => {
+          setCacheCalls.push({ key, steps });
+        }),
+      clearCache: jest.fn().mockImplementation(async (rid: string, ver: number) => {
+        clearCacheCalls.push({ resultId: rid, version: ver });
+      }),
+    };
+
+    aggregator = new ResultAggregator(stepService as unknown as StepService, resultId, version);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('coalesces rapid handleStreamContent into fewer setCache calls than events', async () => {
+    const meta = { step: { name: 'answer' } };
+    const chunks = ['Hello', ' ', 'world', '!', ' more'];
+
+    for (const chunk of chunks) {
+      aggregator.handleStreamContent(meta as any, chunk);
+    }
+
+    expect(setCacheCalls).toHaveLength(0);
+
+    jest.advanceTimersByTime(200);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(setCacheCalls.length).toBeGreaterThanOrEqual(1);
+    expect(setCacheCalls.length).toBeLessThan(chunks.length);
+
+    const steps = await aggregator.getSteps({ resultId, version });
+    expect(steps).toHaveLength(1);
+    expect(steps[0].content).toBe('Hello world! more');
+
+    const lastWrite = setCacheCalls[setCacheCalls.length - 1];
+    expect(lastWrite.key).toBe(cacheKey);
+    expect((lastWrite.steps.answer as { content: string }).content).toBe('Hello world! more');
+  });
+
+  it('does not recreate Redis key via setCache after clearCache (in-flight + post-clear)', async () => {
+    let resolveSet: (() => void) | undefined;
+    const setGate = new Promise<void>((resolve) => {
+      resolveSet = resolve;
+    });
+
+    stepService.setCache.mockImplementation(async (key: string, steps: Record<string, unknown>) => {
+      setCacheCalls.push({ key, steps });
+      await setGate;
+    });
+
+    aggregator.handleStreamContent({ step: { name: 'answer' } } as any, 'partial');
+    jest.advanceTimersByTime(200);
+    // Allow flush to start and hit the gated setCache
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(stepService.setCache).toHaveBeenCalled();
+    const callsBeforeClear = setCacheCalls.length;
+
+    const clearPromise = aggregator.clearCache();
+    // Mutation while clear awaits in-flight write
+    aggregator.handleStreamContent({ step: { name: 'answer' } } as any, ' after-clear-race');
+
+    resolveSet?.();
+    await clearPromise;
+
+    // Drain any microtasks / timers that might try to rearm
+    jest.advanceTimersByTime(500);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(clearCacheCalls).toEqual([{ resultId, version }]);
+    expect(setCacheCalls.length).toBe(callsBeforeClear);
+
+    aggregator.handleStreamContent({ step: { name: 'answer' } } as any, ' post-clear');
+    jest.advanceTimersByTime(500);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(setCacheCalls.length).toBe(callsBeforeClear);
+
+    const steps = await aggregator.getSteps({ resultId, version });
+    expect(steps[0].content).toContain('partial');
+    expect(steps[0].content).toContain('after-clear-race');
+    expect(steps[0].content).toContain('post-clear');
+    expect(setCacheCalls.length).toBe(callsBeforeClear);
+  });
+
+  it('mutation after clearCache does not call setCache again', async () => {
+    aggregator.handleStreamContent({ step: { name: 'answer' } } as any, 'before');
+    jest.advanceTimersByTime(200);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(setCacheCalls.length).toBeGreaterThanOrEqual(1);
+    const afterFirstPersist = setCacheCalls.length;
+
+    await aggregator.clearCache();
+    expect(clearCacheCalls).toEqual([{ resultId, version }]);
+
+    aggregator.handleStreamContent({ step: { name: 'answer' } } as any, ' after');
+    aggregator.addUsageItem(
+      { step: { name: 'answer' } } as any,
+      {
+        modelName: 'm',
+        modelProvider: 'p',
+        inputTokens: 1,
+        outputTokens: 1,
+      } as any,
+    );
+
+    jest.advanceTimersByTime(500);
+    await Promise.resolve();
+    await aggregator.getSteps({ resultId, version });
+
+    expect(setCacheCalls.length).toBe(afterFirstPersist);
+  });
+});

--- a/apps/api/src/utils/result.spec.ts
+++ b/apps/api/src/utils/result.spec.ts
@@ -2,8 +2,17 @@ jest.mock('@refly/utils', () => ({
   aggregateTokenUsage: (items: unknown[]) => items ?? [],
 }));
 
-import { ResultAggregator } from './result';
+import { PERSIST_DEBOUNCE_MS, ResultAggregator } from './result';
 import type { StepService } from '../modules/step/step.service';
+
+/** Flush fake timers + microtasks (jest env here lacks advanceTimersByTimeAsync). */
+async function advanceAndFlush(ms: number) {
+  jest.advanceTimersByTime(ms);
+  // Drain promise chains from timer → persistOnce → setCache
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
 
 describe('ResultAggregator', () => {
   const resultId = 'result-1';
@@ -49,9 +58,7 @@ describe('ResultAggregator', () => {
 
     expect(setCacheCalls).toHaveLength(0);
 
-    jest.advanceTimersByTime(200);
-    await Promise.resolve();
-    await Promise.resolve();
+    await advanceAndFlush(PERSIST_DEBOUNCE_MS);
 
     expect(setCacheCalls.length).toBeGreaterThanOrEqual(1);
     expect(setCacheCalls.length).toBeLessThan(chunks.length);
@@ -63,6 +70,39 @@ describe('ResultAggregator', () => {
     const lastWrite = setCacheCalls[setCacheCalls.length - 1];
     expect(lastWrite.key).toBe(cacheKey);
     expect((lastWrite.steps.answer as { content: string }).content).toBe('Hello world! more');
+  });
+
+  it('re-debounces mutations that arrive during an in-flight write (no immediate back-to-back loop)', async () => {
+    let resolveSet: (() => void) | undefined;
+    const setGate = new Promise<void>((resolve) => {
+      resolveSet = resolve;
+    });
+
+    stepService.setCache.mockImplementation(async (key: string, steps: Record<string, unknown>) => {
+      setCacheCalls.push({ key, steps });
+      await setGate;
+    });
+
+    aggregator.handleStreamContent({ step: { name: 'answer' } } as any, 'a');
+    await advanceAndFlush(PERSIST_DEBOUNCE_MS);
+
+    expect(setCacheCalls).toHaveLength(1);
+
+    // Mutations while first write is still in flight
+    aggregator.handleStreamContent({ step: { name: 'answer' } } as any, 'b');
+    aggregator.handleStreamContent({ step: { name: 'answer' } } as any, 'c');
+
+    // Completing the write must not immediately issue another setCache
+    resolveSet?.();
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+    expect(setCacheCalls).toHaveLength(1);
+
+    // Follow-up write only after another debounce window
+    await advanceAndFlush(PERSIST_DEBOUNCE_MS);
+    expect(setCacheCalls).toHaveLength(2);
+    expect((setCacheCalls[1].steps.answer as { content: string }).content).toBe('abc');
   });
 
   it('does not recreate Redis key via setCache after clearCache (in-flight + post-clear)', async () => {
@@ -77,10 +117,7 @@ describe('ResultAggregator', () => {
     });
 
     aggregator.handleStreamContent({ step: { name: 'answer' } } as any, 'partial');
-    jest.advanceTimersByTime(200);
-    // Allow flush to start and hit the gated setCache
-    await Promise.resolve();
-    await Promise.resolve();
+    await advanceAndFlush(PERSIST_DEBOUNCE_MS);
 
     expect(stepService.setCache).toHaveBeenCalled();
     const callsBeforeClear = setCacheCalls.length;
@@ -93,17 +130,13 @@ describe('ResultAggregator', () => {
     await clearPromise;
 
     // Drain any microtasks / timers that might try to rearm
-    jest.advanceTimersByTime(500);
-    await Promise.resolve();
-    await Promise.resolve();
+    await advanceAndFlush(PERSIST_DEBOUNCE_MS * 2);
 
     expect(clearCacheCalls).toEqual([{ resultId, version }]);
     expect(setCacheCalls.length).toBe(callsBeforeClear);
 
     aggregator.handleStreamContent({ step: { name: 'answer' } } as any, ' post-clear');
-    jest.advanceTimersByTime(500);
-    await Promise.resolve();
-    await Promise.resolve();
+    await advanceAndFlush(PERSIST_DEBOUNCE_MS * 2);
 
     expect(setCacheCalls.length).toBe(callsBeforeClear);
 
@@ -116,9 +149,7 @@ describe('ResultAggregator', () => {
 
   it('mutation after clearCache does not call setCache again', async () => {
     aggregator.handleStreamContent({ step: { name: 'answer' } } as any, 'before');
-    jest.advanceTimersByTime(200);
-    await Promise.resolve();
-    await Promise.resolve();
+    await advanceAndFlush(PERSIST_DEBOUNCE_MS);
 
     expect(setCacheCalls.length).toBeGreaterThanOrEqual(1);
     const afterFirstPersist = setCacheCalls.length;
@@ -137,10 +168,37 @@ describe('ResultAggregator', () => {
       } as any,
     );
 
-    jest.advanceTimersByTime(500);
-    await Promise.resolve();
+    await advanceAndFlush(PERSIST_DEBOUNCE_MS * 2);
     await aggregator.getSteps({ resultId, version });
 
     expect(setCacheCalls.length).toBe(afterFirstPersist);
+  });
+
+  it('abort flushes pending snapshot and rejects further schedule', async () => {
+    aggregator.handleStreamContent({ step: { name: 'answer' } } as any, 'pending');
+    expect(setCacheCalls).toHaveLength(0);
+
+    aggregator.abort();
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+
+    expect(setCacheCalls.length).toBeGreaterThanOrEqual(1);
+    expect((setCacheCalls[0].steps.answer as { content: string }).content).toBe('pending');
+
+    const afterAbort = setCacheCalls.length;
+    aggregator.handleStreamContent({ step: { name: 'answer' } } as any, ' ignored');
+    aggregator.addUsageItem(
+      { step: { name: 'answer' } } as any,
+      {
+        modelName: 'm',
+        modelProvider: 'p',
+        inputTokens: 1,
+        outputTokens: 1,
+      } as any,
+    );
+    await advanceAndFlush(PERSIST_DEBOUNCE_MS * 2);
+
+    expect(setCacheCalls.length).toBe(afterAbort);
   });
 });

--- a/apps/api/src/utils/result.ts
+++ b/apps/api/src/utils/result.ts
@@ -15,6 +15,8 @@ export interface StepData {
   usageItems: TokenUsageItem[];
 }
 
+const PERSIST_DEBOUNCE_MS = 200;
+
 export class ResultAggregator {
   /**
    * Step title list, in the order of sending
@@ -30,6 +32,12 @@ export class ResultAggregator {
    * Whether the skill invocation is aborted
    */
   private aborted = false;
+
+  private persistTimer: ReturnType<typeof setTimeout> | null = null;
+  private persistInFlight: Promise<void> | null = null;
+  private persistDirty = false;
+  /** Set when cache was cleared; in-flight writes should not overwrite after clear. */
+  private persistCleared = false;
 
   constructor(
     private readonly stepService: StepService,
@@ -61,7 +69,74 @@ export class ResultAggregator {
     };
   }
 
-  private async persistSteps() {
+  private schedulePersistSteps() {
+    // Terminal after clearCache: allow in-memory mutations but never rearm Redis writes.
+    if (this.persistCleared) {
+      return;
+    }
+    this.persistDirty = true;
+    if (this.persistTimer != null) {
+      return;
+    }
+    this.persistTimer = setTimeout(() => {
+      this.persistTimer = null;
+      void this.flushPersistSteps();
+    }, PERSIST_DEBOUNCE_MS);
+  }
+
+  /**
+   * Force-flush pending snapshot to Redis (latest-wins single-flight).
+   * Coalesces concurrent callers; if dirty again after a write, runs one more persist.
+   * No-ops Redis writes once clearCache has run (persistCleared is sticky).
+   */
+  private async flushPersistSteps(): Promise<void> {
+    if (this.persistCleared) {
+      if (this.persistTimer != null) {
+        clearTimeout(this.persistTimer);
+        this.persistTimer = null;
+      }
+      return;
+    }
+
+    if (this.persistTimer != null) {
+      clearTimeout(this.persistTimer);
+      this.persistTimer = null;
+    }
+
+    // Ensure at least one attempt when explicitly flushed (e.g. getSteps).
+    this.persistDirty = true;
+
+    while (this.persistDirty && !this.persistCleared) {
+      if (this.persistInFlight) {
+        await this.persistInFlight;
+        // In-flight may have cleared dirty; if a race left us dirty again, loop.
+        continue;
+      }
+
+      const run = this.runPersistLoop();
+      this.persistInFlight = run;
+      try {
+        await run;
+      } finally {
+        if (this.persistInFlight === run) {
+          this.persistInFlight = null;
+        }
+      }
+    }
+  }
+
+  private async runPersistLoop(): Promise<void> {
+    while (this.persistDirty && !this.persistCleared) {
+      this.persistDirty = false;
+      await this.persistStepsNow();
+    }
+  }
+
+  private async persistStepsNow() {
+    if (this.persistCleared) {
+      return;
+    }
+
     try {
       // Generate Map with step name as key and StepData as value
       const stepsMap = new Map<string, StepData>();
@@ -84,6 +159,10 @@ export class ResultAggregator {
 
   abort() {
     this.aborted = true;
+    if (this.persistTimer != null) {
+      clearTimeout(this.persistTimer);
+      this.persistTimer = null;
+    }
   }
 
   addSkillEvent(event: SkillEvent) {
@@ -125,14 +204,14 @@ export class ResultAggregator {
         }
     }
     this.data[step.name] = step;
-    void this.persistSteps();
+    this.schedulePersistSteps();
   }
 
   addUsageItem(meta: SkillRunnableMeta, usage: TokenUsageItem) {
     const step = this.getOrInitData(meta.step?.name);
     step.usageItems.push(usage);
     this.data[step.name] = step;
-    void this.persistSteps();
+    this.schedulePersistSteps();
   }
 
   handleStreamContent(meta: SkillRunnableMeta, content: string, reasoningContent?: string) {
@@ -149,7 +228,7 @@ export class ResultAggregator {
     }
 
     this.data[step.name] = step;
-    this.persistSteps();
+    this.schedulePersistSteps();
   }
 
   async getSteps({
@@ -159,7 +238,7 @@ export class ResultAggregator {
     resultId: string;
     version: number;
   }): Promise<Prisma.ActionStepCreateManyInput[]> {
-    await this.persistSteps();
+    await this.flushPersistSteps();
     return this.stepNames.map((stepName, order) => {
       const { name, content, structuredData, artifacts, usageItems, logs, reasoningContent } =
         this.data[stepName];
@@ -182,6 +261,17 @@ export class ResultAggregator {
   }
 
   async clearCache() {
+    if (this.persistTimer != null) {
+      clearTimeout(this.persistTimer);
+      this.persistTimer = null;
+    }
+    this.persistDirty = false;
+    this.persistCleared = true;
+
+    if (this.persistInFlight) {
+      await this.persistInFlight;
+    }
+
     await this.stepService.clearCache(this.resultId, this.version);
   }
 }

--- a/apps/api/src/utils/result.ts
+++ b/apps/api/src/utils/result.ts
@@ -15,7 +15,7 @@ export interface StepData {
   usageItems: TokenUsageItem[];
 }
 
-const PERSIST_DEBOUNCE_MS = 200;
+export const PERSIST_DEBOUNCE_MS = 200;
 
 export class ResultAggregator {
   /**
@@ -69,51 +69,82 @@ export class ResultAggregator {
     };
   }
 
+  private clearPersistTimer() {
+    if (this.persistTimer != null) {
+      clearTimeout(this.persistTimer);
+      this.persistTimer = null;
+    }
+  }
+
   private schedulePersistSteps() {
     // Terminal after clearCache: allow in-memory mutations but never rearm Redis writes.
     if (this.persistCleared) {
       return;
     }
     this.persistDirty = true;
-    if (this.persistTimer != null) {
+    if (this.persistTimer != null || this.persistInFlight) {
+      // Coalesce: timer already armed, or a write is in flight (re-arm after it finishes).
       return;
     }
     this.persistTimer = setTimeout(() => {
       this.persistTimer = null;
-      void this.flushPersistSteps();
+      void this.runDebouncedPersist();
     }, PERSIST_DEBOUNCE_MS);
   }
 
   /**
-   * Force-flush pending snapshot to Redis (latest-wins single-flight).
-   * Coalesces concurrent callers; if dirty again after a write, runs one more persist.
-   * No-ops Redis writes once clearCache has run (persistCleared is sticky).
+   * Timer-driven path: one write, then re-debounce if mutations arrived during I/O.
+   * Avoids back-to-back Redis snapshots under continuous streaming.
    */
-  private async flushPersistSteps(): Promise<void> {
-    if (this.persistCleared) {
-      if (this.persistTimer != null) {
-        clearTimeout(this.persistTimer);
-        this.persistTimer = null;
+  private async runDebouncedPersist(): Promise<void> {
+    if (this.persistCleared || !this.persistDirty) {
+      return;
+    }
+    if (this.persistInFlight) {
+      await this.persistInFlight;
+      if (this.persistDirty && !this.persistCleared) {
+        this.schedulePersistSteps();
       }
       return;
     }
 
-    if (this.persistTimer != null) {
-      clearTimeout(this.persistTimer);
-      this.persistTimer = null;
+    const run = this.persistOnce();
+    this.persistInFlight = run;
+    try {
+      await run;
+    } finally {
+      if (this.persistInFlight === run) {
+        this.persistInFlight = null;
+      }
     }
 
+    if (this.persistDirty && !this.persistCleared) {
+      this.schedulePersistSteps();
+    }
+  }
+
+  /**
+   * Force-flush pending snapshot to Redis (latest-wins single-flight).
+   * Used by getSteps/abort — drains until clean so final snapshot is not lost.
+   * No-ops Redis writes once clearCache has run (persistCleared is sticky).
+   */
+  private async flushPersistSteps(): Promise<void> {
+    if (this.persistCleared) {
+      this.clearPersistTimer();
+      return;
+    }
+
+    this.clearPersistTimer();
     // Ensure at least one attempt when explicitly flushed (e.g. getSteps).
     this.persistDirty = true;
 
     while (this.persistDirty && !this.persistCleared) {
       if (this.persistInFlight) {
         await this.persistInFlight;
-        // In-flight may have cleared dirty; if a race left us dirty again, loop.
         continue;
       }
 
-      const run = this.runPersistLoop();
+      const run = this.persistOnce();
       this.persistInFlight = run;
       try {
         await run;
@@ -125,11 +156,13 @@ export class ResultAggregator {
     }
   }
 
-  private async runPersistLoop(): Promise<void> {
-    while (this.persistDirty && !this.persistCleared) {
-      this.persistDirty = false;
-      await this.persistStepsNow();
+  /** Single snapshot write; clears dirty before I/O so concurrent mutations re-dirty. */
+  private async persistOnce(): Promise<void> {
+    if (!this.persistDirty || this.persistCleared) {
+      return;
     }
+    this.persistDirty = false;
+    await this.persistStepsNow();
   }
 
   private async persistStepsNow() {
@@ -159,10 +192,9 @@ export class ResultAggregator {
 
   abort() {
     this.aborted = true;
-    if (this.persistTimer != null) {
-      clearTimeout(this.persistTimer);
-      this.persistTimer = null;
-    }
+    this.clearPersistTimer();
+    // Ensure the last buffered snapshot is not lost if no getSteps()/clearCache() follows.
+    void this.flushPersistSteps();
   }
 
   addSkillEvent(event: SkillEvent) {
@@ -208,6 +240,9 @@ export class ResultAggregator {
   }
 
   addUsageItem(meta: SkillRunnableMeta, usage: TokenUsageItem) {
+    if (this.aborted) {
+      return;
+    }
     const step = this.getOrInitData(meta.step?.name);
     step.usageItems.push(usage);
     this.data[step.name] = step;
@@ -261,10 +296,7 @@ export class ResultAggregator {
   }
 
   async clearCache() {
-    if (this.persistTimer != null) {
-      clearTimeout(this.persistTimer);
-      this.persistTimer = null;
-    }
+    this.clearPersistTimer();
     this.persistDirty = false;
     this.persistCleared = true;
 

--- a/deploy/helm/refly-api/values.yaml
+++ b/deploy/helm/refly-api/values.yaml
@@ -30,6 +30,9 @@ env:
     value: "production"
   - name: GOOGLE_APPLICATION_CREDENTIALS
     value: "/var/secrets/google/credentials.json"
+  # Cap glibc arenas to reduce RSS fragmentation under Sharp/libvips (see sharp Linux allocator docs).
+  - name: MALLOC_ARENA_MAX
+    value: "2"
 
 envFrom:
   configMapRef:


### PR DESCRIPTION
## Summary
- Cap concurrent Sharp/base64 image work per pod (`IMAGE_PROCESS_CONCURRENCY` default 2, clamp 1–4), set `sharp.concurrency(1)`, and remove a redundant `Buffer.from` copy on the vision base64 path — main RSS ratchet driver is glibc arena fragmentation under concurrent libvips + multi-buffer Base64, not a JS retained-object leak.
- Set `MALLOC_ARENA_MAX=2` in the API Dockerfile and helm values (Sharp/glibc allocator guidance).
- Debounce `ResultAggregator` Redis step snapshots (200ms coalesce + single-flight, terminal `clearCache`) to cut secondary stream allocation churn; unit tests cover debounce and clear races.

## Deploy notes
- Prefer a **one-pod canary** (or pause rolling after the first pod) before fleet rollout.
- Monitor RSS peak/baseline after image batches, OOM/restarts, image-path p95/p99 latency, CPU, error rate.
- Rollback: remove `MALLOC_ARENA_MAX` or set to `4`; optionally tune `IMAGE_PROCESS_CONCURRENCY` in 1–4.
- Shipping image-path + allocator first makes RSS attribution clearer; snapshot debounce is secondary.

## Test plan
- [x] `pnpm exec jest src/utils/result.spec.ts` (apps/api) — 3/3 pass
- [ ] Canary one `refly-api` pod with new image + `MALLOC_ARENA_MAX=2`
- [ ] Compare canary vs control: RSS after image/Base64 skill load, residual baseline, OOM
- [ ] Spot-check vision (bedrock/vertex base64) still returns images under multi-file input
- [ ] Spot-check long skill stream still persists final steps to DB; mid-stream Redis lag ≤200ms is expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced memory fragmentation by setting allocator arena limits in the API container.
  * Improved drive base64 image generation stability by capping concurrent conversions.
* **Bug Fixes**
  * Improved result step persistence by debouncing rapid updates and coalescing writes to the latest snapshot.
  * Cache clearing now permanently prevents future persistence, and pending updates behave consistently.
  * Updated abort behavior to flush any pending snapshot without scheduling further writes.
* **Tests**
  * Added Jest coverage for debounced persistence, in-flight updates, cache clearing, and abort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->