### PR TITLE
feat(provider-catalog): add SSYCloud LLM provider

### DIFF
--- a/config/provider-catalog.json
+++ b/config/provider-catalog.json
@@ -1,6 +1,18 @@
 {
   "providers": [
     {
+      "name": "SSYCloud",
+      "providerKey": "openai",
+      "baseUrl": "https://router.shengsuanyun.com/api/v1",
+      "description": {
+        "en": "SSYCloud is an API router providing unified access to 300+ LLM and multimodal models.",
+        "zh-CN": "胜算云是一个 API 路由服务，为 300 多个大语言模型和多模态模型提供统一接入。"
+      },
+      "categories": ["llm"],
+      "documentation": "https://lean.shengsuanyun.com/apidocs/guides/quick-start",
+      "icon": "https://avatars.githubusercontent.com/u/204312386?s=200&v=4"
+    },
+    {
       "name": "PPIO",
       "providerKey": "openai",
       "baseUrl": "https://api.ppinfra.com/v3/openai",


### PR DESCRIPTION
## feat(provider-catalog): add SSYCloud LLM provider

## Summary

Add Shengsuanyun (SSYCloud) to the community provider catalog.

Shengsuanyun is an OpenAI-compatible API router providing unified access to 300+ LLM and multimodal models.

- Base URL: `https://router.shengsuanyun.com/api/v1`
- Authentication: Bearer API key
- Model discovery: `GET {baseUrl}/models`
- Documentation: https://lean.shengsuanyun.com/apidocs/guides/quick-start
- Website: https://www.shengsuanyun.com/

## How to Use

1. Open **Settings → Providers → Provider Store**
2. Find **SSYCloud**
3. Click **Install**
4. Enter a Shengsuanyun API key
5. Select one of the automatically loaded models

## Files Changed

- `config/provider-catalog.json`

## Test Plan

- [x] SSYCloud appears in the Provider Store with its logo
- [x] Provider can be installed with an API key
- [x] Models load automatically from `GET {baseUrl}/models`
- [x] A configured model can complete a normal chat request
- [x] `provider-catalog.json` passes JSON validation

## Notes
- Channel tracking: https://www.shengsuanyun.com/?from=CH_AEXRW8RL
- Docs: https://lean.shengsuanyun.com/apidocs
- Test quota exchange code: H200DFW30425S (console → avatar → redeem quota)
- Support/Business: zhouyang1@shengsuanyun.cn · WeChat 18010814593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SSYCloud as an available provider.
  * Included OpenAI-compatible routing, bilingual descriptions, LLM categorization, documentation links, and provider icon metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->