### PR TITLE
fix(api): authenticated file endpoint reflects any origin with credentials, enabling cross-origin theft of private user files

### DIFF
--- a/apps/api/src/modules/misc/misc.controller.spec.ts
+++ b/apps/api/src/modules/misc/misc.controller.spec.ts
@@ -4,6 +4,8 @@ import { createMock } from '@golevelup/ts-jest';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { MiscService } from '../misc/misc.service';
+import { ApiKeyService } from '../auth/api-key.service';
+import { PrismaService } from '../common/prisma.service';
 
 describe('MiscController', () => {
   let controller: MiscController;
@@ -11,6 +13,8 @@ describe('MiscController', () => {
   const configService = createMock<ConfigService>();
   const jwtService = createMock<JwtService>();
   const miscService = createMock<MiscService>();
+  const apiKeyService = createMock<ApiKeyService>();
+  const prismaService = createMock<PrismaService>();
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -19,6 +23,8 @@ describe('MiscController', () => {
         { provide: ConfigService, useValue: configService },
         { provide: JwtService, useValue: jwtService },
         { provide: MiscService, useValue: miscService },
+        { provide: ApiKeyService, useValue: apiKeyService },
+        { provide: PrismaService, useValue: prismaService },
       ],
     }).compile();
 
@@ -27,5 +33,36 @@ describe('MiscController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('buildCorsHeaders', () => {
+    const buildCorsHeaders = (origin?: string) =>
+      (controller as any).buildCorsHeaders(origin) as Record<string, string>;
+
+    beforeEach(() => {
+      configService.get.mockReturnValue('https://app.refly.ai, https://refly.ai');
+    });
+
+    it('reflects origin and allows credentials for allowlisted origins', () => {
+      const headers = buildCorsHeaders('https://app.refly.ai');
+      expect(headers['Access-Control-Allow-Origin']).toBe('https://app.refly.ai');
+      expect(headers['Access-Control-Allow-Credentials']).toBe('true');
+      expect(headers['Vary']).toBe('Origin');
+      expect(headers['Cross-Origin-Resource-Policy']).toBe('cross-origin');
+    });
+
+    it('does not reflect non-allowlisted origins', () => {
+      const headers = buildCorsHeaders('https://evil.example.com');
+      expect(headers['Access-Control-Allow-Origin']).toBeUndefined();
+      expect(headers['Access-Control-Allow-Credentials']).toBeUndefined();
+      // no-cors embedding (e.g. <img>) must keep working
+      expect(headers['Cross-Origin-Resource-Policy']).toBe('cross-origin');
+    });
+
+    it('omits CORS headers when no Origin header is present', () => {
+      const headers = buildCorsHeaders(undefined);
+      expect(headers['Access-Control-Allow-Origin']).toBeUndefined();
+      expect(headers['Access-Control-Allow-Credentials']).toBeUndefined();
+    });
   });
 });

--- a/apps/api/src/modules/misc/misc.controller.ts
+++ b/apps/api/src/modules/misc/misc.controller.ts
@@ -12,6 +12,7 @@ import {
   Query,
 } from '@nestjs/common';
 import path from 'node:path';
+import { ConfigService } from '@nestjs/config';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
 import { MiscService } from '../misc/misc.service';
 import {
@@ -32,7 +33,37 @@ import { checkHttpCache, send304NotModified, applyCacheHeaders } from '../../uti
 
 @Controller('v1/misc')
 export class MiscController {
-  constructor(private readonly miscService: MiscService) {}
+  constructor(
+    private readonly miscService: MiscService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  /**
+   * Build CORS headers for file-serving endpoints.
+   * Only origins in the ORIGIN allowlist (same source as the global CORS
+   * config in main.ts) get credentialed access; other origins receive no
+   * Access-Control-Allow-Origin header, so browsers block cross-origin reads
+   * of authenticated responses. Cross-Origin-Resource-Policy stays
+   * 'cross-origin' so legitimate no-cors embedding (e.g. <img>) keeps working.
+   */
+  private buildCorsHeaders(origin: string | undefined): Record<string, string> {
+    const allowedOrigins = (this.configService.get<string>('origin') ?? '')
+      .split(',')
+      .map((o) => o.trim())
+      .filter(Boolean);
+
+    const headers: Record<string, string> = {
+      'Cross-Origin-Resource-Policy': 'cross-origin',
+    };
+
+    if (origin && allowedOrigins.includes(origin)) {
+      headers['Access-Control-Allow-Origin'] = origin;
+      headers['Access-Control-Allow-Credentials'] = 'true';
+      headers['Vary'] = 'Origin';
+    }
+
+    return headers;
+  }
 
   @UseGuards(JwtAuthGuard)
   @Post('scrape')
@@ -104,7 +135,7 @@ export class MiscController {
   ): Promise<void> {
     const storageKey = `static/${objectKey}`;
     const filename = path.basename(objectKey);
-    const origin = req.headers.origin;
+    const corsHeaders = this.buildCorsHeaders(req.headers.origin);
 
     // First, get only metadata (no file content loaded yet)
     const { contentType, lastModified } = await this.miscService.getInternalFileMetadata(
@@ -119,12 +150,6 @@ export class MiscController {
       maxAge: 0,
       immutable: false,
     });
-
-    const corsHeaders = {
-      'Access-Control-Allow-Origin': origin || '*',
-      'Access-Control-Allow-Credentials': 'true',
-      'Cross-Origin-Resource-Policy': 'cross-origin',
-    };
 
     // If client has valid cache, return 304 Not Modified (without loading file content)
     if (cacheResult.useCache) {


### PR DESCRIPTION
## Summary

The authenticated file endpoint `GET /v1/misc/static/:objectKey` (guarded by `JwtAuthGuard`, serving users' private files after an ownership check) reflects the request `Origin` header into `Access-Control-Allow-Origin` and simultaneously sends `Access-Control-Allow-Credentials: true`.

Because Refly sessions are stored in cookies, this is exploitable today: any website can make a logged-in victim's browser fetch their private files cross-origin and read the responses. No clicks, no warnings, no visible trace for the victim. Loading an attacker page is enough.

## Impact

- **Silent theft of private user content.** Uploads and generated artifacts belonging to any logged-in user can be read by any site the victim visits: a phishing page, a malicious ad, a compromised third party.
- **Scale.** If `objectKey` values are enumerable or leak through any listing endpoint, an attacker can harvest files from every victim who loads their page, not just one.
- **Blast radius.** Every deployment of this code is affected, including self-hosted instances.

`Cross-Origin-Resource-Policy: cross-origin` additionally allows the protected content to be embedded directly into attacker pages, independent of the CORS issue.

## Proof of concept

From any origin, while the victim is logged in:

```js
fetch('https://<refly-instance>/v1/misc/static/<objectKey>', { credentials: 'include' })
  .then((r) => r.text())
  .then((content) => {
    // content is the victim's private file, readable cross-origin
  });
```

The browser attaches the session cookie, the server reflects the attacker's origin with credentials allowed, and the response is readable. Identified with [umbra](https://github.com/elberacasa/umbra), an open source security scanner I maintain, then verified by manual code review against `main`. I did not test against any live deployment.

## Root cause

CORS safety depends on never combining a reflected untrusted origin with credentials. With both present, the browser sends the victim's cookies *and* exposes the response body to the attacker's JavaScript. The ownership check still passes because the request is legitimately authenticated as the victim.

Notably, the application already does this correctly at the global level: `main.ts` configures CORS with a fixed allowlist from the `ORIGIN` env var. This endpoint overrode that policy with unconditional reflection.

## Fix

Only grant credentialed CORS to origins in the existing `ORIGIN` allowlist, the same configuration the global middleware uses:

- Allowlisted origins keep working exactly as before (`Access-Control-Allow-Origin` + credentials + `Vary: Origin`).
- All other origins receive no `Access-Control-Allow-Origin`, so browsers block cross-origin reads of authenticated responses.
- `Cross-Origin-Resource-Policy: cross-origin` is preserved, so legitimate no-cors embedding (images and similar) keeps working.
- The unauthenticated `servePublicStatic` endpoint is intentionally unchanged: it serves public data, and tightening it could break third-party consumers.

## Tests

Added regression tests covering allowlisted origins (credentialed access preserved), unknown origins (no CORS headers), and requests without an `Origin` header. All pass: `npx jest src/modules/misc/misc.controller.spec.ts`, 4/4.

The controller spec also needed stale mocks refreshed (`ApiKeyService`, `PrismaService`), since `JwtAuthGuard` gained dependencies after the spec was written. Without that, the suite could not run at all.

## Related hardening notes (out of scope here)

1. `CustomThrottlerGuard.shouldSkip` in `apps/api/src/modules/app.module.ts` disables rate limiting whenever `NODE_ENV !== 'production'`. A deployment missing that variable silently loses brute-force protection on auth endpoints.
2. `deploy/searxng/settings.yml` commits a fixed 64-hex SearXNG `secret_key` mounted by the default compose setup, so default self-hosted installs share the same HMAC secret.

Happy to split those into follow-ups if you want them addressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-origin access controls for authenticated static-file requests.
  * Credentialed requests are now limited to configured, approved origins instead of allowing unrestricted origins.
  * Added handling for requests from unapproved or missing origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->